### PR TITLE
ci(windows): enable ImageMagick via vcpkg overlay port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,13 +190,18 @@ jobs:
             ${{ env.VCPKG_INSTALLATION_ROOT }}\installed
             ${{ env.VCPKG_INSTALLATION_ROOT }}\packages
             ~\AppData\Local\vcpkg\archives
-          key: vcpkg-test-${{ runner.os }}-${{ matrix.build_type }}-v4
+          key: vcpkg-test-${{ runner.os }}-${{ matrix.build_type }}-v6
           restore-keys: |
             vcpkg-test-${{ runner.os }}-${{ matrix.build_type }}-
 
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          # Pull our hand-rolled imagemagick overlay port (Q16-HDRI x64,
+          # repackaged from the upstream Inno Setup installer; see
+          # vcpkg-overlay/ports/imagemagick/portfile.cmake).
+          VCPKG_OVERLAY_PORTS: ${{ github.workspace }}\vcpkg-overlay\ports
         run: |
           $packages = @(
             'boost-thread','boost-date-time','boost-regex','boost-filesystem',
@@ -205,7 +210,7 @@ jobs:
             'boost-any','boost-array','boost-dynamic-bitset','boost-exception',
             'boost-foreach','boost-function','boost-lambda','boost-lexical-cast',
             'boost-multi-array','boost-optional','boost-smart-ptr','boost-tuple',
-            'boost-utility','hdf5','fftw3','gsl'
+            'boost-utility','hdf5','fftw3','gsl','imagemagick'
           )
           for ($i = 1; $i -le 5; $i++) {
             Write-Host "vcpkg install attempt $i / 5"
@@ -242,7 +247,6 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DCVC_BUILD_TESTS=ON `
             -DCVC_ENABLE_CUDA=OFF `
-            -DCVC_ENABLE_IMAGEMAGICK=OFF `
             -DDISABLE_CGAL=ON `
             -DCVC_BUILD_VOLROVER3=OFF
 
@@ -265,7 +269,7 @@ jobs:
             ctest --test-dir build \
                   --build-config ${{ matrix.build_type }} \
                   --output-on-failure --parallel \
-                  --repeat until-pass:3 --timeout 1800
+                  --repeat until-pass:3 --timeout 3600
           else
             echo "pull_request event: excluding ${STRESS_REGEX}"
             ctest --test-dir build \
@@ -800,7 +804,7 @@ jobs:
             ${{ env.VCPKG_INSTALLATION_ROOT }}\installed
             ${{ env.VCPKG_INSTALLATION_ROOT }}\packages
             ~\AppData\Local\vcpkg\archives
-          key: vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-v5
+          key: vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-v6
           restore-keys: |
             vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-
 
@@ -826,6 +830,11 @@ jobs:
 
       - name: Install dependencies
         shell: pwsh
+        env:
+          # Pull our hand-rolled imagemagick overlay port (Q16-HDRI x64,
+          # repackaged from the upstream Inno Setup installer; see
+          # vcpkg-overlay/ports/imagemagick/portfile.cmake).
+          VCPKG_OVERLAY_PORTS: ${{ github.workspace }}\vcpkg-overlay\ports
         run: |
           $packages = @(
             'boost-thread','boost-date-time','boost-regex','boost-filesystem',
@@ -834,7 +843,7 @@ jobs:
             'boost-any','boost-array','boost-dynamic-bitset','boost-exception',
             'boost-foreach','boost-function','boost-lambda','boost-lexical-cast',
             'boost-multi-array','boost-optional','boost-smart-ptr','boost-tuple',
-            'boost-utility','hdf5','fftw3','gsl'
+            'boost-utility','hdf5','fftw3','gsl','imagemagick'
           )
           if ('${{ matrix.kind }}' -eq 'volrover3') {
             # qt6-base intentionally omitted — handled by install-qt-action above.
@@ -873,7 +882,7 @@ jobs:
             ${{ env.VCPKG_INSTALLATION_ROOT }}\installed
             ${{ env.VCPKG_INSTALLATION_ROOT }}\packages
             ~\AppData\Local\vcpkg\archives
-          key: vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-v5
+          key: vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-v6
 
       - name: Configure
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,7 +361,7 @@ jobs:
             ${{ env.VCPKG_INSTALLATION_ROOT }}\installed
             ${{ env.VCPKG_INSTALLATION_ROOT }}\packages
             ~\AppData\Local\vcpkg\archives
-          key: vcpkg-release-${{ matrix.kind }}-${{ matrix.build_type }}-v4
+          key: vcpkg-release-${{ matrix.kind }}-${{ matrix.build_type }}-v5
           restore-keys: |
             vcpkg-release-${{ matrix.kind }}-${{ matrix.build_type }}-
 
@@ -384,8 +384,38 @@ jobs:
           modules: ''
           cache: true
 
+      # windows-latest C: drive has only ~14 GB free; vcpkg + qt + vtk
+      # buildtrees blow it up. Free up hosted-tool dirs we don't need
+      # and route vcpkg's heavy working dirs to D: where there's ~80 GB.
+      - name: 'Free disk space and route vcpkg to D: (Windows)'
+        shell: pwsh
+        run: |
+          foreach ($dir in @(
+              'C:\Android', 'C:\Program Files\dotnet',
+              'C:\hostedtoolcache\windows\Ruby',
+              'C:\hostedtoolcache\windows\PyPy',
+              'C:\hostedtoolcache\windows\go',
+              'C:\hostedtoolcache\windows\node')) {
+            if (Test-Path $dir) {
+              Write-Host "Removing $dir"
+              Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $dir
+            }
+          }
+          New-Item -ItemType Directory -Force -Path D:\vcpkg-buildtrees | Out-Null
+          New-Item -ItemType Directory -Force -Path D:\vcpkg-packages   | Out-Null
+          New-Item -ItemType Directory -Force -Path D:\vcpkg-downloads  | Out-Null
+          "VCPKG_DOWNLOADS=D:\vcpkg-downloads"   | Out-File -Append $env:GITHUB_ENV
+          "VCPKG_BUILDTREES=D:\vcpkg-buildtrees" | Out-File -Append $env:GITHUB_ENV
+          "VCPKG_PACKAGES=D:\vcpkg-packages"     | Out-File -Append $env:GITHUB_ENV
+          Get-PSDrive -PSProvider FileSystem | Format-Table -AutoSize
+
       - name: Install dependencies
         shell: pwsh
+        env:
+          # Pull our hand-rolled imagemagick overlay port (Q16-HDRI x64,
+          # repackaged from the upstream Inno Setup installer; see
+          # vcpkg-overlay/ports/imagemagick/portfile.cmake).
+          VCPKG_OVERLAY_PORTS: ${{ github.workspace }}\vcpkg-overlay\ports
         run: |
           $packages = @(
             'boost-thread','boost-date-time','boost-regex','boost-filesystem',
@@ -394,15 +424,23 @@ jobs:
             'boost-any','boost-array','boost-dynamic-bitset','boost-exception',
             'boost-foreach','boost-function','boost-lambda','boost-lexical-cast',
             'boost-multi-array','boost-optional','boost-smart-ptr','boost-tuple',
-            'boost-utility','hdf5','fftw3','gsl'
+            'boost-utility','hdf5','fftw3','gsl','imagemagick'
           )
           if ('${{ matrix.kind }}' -eq 'volrover3') {
             # qt6-base intentionally omitted — handled by install-qt-action above.
-            $packages += @('vtk','cgal')
+            # vtk[qt,opengl] enables GUISupportQt (QVTKOpenGLNativeWidget.h)
+            # plus all OpenGL-rendering modules that volrover3 includes.
+            $packages += @('vtk[qt,opengl]','cgal')
           }
           for ($i = 1; $i -le 5; $i++) {
             Write-Host "vcpkg install attempt $i / 5"
-            vcpkg install @packages --triplet x64-windows
+            # --clean-after-build deletes each port's buildtree/packages
+            # immediately after installation. --x-buildtrees-root /
+            # --x-packages-root keep the heavy working dirs on D:.
+            vcpkg install @packages --triplet x64-windows `
+              --clean-after-build `
+              --x-buildtrees-root=D:\vcpkg-buildtrees `
+              --x-packages-root=D:\vcpkg-packages
             if ($LASTEXITCODE -eq 0) { break }
             if ($i -eq 5) { exit $LASTEXITCODE }
             $sleep = [Math]::Min(60 * $i, 180)

--- a/src/cvc/CMakeLists.txt
+++ b/src/cvc/CMakeLists.txt
@@ -481,11 +481,41 @@ if(CVC_ENABLE_CUDA)
 endif()
 
 # ImageMagick support (for volume_ops image I/O)
+#
+# Quantum-depth and HDRI flags must match the installed library's build:
+# Q8 vs Q16, HDRI on/off. On Linux/macOS we ask pkg-config for the
+# canonical cflags, which include the right `MAGICKCORE_QUANTUM_DEPTH`
+# and `MAGICKCORE_HDRI_ENABLE` defines. On Windows our overlay vcpkg
+# port ships Q16-HDRI x64.
 option(CVC_ENABLE_IMAGEMAGICK "Enable ImageMagick support for image I/O in volume_ops" ON)
 if(CVC_ENABLE_IMAGEMAGICK)
+  set(CVC_IMAGEMAGICK_QUANTUM_DEPTH 16)
+  set(CVC_IMAGEMAGICK_HDRI_ENABLE 0)
+  if(NOT WIN32)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+      pkg_check_modules(IMAGEMAGICK_PC QUIET Magick++)
+      if(IMAGEMAGICK_PC_FOUND)
+        # Extract Q-depth / HDRI from -D flags. Drop them from the cflag
+        # list afterwards so we add them once via target_compile_definitions
+        # below (avoids per-source duplication).
+        foreach(_def IN LISTS IMAGEMAGICK_PC_CFLAGS_OTHER)
+          if(_def MATCHES "^-DMAGICKCORE_QUANTUM_DEPTH=([0-9]+)$")
+            set(CVC_IMAGEMAGICK_QUANTUM_DEPTH "${CMAKE_MATCH_1}")
+          elseif(_def MATCHES "^-DMAGICKCORE_HDRI_ENABLE=([0-9]+)$")
+            set(CVC_IMAGEMAGICK_HDRI_ENABLE "${CMAKE_MATCH_1}")
+          endif()
+        endforeach()
+      endif()
+    endif()
+  else()
+    set(CVC_IMAGEMAGICK_HDRI_ENABLE 1)  # Q16-HDRI x64 from vcpkg overlay
+  endif()
   find_package(ImageMagick COMPONENTS Magick++ MagickCore)
   if(ImageMagick_FOUND)
-    message(STATUS "ImageMagick found: ${ImageMagick_INCLUDE_DIRS}")
+    message(STATUS "ImageMagick found: ${ImageMagick_INCLUDE_DIRS} "
+                   "(Q${CVC_IMAGEMAGICK_QUANTUM_DEPTH}, "
+                   "HDRI=${CVC_IMAGEMAGICK_HDRI_ENABLE})")
   else()
     message(STATUS "ImageMagick not found - disabling image I/O in volume_ops")
     set(CVC_ENABLE_IMAGEMAGICK OFF)
@@ -636,8 +666,8 @@ endif()
 # ImageMagick linking
 if(CVC_ENABLE_IMAGEMAGICK)
   target_compile_definitions(cvc PUBLIC CVC_ENABLE_IMAGEMAGICK
-    MAGICKCORE_QUANTUM_DEPTH=16
-    MAGICKCORE_HDRI_ENABLE=0)
+    MAGICKCORE_QUANTUM_DEPTH=${CVC_IMAGEMAGICK_QUANTUM_DEPTH}
+    MAGICKCORE_HDRI_ENABLE=${CVC_IMAGEMAGICK_HDRI_ENABLE})
   target_include_directories(cvc PUBLIC ${ImageMagick_INCLUDE_DIRS})
   target_link_libraries(cvc PUBLIC ${ImageMagick_LIBRARIES})
 endif()

--- a/vcpkg-overlay/ports/imagemagick/portfile.cmake
+++ b/vcpkg-overlay/ports/imagemagick/portfile.cmake
@@ -1,0 +1,117 @@
+# ─────────────────────────────────────────────────────────────────────
+# imagemagick (overlay port)
+#
+# vcpkg upstream does not ship an `imagemagick` port. ImageMagick's
+# Windows source build is intricate (its own VisualMagick configure
+# wizard, ~20 optional delegate libraries, Q-depth and HDRI matrices)
+# and not amenable to a quick vcpkg port. For CI usage we instead
+# repackage the official upstream Inno Setup installer:
+#
+#   * Download the installer + a pinned innoextract.exe
+#   * Run innoextract to unpack the installer into a temp tree
+#   * Copy headers / import libraries / DLLs into vcpkg's layout so
+#     CMake's stock FindImageMagick.cmake can locate them via the
+#     vcpkg toolchain's CMAKE_PREFIX_PATH.
+#
+# This intentionally tracks the Q16-HDRI x64 build, which matches the
+# brew-installed flavor on macOS and keeps MAGICKCORE_QUANTUM_DEPTH=16
+# / MAGICKCORE_HDRI_ENABLE=1 consistent across platforms.
+# ─────────────────────────────────────────────────────────────────────
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+  message(FATAL_ERROR "imagemagick overlay port is Windows-only.")
+endif()
+
+if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+  message(FATAL_ERROR "imagemagick overlay port supports x64 only.")
+endif()
+
+set(IM_VERSION "7.1.2-21")
+
+vcpkg_download_distfile(IM_INSTALLER
+  URLS "https://imagemagick.org/archive/binaries/ImageMagick-${IM_VERSION}-Q16-HDRI-x64-dll.exe"
+  FILENAME "ImageMagick-${IM_VERSION}-Q16-HDRI-x64-dll.exe"
+  SHA512 107455499f3f95e1a3e9b6ec32feb541cdf58a54237f96a6ac8390a1d55c00110bea188d0542234ba8c9ff1cab2ec436957820938109e2f4ac8abd468eb27a0c
+)
+
+# innoextract 1.9 supports Inno Setup 6.1.0 (the format used by IM 7.1.2-21).
+vcpkg_download_distfile(INNOEXTRACT_ZIP
+  URLS "https://github.com/dscharrer/innoextract/releases/download/1.9/innoextract-1.9-windows.zip"
+  FILENAME "innoextract-1.9-windows.zip"
+  SHA512 eea751bc021b8cb9a979875d7df5ef0438a8ec6157f75fa9d34b0471bb359daf15cf9cee51a21f9115cb8410bdb836a57f1cd6b2198c634cf108e6785f902488
+)
+
+# Stage everything under the buildtrees temp dir.
+set(STAGE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-stage")
+file(REMOVE_RECURSE "${STAGE_DIR}")
+file(MAKE_DIRECTORY "${STAGE_DIR}")
+
+# Unpack innoextract.exe.
+vcpkg_execute_required_process(
+  COMMAND "${CMAKE_COMMAND}" -E tar xf "${INNOEXTRACT_ZIP}"
+  WORKING_DIRECTORY "${STAGE_DIR}"
+  LOGNAME "unzip-innoextract-${TARGET_TRIPLET}"
+)
+set(INNOEXTRACT_EXE "${STAGE_DIR}/innoextract.exe")
+if(NOT EXISTS "${INNOEXTRACT_EXE}")
+  message(FATAL_ERROR "innoextract.exe missing after unzip: ${INNOEXTRACT_EXE}")
+endif()
+
+# Run innoextract on the IM installer. -s strips the leading "{app}"
+# prefix from extracted paths so the layout below is just "app/...".
+vcpkg_execute_required_process(
+  COMMAND "${INNOEXTRACT_EXE}" --silent --extract --output-dir "${STAGE_DIR}" "${IM_INSTALLER}"
+  WORKING_DIRECTORY "${STAGE_DIR}"
+  LOGNAME "innoextract-${TARGET_TRIPLET}"
+)
+set(APP_DIR "${STAGE_DIR}/app")
+if(NOT EXISTS "${APP_DIR}/include")
+  message(FATAL_ERROR "innoextract output missing headers: ${APP_DIR}/include")
+endif()
+
+# Headers: Magick++/, MagickCore/, MagickWand/ subtrees go straight into
+# the vcpkg include root. CMake's FindImageMagick recognises this layout.
+file(COPY "${APP_DIR}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+# Import libraries.
+file(GLOB IM_LIBS "${APP_DIR}/lib/CORE_RL_*.lib")
+if(NOT IM_LIBS)
+  message(FATAL_ERROR "No CORE_RL_*.lib files found under ${APP_DIR}/lib")
+endif()
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib")
+file(COPY ${IM_LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+# Upstream ships only one (release) build; alias it for Debug so
+# vcpkg's debug-config also resolves.
+file(COPY ${IM_LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+
+# Runtime DLLs (CORE_RL_*, IM_MOD_RL_*, FILTER_*) plus the C/C++ runtime
+# bundled by the installer; ship them all so apps can resolve symbols.
+file(GLOB IM_DLLS
+  "${APP_DIR}/CORE_RL_*.dll"
+  "${APP_DIR}/IM_MOD_RL_*.dll"
+  "${APP_DIR}/FILTER_*.dll"
+)
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+if(IM_DLLS)
+  file(COPY ${IM_DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+  file(COPY ${IM_DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+# License.
+if(EXISTS "${APP_DIR}/License.txt")
+  file(INSTALL "${APP_DIR}/License.txt"
+       DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+       RENAME copyright)
+elseif(EXISTS "${APP_DIR}/LICENSE.txt")
+  file(INSTALL "${APP_DIR}/LICENSE.txt"
+       DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+       RENAME copyright)
+else()
+  file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright"
+       "ImageMagick license: see https://imagemagick.org/script/license.php\n")
+endif()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/vcpkg-overlay/ports/imagemagick/portfile.cmake
+++ b/vcpkg-overlay/ports/imagemagick/portfile.cmake
@@ -85,6 +85,25 @@ file(COPY ${IM_LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
 # vcpkg's debug-config also resolves.
 file(COPY ${IM_LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
 
+# CMake's FindImageMagick.cmake searches for Magick++/MagickCore/
+# MagickWand/MagickWand-7.Q16HDRI/etc. and also CORE_RL_Magick++_,
+# but only on recent versions. Older CMakes (< 3.27 or so) and some
+# distro-patched FindImageMagick scripts only know the canonical
+# unprefixed names. The IM Windows installer ships only
+# 'CORE_RL_<component>_.lib', so create canonical-named hardlinks/
+# copies (Magick++.lib, MagickCore.lib, MagickWand.lib) to make
+# find_library() succeed regardless of FindImageMagick vintage.
+foreach(_im_lib_dir
+    "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug/lib")
+  foreach(_im_component Magick++ MagickCore MagickWand)
+    set(_src "${_im_lib_dir}/CORE_RL_${_im_component}_.lib")
+    set(_dst "${_im_lib_dir}/${_im_component}.lib")
+    if(EXISTS "${_src}" AND NOT EXISTS "${_dst}")
+      configure_file("${_src}" "${_dst}" COPYONLY)
+    endif()
+  endforeach()
+endforeach()
+
 # Runtime DLLs (CORE_RL_*, IM_MOD_RL_*, FILTER_*) plus the C/C++ runtime
 # bundled by the installer; ship them all so apps can resolve symbols.
 file(GLOB IM_DLLS

--- a/vcpkg-overlay/ports/imagemagick/usage
+++ b/vcpkg-overlay/ports/imagemagick/usage
@@ -1,0 +1,9 @@
+imagemagick provides Q16-HDRI x64 development files for Windows. Use
+CMake's stock module to consume it:
+
+    find_package(ImageMagick COMPONENTS Magick++ MagickCore)
+    target_include_directories(your_target PRIVATE ${ImageMagick_INCLUDE_DIRS})
+    target_link_libraries(your_target PRIVATE ${ImageMagick_LIBRARIES})
+    target_compile_definitions(your_target PRIVATE
+        MAGICKCORE_QUANTUM_DEPTH=16
+        MAGICKCORE_HDRI_ENABLE=1)

--- a/vcpkg-overlay/ports/imagemagick/vcpkg.json
+++ b/vcpkg-overlay/ports/imagemagick/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "imagemagick",
+  "version": "7.1.2-21",
+  "port-version": 0,
+  "description": "ImageMagick Q16-HDRI development files for Windows, repackaged from the official upstream Inno Setup installer.",
+  "homepage": "https://imagemagick.org/",
+  "license": "ImageMagick",
+  "supports": "windows & x64"
+}


### PR DESCRIPTION
Adds a vcpkg overlay port that repackages the upstream Q16-HDRI x64 Inno Setup installer using innoextract so the Windows CI builds gain the same `Magick++`/`MagickCore` development files already present on Linux (`libmagick++-dev`) and macOS (`brew install imagemagick`).

* New: `vcpkg-overlay/ports/imagemagick/{portfile.cmake,vcpkg.json,usage}`. Pinned by SHA-512 to ImageMagick 7.1.2-21 + innoextract 1.9.
* CI: `VCPKG_OVERLAY_PORTS` wired into Windows test, package, and release jobs; `imagemagick` added to vcpkg package list; `-DCVC_ENABLE_IMAGEMAGICK=OFF` removed from Windows test configure.
* CMake: `MAGICKCORE_QUANTUM_DEPTH` and `MAGICKCORE_HDRI_ENABLE` are now derived from `pkg-config Magick++` on Linux/macOS (previously hardcoded `Q16/HDRI=0`, which was wrong for macOS brew Q16-HDRI). Pinned to `Q16/HDRI=1` on Windows to match the overlay port.
* Cache key bumps: `vcpkg-test` `v4 -> v6`, `vcpkg-pkg` `v5 -> v6`, `vcpkg-release` `v4 -> v5` (installed/ tree changes).
* Stress-test timeout raised `1800 -> 3600` for on-push (PR-merge / tag) runs.
* Backports the Windows hardening from ci.yml to release.yml: `vtk[qt,opengl]`, `D:` -routed vcpkg buildtrees, `--clean-after-build`, free-disk step.