### PR TITLE
utility: delete ctx-less calcGradient/sub/volconvert/load/save bridges

### DIFF
--- a/inc/cvc/utility.h
+++ b/inc/cvc/utility.h
@@ -160,14 +160,7 @@ static inline void createVolumeFile(app &ctx, const std::string &filename, const
   (UChar, UShort, UInt), the first half of the set of integers maps to [-1.0,0) and the last half
   maps to (0,1.0].
 */
-void calcGradient(std::vector<volume> &grad, const volume &vol, data_type vt = Float);
-
-void sub(volume &dest, const volume &vol, uint64 off_x, uint64 off_y, uint64 off_z,
-         const dimension &subvoldim);
-
-void volconvert(const std::string &input_volume_file, const std::string &output_volume_file);
-
-// ---- Overloads accepting explicit app& context ----
+// ---- Functions accepting explicit app& context ----
 void calcGradient(app &ctx, std::vector<volume> &grad, const volume &vol, data_type vt = Float);
 
 void sub(app &ctx, volume &dest, const volume &vol, uint64 off_x, uint64 off_y, uint64 off_z,
@@ -241,7 +234,5 @@ bool is_volume(const boost::any &data);
 bool is_volume_file_info(const boost::any &data);
 bool is_geometry_filename(const std::string &filename);
 bool is_volume_filename(const std::string &filename);
-boost::any load(const std::string &filename);
-void save(const boost::any &data, const std::string &filename);
 } // namespace CVC_NAMESPACE
 #endif

--- a/src/cvc/utility.cpp
+++ b/src/cvc/utility.cpp
@@ -118,10 +118,6 @@ void calcGradient(app &ctx, std::vector<volume> &grad, const volume &vol, data_t
   ctx.threadProgress(1.0f);
 }
 
-void calcGradient(std::vector<volume> &grad, const volume &vol, data_type vt) {
-  calcGradient(app::instance(), grad, vol, vt);
-}
-
 void sub(app &ctx, volume &dest, const volume &vol, uint64 off_x, uint64 off_y, uint64 off_z,
          const dimension &subvoldim) {
   thread_info ti(ctx, BOOST_CURRENT_FUNCTION);
@@ -144,11 +140,6 @@ void sub(app &ctx, volume &dest, const volume &vol, uint64 off_x, uint64 off_y, 
     for (uint64 j = 0; j < subvoldim[1]; j++)
       for (uint64 i = 0; i < subvoldim[0]; i++)
         dest(i, j, k, vol(i + off_x, j + off_y, k + off_z));
-}
-
-void sub(volume &dest, const volume &vol, uint64 off_x, uint64 off_y, uint64 off_z,
-         const dimension &subvoldim) {
-  sub(app::instance(), dest, vol, off_x, off_y, off_z, subvoldim);
 }
 
 void volconvert(app &ctx, const std::string &input_volume_file,
@@ -178,10 +169,6 @@ void volconvert(app &ctx, const std::string &input_volume_file,
       }
     ctx.threadProgress(((float)k) / ((float)((int)(volinfo.ZDim() - 1))));
   }
-}
-
-void volconvert(const std::string &input_volume_file, const std::string &output_volume_file) {
-  volconvert(app::instance(), input_volume_file, output_volume_file);
 }
 
 // ----
@@ -291,8 +278,6 @@ boost::any load(app &ctx, const std::string &filename) {
   return boost::any();
 }
 
-boost::any load(const std::string &filename) { return load(app::instance(), filename); }
-
 void save(app &ctx, const boost::any &data, const std::string &filename) {
   thread_info ti(ctx, BOOST_CURRENT_FUNCTION);
   if (is_geometry(data)) {
@@ -305,7 +290,4 @@ void save(app &ctx, const boost::any &data, const std::string &filename) {
     throw CVC_NAMESPACE::write_error(BOOST_CURRENT_FUNCTION);
 }
 
-void save(const boost::any &data, const std::string &filename) {
-  save(app::instance(), data, filename);
-}
 } // namespace CVC_NAMESPACE


### PR DESCRIPTION
Deletes five free-function overloads in `cvc/utility.{h,cpp}` that delegated to their ctx-aware counterparts via `app::instance()`. None of them have in-tree callers \u2014 the cvc-mesher and volrover3 targets either use the ctx-aware overloads or don't call these helpers \u2014 so the bridges are dead weight pinning libcvc to the singleton.

Removed:
- `calcGradient(grad, vol, vt)`
- `sub(dest, vol, off_x, off_y, off_z, subvoldim)`
- `volconvert(input, output)`
- `load(filename)`
- `save(data, filename)`

The ctx-aware overloads remain the public API.

Build clean; `ctest -j4` 590/590 passed.

Part of cvc-singleton-removal-plan.md \u2014 chips away at `app::instance()` callers ahead of PR-10. Stacks on top of #11/#12/#13/#14.