### PR TITLE
volrover3 MainWindow: use volrover3::app() instead of cvcapp

### DIFF
--- a/src/volrover3/MainWindow.cpp
+++ b/src/volrover3/MainWindow.cpp
@@ -422,7 +422,7 @@ void MainWindow::openFile() {
 
       try {
         // Try loading as volume
-        cvc::volume vol(cvcapp, fileName.toStdString());
+        cvc::volume vol(volrover3::app(), fileName.toStdString());
         auto volumeNode = m_sceneGraph->addGraphics(graphicsName, vol);
         volumeNode->setMetadata("type", std::string("volume"));
         volumeNode->setMetadata("filename", fileName.toStdString());

--- a/src/volrover3/StateTreeWidget.cpp
+++ b/src/volrover3/StateTreeWidget.cpp
@@ -480,13 +480,13 @@ std::string StateTreeWidget::getStateDataType(cvc::state *state) {
     return "unknown";
 
   try {
-    // Get the boost::any data and use cvcapp to get the registered type name
+    // Get the boost::any data and use volrover3::app() to get the registered type name
     boost::any anyData = state->data();
     if (anyData.empty()) {
       return "<no data>";
     }
 
-    // Use cvcapp's registered type names
+    // Use volrover3::app()'s registered type names
     std::string typeName = volrover3::app().dataTypeName(anyData);
     return typeName;
   } catch (const std::exception &e) {


### PR DESCRIPTION
Switches the last remaining `cvcapp` reference in volrover3/MainWindow.cpp \u2014 a `cvc::volume vol(cvcapp, ...)` construction in the volume-load path \u2014 to use `volrover3::app()`, which is already used throughout this file (and the rest of volrover3) for thread management. The `volrover3_app.h` header is already included.

This reduces volrover3's dependency on the global `cvcapp` singleton by one site. Pure mechanical rename; no logic change.

Build clean (volrover3 target).

Part of cvc-singleton-removal-plan.md \u2014 chips away at the `cvcapp` references that block PR-10 (delete `app::instance()`).