### PR TITLE
volrover3: pass volrover3::app() to thread_info/thread_feedback ctors

### DIFF
--- a/src/volrover3/GeometryDialog.cpp
+++ b/src/volrover3/GeometryDialog.cpp
@@ -1076,7 +1076,7 @@ void GeometryDialog::onInvertNormalsClicked() {
       threadKey,
       [this, geom, geomName, threadKey]() mutable {
         // Use thread_feedback for proper progress tracking
-        cvc::app::thread_feedback feedback(threadKey);
+        cvc::app::thread_feedback feedback(volrover3::app(), threadKey);
 
         try {
           volrover3::app().threadProgress(threadKey, 0.1);
@@ -1150,7 +1150,7 @@ void GeometryDialog::onReorientClicked() {
   volrover3::app().startThread(
       threadKey,
       [this, geom, geomName, threadKey]() mutable {
-        cvc::app::thread_feedback feedback(threadKey);
+        cvc::app::thread_feedback feedback(volrover3::app(), threadKey);
 
         try {
           volrover3::app().threadProgress(threadKey, 0.1);
@@ -1235,7 +1235,7 @@ void GeometryDialog::onProjectClicked() {
   volrover3::app().startThread(
       threadKey,
       [this, geom, targetGeom, geomName, threadKey]() mutable {
-        cvc::app::thread_feedback feedback(threadKey);
+        cvc::app::thread_feedback feedback(volrover3::app(), threadKey);
 
         try {
           volrover3::app().threadProgress(threadKey, 0.1);
@@ -1311,7 +1311,7 @@ void GeometryDialog::onSmoothingClicked() {
       threadKey,
       [this, geom, delta, fixBoundary, perturb1, geoFlow, smoothingEnabled, perturb2, geomName,
        threadKey]() mutable {
-        cvc::app::thread_feedback feedback(threadKey);
+        cvc::app::thread_feedback feedback(volrover3::app(), threadKey);
 
         try {
           volrover3::app().threadProgress(threadKey, 0.1);
@@ -1383,7 +1383,7 @@ void GeometryDialog::onQualityImproveClicked() {
   volrover3::app().startThread(
       threadKey,
       [this, geom, iterations, method, geomName, threadKey]() mutable {
-        cvc::app::thread_feedback feedback(threadKey);
+        cvc::app::thread_feedback feedback(volrover3::app(), threadKey);
 
         try {
           volrover3::app().threadProgress(threadKey, 0.1);

--- a/src/volrover3/GeometryNode.cpp
+++ b/src/volrover3/GeometryNode.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <volrover3/GeometryNode.h>
 #include <volrover3/NullGraphicNode.h>
+#include <volrover3/volrover3_app.h>
 #include <vtkActor.h>
 #include <vtkCellArray.h>
 #include <vtkFloatArray.h>
@@ -290,7 +291,7 @@ void GeometryNode::setUseSingleColor(bool useSingleColor) {
 vtkProp *GeometryNode::getProp() { return m_actor; }
 
 void GeometryNode::setGeometry(const cvc::geometry &geom) {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   // CRITICAL: Entire method must run on main thread to avoid Qt threading errors
   // Even creating std::shared_ptr or setting member variables can trigger VTK

--- a/src/volrover3/IsosurfaceDialog.cpp
+++ b/src/volrover3/IsosurfaceDialog.cpp
@@ -233,7 +233,7 @@ void IsosurfaceDialog::onVolumeSelected(int index) {
 }
 
 void IsosurfaceDialog::onComputeClicked() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   if (m_computing) {
     // Cancel ongoing computation
@@ -306,7 +306,7 @@ void IsosurfaceDialog::onComputeClicked() {
   volrover3::app().startThread(
       m_activeThreadKey,
       [this, vol, isovalue, method, improveIterations, normalType, volumeName, volumeNode]() {
-        cvc::thread_info ti("Isosurface Extraction");
+        cvc::thread_info ti(volrover3::app(), "Isosurface Extraction");
 
         try {
           // Extract isosurface (thread-safe)
@@ -319,7 +319,7 @@ void IsosurfaceDialog::onComputeClicked() {
 
           // Post all SceneGraph/VTK operations to main thread via SceneGraph event queue
           m_sceneGraph->postEvent([this, isoGeom, volumeName, isovalue, volumeNode]() {
-            cvc::thread_info ti("Add Isosurface");
+            cvc::thread_info ti(volrover3::app(), "Add Isosurface");
 
             try {
               // Sanitize the name to ensure it's a valid C identifier

--- a/src/volrover3/MainWindow.cpp
+++ b/src/volrover3/MainWindow.cpp
@@ -333,7 +333,7 @@ void MainWindow::setupConnections() {
 }
 
 void MainWindow::openFile() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   // First, show parent selection dialog
   GraphicsParentDialog parentDialog(m_sceneGraph, this);
@@ -572,14 +572,14 @@ void MainWindow::toggleAxis() {
 }
 
 void MainWindow::editBoundingBox() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   BoundingBoxDialog dialog(m_sceneGraph, this);
   dialog.exec();
 }
 
 void MainWindow::editCameraSettings() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   CameraController *camCtrl = m_renderWidget->getCameraController();
   if (!camCtrl)
@@ -659,7 +659,7 @@ void MainWindow::editCameraSettings() {
 }
 
 void MainWindow::showGridOptions() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   if (!m_gridOptionsDialog) {
     m_gridOptionsDialog = new GridOptionsDialog(m_sceneGraph->getGridNode());
@@ -677,7 +677,7 @@ void MainWindow::showGridOptions() {
 }
 
 void MainWindow::showViewerOptions() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   if (!m_viewerOptionsDialog) {
     m_viewerOptionsDialog = new ViewerOptionsDialog(m_renderWidget, m_sceneGraph);
@@ -752,7 +752,7 @@ void MainWindow::showStateTree() {
 }
 
 void MainWindow::showSDF() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   // Create SDF dialog as a separate window if not already created
   if (!m_sdfDialog) {
@@ -771,7 +771,7 @@ void MainWindow::showSDF() {
 }
 
 void MainWindow::showIsosurface() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   // Create Isosurface dialog as a separate window if not already created
   if (!m_isosurfaceDialog) {
@@ -790,7 +790,7 @@ void MainWindow::showIsosurface() {
 }
 
 void MainWindow::showGeometry() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   // Create Geometry dialog as a separate window if not already created
   if (!m_geometryDialog) {
@@ -809,7 +809,7 @@ void MainWindow::showGeometry() {
 }
 
 void MainWindow::showVolume() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   // Create Volume dialog as a separate window if not already created
   if (!m_volumeDialog) {
@@ -854,7 +854,7 @@ void MainWindow::resetCamera() {
 }
 
 void MainWindow::generateStanfordBunny() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   try {
     // Load the built-in Stanford Bunny using the .bunny extension

--- a/src/volrover3/SDFDialog.cpp
+++ b/src/volrover3/SDFDialog.cpp
@@ -304,7 +304,7 @@ void SDFDialog::onGeometrySelected(int index) {
 }
 
 void SDFDialog::onComputeClicked() {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   if (m_computing) {
     // Cancel ongoing computation
@@ -378,7 +378,7 @@ void SDFDialog::onComputeClicked() {
       m_activeThreadKey,
       [this, geom, dim, bbox, algorithm, flipNormals, geomName, activeKey = m_activeThreadKey]() {
         // Use thread_feedback for proper progress tracking (must be at thread entry point)
-        cvc::app::thread_feedback feedback(activeKey);
+        cvc::app::thread_feedback feedback(volrover3::app(), activeKey);
 
         try {
           // Update progress to indicate we've started

--- a/src/volrover3/SceneGraph.cpp
+++ b/src/volrover3/SceneGraph.cpp
@@ -281,7 +281,7 @@ cvc::bounding_box SceneGraph::computeGraphicsBounds() const {
 // Multi-object graphics management
 std::shared_ptr<GraphicsNode> SceneGraph::addGraphics(const std::string &name,
                                                       const cvc::geometry &geom) {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   // Check if name already exists
   if (m_graphicsNodes.find(name) != m_graphicsNodes.end()) {
@@ -314,7 +314,7 @@ std::shared_ptr<GraphicsNode> SceneGraph::addGraphics(const std::string &name,
 }
 
 std::shared_ptr<GraphicsNode> SceneGraph::addGraphics(const std::string &name) {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   // Check if name already exists
   if (m_graphicsNodes.find(name) != m_graphicsNodes.end()) {
@@ -350,7 +350,7 @@ bool SceneGraph::hasGraphics(const std::string &name) const {
 }
 
 void SceneGraph::removeGraphics(const std::string &name) {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   auto it = m_graphicsNodes.find(name);
   if (it == m_graphicsNodes.end()) {
@@ -400,7 +400,7 @@ void SceneGraph::registerGraphics(const std::string &name, std::shared_ptr<Graph
 // Volume graphics management
 std::shared_ptr<VolumeNode> SceneGraph::addGraphics(const std::string &name,
                                                     const cvc::volume &vol) {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   // Check if name already exists
   if (m_graphicsNodes.find(name) != m_graphicsNodes.end()) {

--- a/src/volrover3/TransferFunctionWidget.cpp
+++ b/src/volrover3/TransferFunctionWidget.cpp
@@ -532,7 +532,7 @@ void TransferFunctionWidget::loadTransferFunctionFromVolume(std::shared_ptr<Volu
 }
 
 void TransferFunctionWidget::applyPreset(const QString &presetName) {
-  cvc::thread_info ti("Applying transfer function preset");
+  cvc::thread_info ti(volrover3::app(), "Applying transfer function preset");
 
   m_colorPoints.clear();
   // Don't clear opacity points - keep them independent!

--- a/src/volrover3/VolumeNode.cpp
+++ b/src/volrover3/VolumeNode.cpp
@@ -192,7 +192,7 @@ void VolumeNode::addToRenderer(vtkRenderer *renderer) {
 }
 
 void VolumeNode::setVolume(const cvc::volume &vol) {
-  cvc::thread_info ti(BOOST_CURRENT_FUNCTION);
+  cvc::thread_info ti(volrover3::app(), BOOST_CURRENT_FUNCTION);
 
   volrover3::app().log(0, "\n=== VolumeNode::setVolume[" + getName() + "] ===");
 


### PR DESCRIPTION
Part of cvcapp-singleton removal (cvc-singleton-removal-plan.md).

27 call sites across 8 files in volrover3 constructed `cvc::thread_info` or `cvc::app::thread_feedback` via the legacy single-arg ctor that falls back on `cvc::app::instance()`. Pass `volrover3::app()` explicitly so these ctors no longer reach into the deprecated `cvcapp` singleton.

This is one of the prerequisites for deleting the legacy delegating ctors at `inc/cvc/app.h:384` (`thread_info`) and `:421` (`thread_feedback`), which is itself a prerequisite for Phase C (delete `app::instance()` + `cvcapp` macro).

## Files
- GeometryDialog.cpp (5 thread_feedback)
- GeometryNode.cpp (1 thread_info, +#include <volrover3/volrover3_app.h>)
- IsosurfaceDialog.cpp (3 thread_info)
- MainWindow.cpp (10 thread_info)
- SDFDialog.cpp (1 thread_info, 1 thread_feedback)
- SceneGraph.cpp (4 thread_info)
- TransferFunctionWidget.cpp (1 thread_info)
- VolumeNode.cpp (1 thread_info)

## Validation
- volrover3 builds clean.
- `ctest -j8` 590/590 pass.

Independent of #17 (state_test fixture).