### PR TITLE
app: use this->uniqueThreadKey() inside startThread<T> (no singleton self-reach)

### DIFF
--- a/inc/cvc/app.h
+++ b/inc/cvc/app.h
@@ -331,7 +331,7 @@ public:
       }
     }
 
-    threads(wait ? key : app::instance().uniqueThreadKey(key),
+    threads(wait ? key : this->uniqueThreadKey(key),
             CVC_NAMESPACE::thread_ptr(new boost::thread(t)));
   }
 


### PR DESCRIPTION
Tiny cleanup, part of cvcapp-singleton removal.

`app::startThread<T>()` was reaching into `app::instance().uniqueThreadKey(key)` even though `this` IS the app — a relic from when only one app existed. Switch to `this->uniqueThreadKey(key)`. Behaviorally a no-op while the singleton exists; semantically removes one of the last in-class singleton self-references and makes the template safe for non-singleton `app` instances (like the per-test fixtures used by the test migrations).

## Validation
- Builds clean.
- `ctest -j8` 590/590 pass.

After this lands, the only `app::instance()` references inside `inc/cvc/app.h` are the deprecated legacy ctors (lines 384/421/495) and the `cvcapp` macro itself — all explicitly slated for deletion in Phase C.