### PR TITLE
volume_file_info: remove legacy cvcapp ctor and read overload

### DIFF
--- a/inc/cvc/volume_file_info.h
+++ b/inc/cvc/volume_file_info.h
@@ -41,15 +41,6 @@ public:
         _voxelTypes(_data._voxelTypes), _filename(_data._filename), _names(_data._names),
         _tmin(_data._tmin), _tmax(_data._tmax), _ctx(nullptr) {}
 
-  volume_file_info(const std::string &file)
-      : _dimension(_data._dimension), _boundingBox(_data._boundingBox), _minIsSet(_data._minIsSet),
-        _min(_data._min), _maxIsSet(_data._maxIsSet), _max(_data._max),
-        _numVariables(_data._numVariables), _numTimesteps(_data._numTimesteps),
-        _voxelTypes(_data._voxelTypes), _filename(_data._filename), _names(_data._names),
-        _tmin(_data._tmin), _tmax(_data._tmax), _ctx(nullptr) {
-    read(file);
-  }
-
   volume_file_info(app &ctx, const std::string &file)
       : _dimension(_data._dimension), _boundingBox(_data._boundingBox), _minIsSet(_data._minIsSet),
         _min(_data._min), _maxIsSet(_data._maxIsSet), _max(_data._max),
@@ -79,7 +70,6 @@ public:
     call volume_file_info::read() to fill out this object from
     the info in the supplied file header.
   */
-  void read(const std::string &filename);
   void read(app &ctx, const std::string &filename);
 
   /***** Volume info accessors *****/

--- a/src/cvc/hdf5_io.cpp
+++ b/src/cvc/hdf5_io.cpp
@@ -492,7 +492,7 @@ struct hdf5_io : public volume_file_io {
       volume_name = objectName;
     }
 
-    volume_file_info vfi(filename);
+    volume_file_info vfi(ctx, filename);
     bounding_box boundingBox = vfi.boundingBox();
     dimension dimension = vfi.voxel_dimensions();
 
@@ -630,7 +630,7 @@ struct hdf5_io : public volume_file_io {
       volume_name = objectName;
     }
 
-    volume_file_info vfi(filename);
+    volume_file_info vfi(ctx, filename);
 
     vol.voxelType(vfi.voxelTypes(var));
     vol.desc(vfi.name(var));

--- a/src/cvc/mrc_io.cpp
+++ b/src/cvc/mrc_io.cpp
@@ -490,7 +490,7 @@ struct mrc_io : public volume_file_io {
     if (subvoldim.isNull())
       throw index_out_of_bounds("Specified subvolume dimension is null.");
 
-    volume_file_info vfi(filename);
+    volume_file_info vfi(ctx, filename);
 
     if ((off_x + subvoldim[0] - 1 >= vfi.XDim()) || (off_y + subvoldim[1] - 1 >= vfi.YDim()) ||
         (off_z + subvoldim[2] - 1 >= vfi.ZDim())) {
@@ -803,7 +803,7 @@ struct mrc_io : public volume_file_io {
 
     // check if the file exists and we can write the specified subvolume to it
     try {
-      volinfo.read(filename);
+      volinfo.read(ctx, filename);
       // if(!(dimension(off_x+vol.XDim(),off_y+vol.YDim(),off_z+vol.ZDim()) <=
       // volinfo.voxel_dimensions()))
       if (off_x + vol.XDim() > volinfo.voxel_dimensions()[0] &&
@@ -829,7 +829,7 @@ struct mrc_io : public volume_file_io {
 
       CVC_NAMESPACE::createVolumeFile(ctx, filename, box, dim,
                                       std::vector<data_type>(1, vol.voxelType()), 1, 1, 0.0, 0.0);
-      volinfo.read(filename);
+      volinfo.read(ctx, filename);
 
       if (var >= volinfo.numVariables()) {
         std::string errStr =
@@ -1126,7 +1126,7 @@ struct imod_mrc_io : public mrc_io {
     if (subvoldim.isNull())
       throw index_out_of_bounds("Specified subvolume dimension is null.");
 
-    volume_file_info vfi(filename);
+    volume_file_info vfi(ctx, filename);
 
     if ((off_x + subvoldim[0] - 1 >= vfi.XDim()) || (off_y + subvoldim[1] - 1 >= vfi.YDim()) ||
         (off_z + subvoldim[2] - 1 >= vfi.ZDim()))

--- a/src/cvc/rawiv_io.cpp
+++ b/src/cvc/rawiv_io.cpp
@@ -661,7 +661,7 @@ struct rawiv_io : public volume_file_io {
 
     // check if the file exists and we can write the specified subvolume to it
     try {
-      volinfo.read(filename);
+      volinfo.read(ctx, filename);
 
       using namespace std;
 
@@ -690,7 +690,7 @@ struct rawiv_io : public volume_file_io {
       dim[2] += off_z;
       CVC_NAMESPACE::createVolumeFile(ctx, filename, box, dim,
                                       std::vector<data_type>(1, vol.voxelType()), 1, 1, 0.0, 0.0);
-      volinfo.read(filename);
+      volinfo.read(ctx, filename);
 
       if (var >= volinfo.numVariables()) {
         std::string errStr =

--- a/src/cvc/rawv_io.cpp
+++ b/src/cvc/rawv_io.cpp
@@ -691,7 +691,7 @@ struct rawv_io : public volume_file_io {
 
     // check if the file exists and we can write the specified subvolume to it
     try {
-      volinfo.read(filename);
+      volinfo.read(ctx, filename);
       // if(!(Dimension(off_x+vol.XDim(),off_y+vol.YDim(),off_z+vol.ZDim()) <=
       // volinfo.voxel_dimensions()))
       if (off_x + vol.XDim() > volinfo.voxel_dimensions()[0] &&
@@ -726,7 +726,7 @@ struct rawv_io : public volume_file_io {
       dim[2] += off_z;
       CVC_NAMESPACE::createVolumeFile(ctx, filename, box, dim,
                                       std::vector<data_type>(1, vol.voxelType()), 1, 1, 0.0, 0.0);
-      volinfo.read(filename);
+      volinfo.read(ctx, filename);
 
       if (var >= volinfo.numVariables()) {
         std::string errStr =

--- a/src/cvc/volume_file_info.cpp
+++ b/src/cvc/volume_file_info.cpp
@@ -41,13 +41,6 @@ namespace CVC_NAMESPACE {
 // 12/28/2009 -- Joe R. -- Collecting exception error strings
 // 09/08/2011 -- Joe R. -- Using splitRawFilename to extract real filename
 //                         if the provided filename is a file|obj tuple.
-void volume_file_info::read(const std::string &filename) {
-  // Legacy overload: delegate to the ctx-aware overload using the
-  // process-wide singleton. New code should call the (app&, filename)
-  // overload directly.
-  read(app::instance(), filename);
-}
-
 void volume_file_info::read(app &ctx, const std::string &filename) {
   _ctx = &ctx;
   std::string errors;
@@ -80,7 +73,11 @@ void volume_file_info::read(app &ctx, const std::string &filename) {
 }
 
 void volume_file_info::calcMinMax(unsigned int var, unsigned int time) const {
-  app &ctx = _ctx ? *_ctx : app::instance();
+  if (!_ctx)
+    throw std::runtime_error(
+        "volume_file_info::calcMinMax called on instance without an associated cvc::app; "
+        "construct via volume_file_info(app&, filename) or call read(app&, filename) first.");
+  app &ctx = *_ctx;
   thread_info ti(ctx, BOOST_CURRENT_FUNCTION);
 
   volume vol(ctx);

--- a/src/volutils/main.cpp
+++ b/src/volutils/main.cpp
@@ -97,7 +97,7 @@ static int cmd_info(int argc, char **argv) {
   }
   po::notify(vm);
 
-  cvc::volume_file_info vfi(vm["input"].as<std::string>());
+  cvc::volume_file_info vfi(volutils_app(), vm["input"].as<std::string>());
 
   std::cout << "File:       " << vfi.filename() << "\n"
             << "Dimensions: " << vfi.XDim() << " x " << vfi.YDim() << " x " << vfi.ZDim() << "\n"


### PR DESCRIPTION
Migrate the remaining callers of the legacy 1-arg `volume_file_info(filename)` ctor and `read(filename)` overload to the `(app&, filename)` versions, then delete the singleton-using overloads.

## Changes

**Caller migrations:**
- `mrc_io.cpp` x2, `hdf5_io.cpp` x2: `volume_file_info vfi(ctx, filename)`. Each enclosing `read*Volume` function already takes `cvc::app&`.
- `rawv_io.cpp` x2, `mrc_io.cpp` x2, `rawiv_io.cpp` x2: `volinfo.read(ctx, filename)` inside `writeVolumeFile(app&, ...)`.
- `src/volutils/main.cpp`: pass `volutils_app()`.

**Deletions:**
- `volume_file_info(const std::string&)` ctor.
- `void read(const std::string&)` decl + the singleton-delegating definition.
- `calcMinMax()` no longer falls back to `app::instance()`. Instances without a bound `cvc::app` now throw `std::runtime_error`. All in-tree default-constructed instances populate `_data` fields manually before any `min()/max()` readout, so behaviour is unchanged.

## Validation

- Clean build.
- 590/590 tests passing locally.
- clang-format clean.

Part of the `cvcapp` singleton-removal plan (see `cvc-singleton-removal-plan.md`).