### PR TITLE
geometry_file_io: drop app::instance() lazy trigger

### DIFF
--- a/inc/cvc/io_handlers.h
+++ b/inc/cvc/io_handlers.h
@@ -27,6 +27,18 @@ void register_hdf5_io(app &ctx);
 void register_bunny_io(app &ctx);
 void register_off_io(app &ctx);
 void register_cvcraw_io(app &ctx);
+
+// No-app overloads of the geometry registrations. The geometry handlers
+// register themselves into a global handler map and do not depend on
+// any cvc::app state.
+void register_bunny_io();
+void register_off_io();
+void register_cvcraw_io();
+
+// Convenience entry point that calls each register_*_io() above. Used
+// by geometry_file_io::get_handlers() to populate the handler map on
+// first access without requiring a cvc::app instance to exist.
+void register_default_geometry_handlers();
 } // namespace CVC_NAMESPACE
 
 #endif

--- a/src/cvc/bunny_io.cpp
+++ b/src/cvc/bunny_io.cpp
@@ -100,4 +100,6 @@ namespace CVC_NAMESPACE {
 void register_bunny_io(app & /*ctx*/) {
   geometry_file_io::insert_handler(geometry_file_io::ptr(new bunny_io));
 }
+
+void register_bunny_io() { geometry_file_io::insert_handler(geometry_file_io::ptr(new bunny_io)); }
 } // namespace CVC_NAMESPACE

--- a/src/cvc/cvcraw_io.cpp
+++ b/src/cvc/cvcraw_io.cpp
@@ -474,4 +474,8 @@ namespace CVC_NAMESPACE {
 void register_cvcraw_io(app & /*ctx*/) {
   geometry_file_io::insert_handler(geometry_file_io::ptr(new cvcraw_io));
 }
+
+void register_cvcraw_io() {
+  geometry_file_io::insert_handler(geometry_file_io::ptr(new cvcraw_io));
+}
 } // namespace CVC_NAMESPACE

--- a/src/cvc/geometry_file_io.cpp
+++ b/src/cvc/geometry_file_io.cpp
@@ -1,7 +1,7 @@
 #include <boost/foreach.hpp>
 #include <boost/regex.hpp>
-#include <cvc/app.h>
 #include <cvc/geometry_file_io.h>
+#include <cvc/io_handlers.h>
 
 namespace CVC_NAMESPACE {
 // A regex to extract a filename extension
@@ -32,13 +32,20 @@ geometry_file_io::handler_map &geometry_file_io::get_handlers() {
   // It's ok to leak: http://www.parashift.com/c++-faq-lite/ctors.html#faq-10.15
   static handler_map *p = initialize_map();
 
-  // Ensure the default I/O handlers have been registered. Registration
-  // happens lazily when the app singleton is first accessed; triggering
-  // it here guarantees the handler map is populated before any lookup
-  // regardless of whether the caller has explicitly touched the app
-  // singleton.
-  // TODO: Remove this lazy trigger once the singleton is removed.
-  (void)app::instance();
+  // Ensure the default geometry I/O handlers are registered the first
+  // time the handler map is requested. The handler register_* helpers
+  // call back into insert_handler() and therefore re-enter
+  // get_handlers(); an explicit guard avoids re-entering the same
+  // function-local static initialiser, which would be undefined
+  // behaviour.
+  static bool _registering_defaults = false;
+  static bool _defaults_registered = false;
+  if (!_defaults_registered && !_registering_defaults) {
+    _registering_defaults = true;
+    register_default_geometry_handlers();
+    _defaults_registered = true;
+    _registering_defaults = false;
+  }
 
   return *p;
 }
@@ -193,5 +200,18 @@ void write_geometry(const geometry &geo, const std::string &filename) {
   }
   throw unsupported_geometry_file_type(str(boost::format("%1% : Cannot write '%2%'%3%") %
                                            BOOST_CURRENT_FUNCTION % filename % errors));
+}
+
+// -----------------------------------
+// register_default_geometry_handlers
+// -----------------------------------
+// Purpose:
+//   Register the built-in geometry I/O handlers without requiring a
+//   cvc::app instance. Called from geometry_file_io::get_handlers() the
+//   first time the handler map is requested.
+void register_default_geometry_handlers() {
+  register_bunny_io();
+  register_off_io();
+  register_cvcraw_io();
 }
 } // namespace CVC_NAMESPACE

--- a/src/cvc/off_io.cpp
+++ b/src/cvc/off_io.cpp
@@ -193,4 +193,6 @@ namespace CVC_NAMESPACE {
 void register_off_io(app & /*ctx*/) {
   geometry_file_io::insert_handler(geometry_file_io::ptr(new off_io));
 }
+
+void register_off_io() { geometry_file_io::insert_handler(geometry_file_io::ptr(new off_io)); }
 } // namespace CVC_NAMESPACE


### PR DESCRIPTION
Removes the `(void)app::instance();` line in `geometry_file_io::get_handlers()` that existed solely to provoke registration of the default geometry handlers via `app::registerDefaultHandlers()`.

## Approach

Add no-arg overloads of `register_bunny_io`, `register_off_io`, `register_cvcraw_io` (the existing `(app&)` overloads already ignore their parameter), plus a `register_default_geometry_handlers()` dispatcher.

`geometry_file_io::get_handlers()` calls `register_default_geometry_handlers()` exactly once per process via a re-entrancy-safe guard pair (the register helpers call `insert_handler()`, which re-enters `get_handlers()`).

## Validation

- Clean build.
- 590/590 tests pass (debug).
- clang-format clean.

Part of the `cvcapp` singleton-removal plan.