### PR TITLE
geometry: drop app::instance() from default ctors and smoothing()

### DIFF
--- a/inc/cvc/geometry.h
+++ b/inc/cvc/geometry.h
@@ -244,9 +244,9 @@ public:
   geometry &project(const geometry &input);
 
   // sangmin park's smoothing method
-  geometry &smoothing(float delta = 0.1f, bool fix_boundary = false, bool perturb_1 = false,
-                      bool geometric_flow = true, bool smoothing_enabled = true,
-                      bool perturb_2 = false);
+  geometry &smoothing(app &ctx, float delta = 0.1f, bool fix_boundary = false,
+                      bool perturb_1 = false, bool geometric_flow = true,
+                      bool smoothing_enabled = true, bool perturb_2 = false);
 
   // LBIE mesh quality improvement
 #ifdef CVC_ENABLE_MESHER

--- a/src/cvc/geometry.cpp
+++ b/src/cvc/geometry.cpp
@@ -47,7 +47,7 @@
 // #define CVC_GEOMETRY_CORRECT_INDEX_START
 
 namespace CVC_NAMESPACE {
-geometry::geometry() : _geom_type(SURFACE_TRI), _extents_set(false), _ctx(&app::instance()) {
+geometry::geometry() : _geom_type(SURFACE_TRI), _extents_set(false), _ctx(nullptr) {
   for (uint64_t i = 0; i < 3; i++)
     _min[i] = _max[i] = 0.0;
 
@@ -634,7 +634,7 @@ void geometry::write(const std::string &filename) const { write_geometry(*this, 
 // arand: written 4-11-2011
 //        directly read a cvc-raw type file into the data structure
 geometry::geometry(const std::string &filename)
-    : _geom_type(SURFACE_TRI), _extents_set(false), _ctx(&app::instance()) {
+    : _geom_type(SURFACE_TRI), _extents_set(false), _ctx(nullptr) {
   for (uint64_t i = 0; i < 3; i++)
     _min[i] = _max[i] = 0.0;
   init_ptrs();

--- a/src/cvc/smoothing.cpp
+++ b/src/cvc/smoothing.cpp
@@ -655,9 +655,9 @@ void smooth_geometry(CVC_NAMESPACE::app &ctx, CVC_NAMESPACE::geometry &geo, floa
 }; // namespace
 
 namespace CVC_NAMESPACE {
-geometry &geometry::smoothing(float delta, bool fix_boundary, bool perturb_1, bool geometric_flow,
-                              bool smoothing_enabled, bool perturb_2) {
-  smooth_geometry(ctx(), *this, delta, fix_boundary, perturb_1, geometric_flow, smoothing_enabled,
+geometry &geometry::smoothing(app &ctx, float delta, bool fix_boundary, bool perturb_1,
+                              bool geometric_flow, bool smoothing_enabled, bool perturb_2) {
+  smooth_geometry(ctx, *this, delta, fix_boundary, perturb_1, geometric_flow, smoothing_enabled,
                   perturb_2);
   return *this;
 }

--- a/src/cvc/tests/geometry_test.cpp
+++ b/src/cvc/tests/geometry_test.cpp
@@ -759,7 +759,7 @@ TEST_F(GeometryTest, SmoothingPreservesTopology) {
   uint64_t original_tris = geom.num_tris();
 
   // Apply smoothing
-  geom.smoothing(0.1f, false);
+  geom.smoothing(ctx, 0.1f, false);
 
   // Topology should be preserved
   EXPECT_EQ(geom.num_points(), original_points);
@@ -771,7 +771,7 @@ TEST_F(GeometryTest, SmoothingMovesVertices) {
   geometry smoothed(bunny);
 
   // Apply smoothing
-  smoothed.smoothing(0.5f, false);
+  smoothed.smoothing(ctx, 0.5f, false);
 
   // Vertices should have moved
   bool vertices_moved = false;
@@ -808,7 +808,7 @@ TEST_F(GeometryTest, SmoothingWithBoundaryFixed) {
   }
 
   // Apply smoothing with boundary fixed
-  geom.smoothing(0.5f, true);
+  geom.smoothing(ctx, 0.5f, true);
 
   // Boundary vertices should not have moved (allow small numerical errors)
   for (size_t i = 0; i < 10; i++) {

--- a/src/volrover3/GeometryDialog.cpp
+++ b/src/volrover3/GeometryDialog.cpp
@@ -1318,7 +1318,8 @@ void GeometryDialog::onSmoothingClicked() {
           volrover3::app().threadInfo(threadKey, "Smoothing mesh...");
 
           // Perform the smoothing operation with all parameters
-          geom.smoothing(delta, fixBoundary, perturb1, geoFlow, smoothingEnabled, perturb2);
+          geom.smoothing(volrover3::app(), delta, fixBoundary, perturb1, geoFlow, smoothingEnabled,
+                         perturb2);
 
           volrover3::app().threadProgress(threadKey, 0.9);
           volrover3::app().threadInfo(threadKey, "Updating scene...");


### PR DESCRIPTION
Removes two more singleton accesses from `cvc::geometry`.

## Before
- `geometry::geometry()` and `geometry::geometry(filename)` initialised `_ctx` to `&app::instance()`.
- `geometry::smoothing(...)` took no `app&` and used `ctx()` (i.e. `*_ctx`) to get one.

## After
- Both default ctors leave `_ctx = nullptr`. The explicit `(app&, filename)` ctor and the assignment fast-path in `geometry::read()` continue to populate it as before.
- `geometry::smoothing(app&, ...)` takes the context explicitly and forwards it to `smooth_geometry()`.
- All four call sites updated:
  - `src/cvc/tests/geometry_test.cpp` x3 — tests already own a `cvc::app ctx;` via the `GeometryTest` fixture.
  - `src/volrover3/GeometryDialog.cpp` passes `volrover3::app()`.

`ctx()` / `_ctx` stay on the class for now; they will be removed in a later PR once `read_geometry` / `write_geometry` are also threaded.

## Validation
- Clean build.
- `ctest -j8` 590/590 (debug).
- clang-format clean.

Part of the cvcapp singleton-removal plan.