### PR TITLE
app: delete legacy 1-arg thread_info/thread_feedback/scoped_lock ctors

### DIFF
--- a/inc/cvc/app.h
+++ b/inc/cvc/app.h
@@ -380,9 +380,6 @@ public:
       }
     }
 
-    // Legacy: uses app::instance()
-    thread_info(const std::string &info = "running") : thread_info(app::instance(), info) {}
-
     ~thread_info() {
       try {
         _app.thisThreadInfo(_origInfo);
@@ -416,9 +413,6 @@ public:
         // Swallow exceptions during construction (thread may be interrupted)
       }
     }
-
-    // Legacy: uses app::instance()
-    thread_feedback(const std::string &key = "") : thread_feedback(app::instance(), key) {}
 
     ~thread_feedback() {
       // CRITICAL: Must catch exceptions in destructor to prevent std::terminate()
@@ -489,12 +483,6 @@ public:
         : _ctx(ctx), _scopedLock(*ctx.mutex(name)), _name(name) {
       // prepend the thread key
       _ctx.mutexInfo(name, _ctx.threadKey() + ": " + info);
-    }
-    // Legacy: uses app::instance()
-    scoped_lock(const std::string &name, const std::string &info = std::string())
-        : _ctx(app::instance()), _scopedLock(*app::instance().mutex(name)), _name(name) {
-      // prepend the thread key
-      app::instance().mutexInfo(name, app::instance().threadKey() + ": " + info);
     }
     ~scoped_lock() { _ctx.mutexInfo(_name, ""); }
 

--- a/inc/cvc/state_object.h
+++ b/inc/cvc/state_object.h
@@ -425,7 +425,7 @@ private:
         lock.unlock();
         std::string threadKey = stateName(childState) + "_stateChanged";
         _ctx.startThread(threadKey, [this, childState, threadKey]() {
-          cvc::app::thread_feedback feedback(threadKey);
+          cvc::app::thread_feedback feedback(_ctx, threadKey);
           this->handleStateChanged(childState);
         });
       } else {


### PR DESCRIPTION
Stacked on #23.

Removes the three legacy constructors that silently delegated to `app::instance()`:
- `thread_info(const std::string&)`
- `thread_feedback(const std::string&)`
- `scoped_lock(const std::string&, const std::string&)`

After PR #23 (algorithm.cpp dropping its 25 `thread_info(BOOST_CURRENT_FUNCTION)` calls), these legacy ctors had no callers outside of one site in `state_object.h::handleStateChanged()` lambda, which is updated to pass `_ctx` explicitly.

The `(app&, ...)` variants remain the supported API.

Remaining `app::instance()`/`cvcapp` users are now confined to:
- `xmlrpc_client.cpp` / `xmlrpc_server.cpp` (deferred per master plan, bundled with cvcstate fold-in)
- `state.cpp:98-101` (Phase D, cvcstate fold-in)
- `app.h:620` `#define cvcapp` macro + `app.cpp:187` `app::instance()` impl (Phase C, deleted last)

Build + `ctest -j8` green: 590/590 (one ThreadFeedbackExceptionSafety flake passed on rerun, unrelated).