### PR TITLE
xmlrpc_client: thread cvc::app& through rpc/rpc_call API

### DIFF
--- a/inc/cvc/utility.h
+++ b/inc/cvc/utility.h
@@ -193,18 +193,18 @@ const int XMLRPC_DEFAULT_PORT = 23196;
 
 // 01/13/2014 - Joe R. - Creation.  Implementation is in xmlrpc_client.cpp
 XmlRpc::XmlRpcValue
-rpc_call(const std::string &host, int port, const std::string &method_name,
+rpc_call(app &ctx, const std::string &host, int port, const std::string &method_name,
          const XmlRpc::XmlRpcValue &params, bool sync = true,
          boost::posix_time::ptime mod_time = boost::posix_time::microsec_clock::universal_time());
 
 XmlRpc::XmlRpcValue
-rpc_call(const std::string &host, int port, const std::string &method_name,
+rpc_call(app &ctx, const std::string &host, int port, const std::string &method_name,
          const std::vector<std::string> &params, bool sync = true,
          boost::posix_time::ptime mod_time = boost::posix_time::microsec_clock::universal_time());
 
 XmlRpc::XmlRpcValue
-rpc(const std::string &url, const std::string &method_name, const std::vector<std::string> &params,
-    bool sync = true,
+rpc(app &ctx, const std::string &url, const std::string &method_name,
+    const std::vector<std::string> &params, bool sync = true,
     boost::posix_time::ptime mod_time = boost::posix_time::microsec_clock::universal_time());
 
 // Splits a string of the form <host>:<port>

--- a/src/cvc/libcvc.cpp
+++ b/src/cvc/libcvc.cpp
@@ -171,7 +171,7 @@ void client(CVC_NAMESPACE::app &ctx, const std::vector<std::string> &args) {
   std::string method_name = args[1];
   vector<string> rpc_args = args;
   rpc_args.erase(rpc_args.begin(), rpc_args.begin() + 2);
-  string result = rpc(host_and_port, method_name, rpc_args);
+  string result = rpc(ctx, host_and_port, method_name, rpc_args);
   if (!result.empty())
     cout << result << endl;
 }

--- a/src/cvc/xmlrpc_client.cpp
+++ b/src/cvc/xmlrpc_client.cpp
@@ -3,7 +3,6 @@
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <cvc/app.h>
-#include <cvc/state.h>
 #include <cvc/utility.h>
 #include <xmlrpc/XmlRpc.h>
 
@@ -18,38 +17,23 @@ namespace CVC_NAMESPACE {
 class xmlrpc_client_thread {
 public:
   xmlrpc_client_thread(
-      const std::string &host, int port, const std::string &method_name,
+      app &ctx, const std::string &host, int port, const std::string &method_name,
       const XmlRpc::XmlRpcValue &params,
       boost::posix_time::ptime mod_time = boost::posix_time::microsec_clock::universal_time())
-      : _host(host), _port(port), _method_name(method_name), _params(params), _mod_time(mod_time) {
+      : _app(&ctx), _host(host), _port(port), _method_name(method_name), _params(params),
+        _mod_time(mod_time) {
     _thread_name =
         boost::str(boost::format("xmlrpc_client_thread_%s_%d_%s") % host % port % method_name);
   }
 
-  xmlrpc_client_thread(const xmlrpc_client_thread &t)
-      : _thread_name(t._thread_name), _host(t._host), _port(t._port), _method_name(t._method_name),
-        _params(t._params), _mod_time(t._mod_time) {}
-
-  xmlrpc_client_thread &operator=(const xmlrpc_client_thread &t) {
-    if (this == &t)
-      return *this;
-    _thread_name = t._thread_name;
-    _host = t._host;
-    _port = t._port;
-    _method_name = t._method_name;
-    _params = t._params;
-    _mod_time = t._mod_time;
-    return *this;
-  }
+  xmlrpc_client_thread(const xmlrpc_client_thread &t) = default;
+  xmlrpc_client_thread &operator=(const xmlrpc_client_thread &t) = default;
 
   void operator()() const {
     using namespace boost;
     using namespace std;
 
-    using namespace boost;
-    using namespace std;
-
-    CVC_NAMESPACE::thread_feedback feedback;
+    CVC_NAMESPACE::thread_feedback feedback(*_app);
 
     XmlRpc::XmlRpcClient c(_host.c_str(), _port);
     XmlRpc::XmlRpcValue params, result;
@@ -62,79 +46,24 @@ public:
     //       params[1] = posix_time::to_simple_string(_mod_time);
 
     for (int i = 0; i < 3; i++)
-      cvcapp.log(6, str(boost::format("%s :: params[%d] = %s\n") % BOOST_CURRENT_FUNCTION % i %
-                        string(params[i])));
+      _app->log(6, str(boost::format("%s :: params[%d] = %s\n") % BOOST_CURRENT_FUNCTION % i %
+                       string(params[i])));
 
     c.execute(_method_name.c_str(), params, result);
 
-    cvcapp.data(thread_name(), result);
+    _app->data(thread_name(), result);
   }
 
   const std::string &thread_name() const { return _thread_name; }
 
 protected:
+  app *_app;
   std::string _thread_name;
   std::string _host;
   int _port;
   std::string _method_name;
   XmlRpc::XmlRpcValue _params;
   boost::posix_time::ptime _mod_time;
-};
-
-// --------------------------
-// queue_xmlrpc_client_thread
-// --------------------------
-// Purpose:
-//   Queues up a thread on the data map to set a remote state value at a later time.
-//   process_xmlrpc_client_threads is in charge of actually launching the thread.
-// ---- Change History ----
-// 01/13/2014 -- Joe R. -- Creation.
-class queue_xmlrpc_client_thread {
-public:
-  queue_xmlrpc_client_thread(const xmlrpc_client_thread &xct) : _xct(xct) {}
-
-  queue_xmlrpc_client_thread(const queue_xmlrpc_client_thread &q) : _xct(q._xct) {}
-
-  queue_xmlrpc_client_thread &operator=(const queue_xmlrpc_client_thread &rhs) { _xct = rhs._xct; }
-
-  void operator()() const {
-    CVC_NAMESPACE::thread_feedback feedback;
-
-    // Stick the thread on the datamap.  There is another thread that will actually launch
-    // these threads some time later.  Doing this, we won't flood the network with xmlrpc
-    // requests if data gets old before it is sent out over the network.
-    cvcapp.data(_xct.thread_name(), _xct);
-  }
-
-private:
-  xmlrpc_client_thread _xct;
-};
-
-// -----------------------------
-// process_xmlrpc_client_threads
-// -----------------------------
-// Purpose:
-//   Starts all the xmlrpc client threads that are on the data map.
-// ---- Change History ----
-// 01/13/2014 -- Joe R. -- creation.
-class process_xmlrpc_client_threads {
-public:
-  void operator()() const {
-    CVC_NAMESPACE::thread_feedback feedback;
-
-    while (1) {
-      cvcapp.sleep(cvcstate("__system.xmlrpc_client.interval").value<double>());
-
-      std::vector<std::string> keys = cvcapp.data<xmlrpc_client_thread>();
-      std::vector<xmlrpc_client_thread> threads = cvcapp.data<xmlrpc_client_thread>(keys);
-      BOOST_FOREACH (xmlrpc_client_thread &thread, threads) {
-        if (cvcapp.hasThread(thread.thread_name()))
-          continue;
-        cvcapp.data(thread.thread_name(), boost::any()); // this will be replaced by the result
-        cvcapp.startThread(thread.thread_name(), thread);
-      }
-    }
-  }
 };
 
 // --------
@@ -144,17 +73,17 @@ public:
 //  Does an xmlrpc method call on the specified host and port.
 // ---- Change History ----
 // 01/13/2014 -- Joe R. -- Creation.
-XmlRpc::XmlRpcValue rpc_call(const std::string &host, int port, const std::string &method_name,
-                             const XmlRpc::XmlRpcValue &params, bool sync,
-                             boost::posix_time::ptime mod_time) {
+XmlRpc::XmlRpcValue rpc_call(app &ctx, const std::string &host, int port,
+                             const std::string &method_name, const XmlRpc::XmlRpcValue &params,
+                             bool sync, boost::posix_time::ptime mod_time) {
   if (sync) {
-    xmlrpc_client_thread xct(host, port, method_name, params, mod_time);
+    xmlrpc_client_thread xct(ctx, host, port, method_name, params, mod_time);
     xct();
-    return cvcapp.data<XmlRpc::XmlRpcValue>(xct.thread_name());
+    return ctx.data<XmlRpc::XmlRpcValue>(xct.thread_name());
   } else // async calls are broken at the moment ... 01/13/2014
   {
-    xmlrpc_client_thread xct(host, port, method_name, params, mod_time);
-    cvcapp.data(xct.thread_name(), xct);
+    xmlrpc_client_thread xct(ctx, host, port, method_name, params, mod_time);
+    ctx.data(xct.thread_name(), xct);
     return XmlRpc::XmlRpcValue();
   }
 }
@@ -166,14 +95,14 @@ XmlRpc::XmlRpcValue rpc_call(const std::string &host, int port, const std::strin
 //  Does an xmlrpc method call on the specified host and port.
 // ---- Change History ----
 // 01/13/2014 -- Joe R. -- Creation.
-XmlRpc::XmlRpcValue rpc_call(const std::string &host, int port, const std::string &method_name,
-                             const std::vector<std::string> &params, bool sync,
-                             boost::posix_time::ptime mod_time) {
+XmlRpc::XmlRpcValue rpc_call(app &ctx, const std::string &host, int port,
+                             const std::string &method_name, const std::vector<std::string> &params,
+                             bool sync, boost::posix_time::ptime mod_time) {
   XmlRpc::XmlRpcValue vals;
   int i = 0;
   BOOST_FOREACH (const std::string &p, params)
     vals[i++] = p;
-  return rpc_call(host, port, method_name, vals, sync, mod_time);
+  return rpc_call(ctx, host, port, method_name, vals, sync, mod_time);
 }
 
 // ---
@@ -183,29 +112,12 @@ XmlRpc::XmlRpcValue rpc_call(const std::string &host, int port, const std::strin
 //  Does an xmlrpc method call on the specified host and port.
 // ---- Change History ----
 // 01/13/2014 -- Joe R. -- Creation.
-XmlRpc::XmlRpcValue rpc(const std::string &host_and_port, const std::string &method_name,
+XmlRpc::XmlRpcValue rpc(app &ctx, const std::string &host_and_port, const std::string &method_name,
                         const std::vector<std::string> &params, bool sync,
                         boost::posix_time::ptime mod_time) {
   std::string host;
   int port = -1;
   boost::tie(host, port) = get_xmlrpc_host_and_port(host_and_port);
-  return rpc_call(host, port, method_name, params, sync, mod_time);
+  return rpc_call(ctx, host, port, method_name, params, sync, mod_time);
 }
 } // namespace CVC_NAMESPACE
-
-namespace {
-class process_xmlrpc_client_threads_init {
-public:
-  static void init() {
-    // Sleep for 200ms before each iteration by default.
-    cvcstate("__system.xmlrpc_client.interval").value(double(200.0));
-    cvcapp.startThread("process_xmlrpc_client_threads",
-                       CVC_NAMESPACE::process_xmlrpc_client_threads());
-  }
-
-  process_xmlrpc_client_threads_init() {
-    // Need to fix async calls.  For now, disabling this thread.
-    // CVC_NAMESPACE::state::on_startup(init);
-  }
-} static_init;
-} // namespace


### PR DESCRIPTION
Removes the last `cvcapp`/`app::instance()` references from `src/cvc/xmlrpc_client.cpp`.

The free functions `rpc()` and `rpc_call()` now take `cvc::app &ctx` as their first parameter and forward it to `xmlrpc_client_thread`, which now holds an `app *` member and calls `ctx.log()` / `ctx.data()` instead of `cvcapp.log` / `cvcapp.data`.

Also drops the unused `queue_xmlrpc_client_thread` and `process_xmlrpc_client_threads` classes plus their static initializer:
- The class comment already noted async calls were broken since 2014.
- The `on_startup()` registration was commented out (`// CVC_NAMESPACE::state::on_startup(init);`).
- The `static_init` therefore had no runtime effect.

Updated:
- `inc/cvc/utility.h`: `rpc`/`rpc_call` signatures gain leading `app &ctx`.
- `src/cvc/libcvc.cpp`: `client()` command passes its `ctx` through to `rpc()`.

After this change, `libcvc.cpp` and `xmlrpc_client.cpp` are free of `cvcapp`. Remaining singleton sites: `app.h`/`app.cpp` mechanics, `state.cpp:98-101`, `state_object.h:218` default ctor, and `xmlrpc_server.cpp`.

Build + `ctest -j8` green: 590/590 (one ThreadProgressPersistence flake passed on rerun, unrelated).