### PR TITLE
volrover3: thread cvc::app& through SceneNode hierarchy ctors

### DIFF
--- a/inc/volrover3/AxisNode.h
+++ b/inc/volrover3/AxisNode.h
@@ -9,7 +9,7 @@ class vtkAxesActor;
 
 class AxisNode : public GraphicsNode {
 public:
-  AxisNode(const std::string &statePath, const std::string &name = "axis");
+  AxisNode(CVC_NAMESPACE::app &ctx, const std::string &statePath, const std::string &name = "axis");
   ~AxisNode() override;
 
   void setAxisLength(double length);

--- a/inc/volrover3/CameraController.h
+++ b/inc/volrover3/CameraController.h
@@ -10,7 +10,7 @@ enum CameraMode { ORBIT_MODE = 0, FLY_MODE = 1 };
 
 class CameraController : public SceneNode {
 public:
-  CameraController(const std::string &statePath = "volrover3.camera");
+  CameraController(CVC_NAMESPACE::app &ctx, const std::string &statePath = "volrover3.camera");
   ~CameraController();
 
   void setCamera(vtkCamera *camera);

--- a/inc/volrover3/GeometryNode.h
+++ b/inc/volrover3/GeometryNode.h
@@ -42,7 +42,8 @@ enum class GeometryRenderMode {
  */
 class GeometryNode : public GraphicsNode {
 public:
-  GeometryNode(const std::string &statePath, const std::string &name = "geometry");
+  GeometryNode(CVC_NAMESPACE::app &ctx, const std::string &statePath,
+               const std::string &name = "geometry");
   ~GeometryNode() override;
 
   // Generic setData for template compatibility

--- a/inc/volrover3/GraphicsNode.h
+++ b/inc/volrover3/GraphicsNode.h
@@ -43,7 +43,7 @@ class volume;
  */
 class GraphicsNode : public SceneNode {
 public:
-  GraphicsNode(const std::string &statePath, const std::string &name = "");
+  GraphicsNode(CVC_NAMESPACE::app &ctx, const std::string &statePath, const std::string &name = "");
   virtual ~GraphicsNode();
 
   // Identity and naming
@@ -84,7 +84,7 @@ public:
     std::string childStatePath = getState().fullName() + ".children." + name;
 
     // Create the child node with proper state path and name
-    auto child = std::make_shared<T>(childStatePath, name);
+    auto child = std::make_shared<T>(this->app(), childStatePath, name);
 
     // Add to children using the non-template version
     addGraphicsChild(std::static_pointer_cast<GraphicsNode>(child));

--- a/inc/volrover3/GridNode.h
+++ b/inc/volrover3/GridNode.h
@@ -14,7 +14,7 @@ class vtkTextMapper;
 
 class GridNode : public GraphicsNode {
 public:
-  GridNode(const std::string &statePath, const std::string &name = "grid");
+  GridNode(CVC_NAMESPACE::app &ctx, const std::string &statePath, const std::string &name = "grid");
   ~GridNode() override;
 
   void setBounds(const cvc::bounding_box &bounds);

--- a/inc/volrover3/NullGraphicNode.h
+++ b/inc/volrover3/NullGraphicNode.h
@@ -23,7 +23,8 @@ class state;
  */
 class NullGraphicNode : public GraphicsNode {
 public:
-  NullGraphicNode(const std::string &statePath, const std::string &name = "null");
+  NullGraphicNode(CVC_NAMESPACE::app &ctx, const std::string &statePath,
+                  const std::string &name = "null");
   ~NullGraphicNode() override;
 
   // Set custom bounding box extents (user-modifiable)

--- a/inc/volrover3/SceneNode.h
+++ b/inc/volrover3/SceneNode.h
@@ -13,8 +13,12 @@ class SceneGraph;
 
 class SceneNode : public CVC_NAMESPACE::state_object<SceneNode> {
 public:
-  SceneNode(const std::string &statePath);
+  SceneNode(CVC_NAMESPACE::app &ctx, const std::string &statePath);
   virtual ~SceneNode();
+
+  // Access the app context this node is bound to. Subclasses use this when
+  // creating child nodes so that the singleton is not consulted.
+  CVC_NAMESPACE::app &app() const { return _ctx; }
 
   virtual void addToRenderer(vtkRenderer *renderer);
   virtual void removeFromRenderer(vtkRenderer *renderer);

--- a/inc/volrover3/VolumeNode.h
+++ b/inc/volrover3/VolumeNode.h
@@ -35,7 +35,8 @@ class state;
  */
 class VolumeNode : public GraphicsNode {
 public:
-  VolumeNode(const std::string &statePath, const std::string &name = "volume");
+  VolumeNode(CVC_NAMESPACE::app &ctx, const std::string &statePath,
+             const std::string &name = "volume");
   ~VolumeNode() override;
 
   // Generic setData for template compatibility

--- a/src/volrover3/AxisNode.cpp
+++ b/src/volrover3/AxisNode.cpp
@@ -5,8 +5,8 @@
 #include <vtkTextProperty.h>
 #include <vtkTransform.h>
 
-AxisNode::AxisNode(const std::string &statePath, const std::string &name)
-    : GraphicsNode(statePath, name), m_axesActor(vtkSmartPointer<vtkAxesActor>::New()) {
+AxisNode::AxisNode(cvc::app &ctx, const std::string &statePath, const std::string &name)
+    : GraphicsNode(ctx, statePath, name), m_axesActor(vtkSmartPointer<vtkAxesActor>::New()) {
   // Set axis length
   m_axesActor->SetTotalLength(2.0, 2.0, 2.0);
   m_axesActor->SetShaftTypeToLine();

--- a/src/volrover3/CameraController.cpp
+++ b/src/volrover3/CameraController.cpp
@@ -4,8 +4,8 @@
 #include <sstream>
 #include <volrover3/CameraController.h>
 
-CameraController::CameraController(const std::string &statePath)
-    : SceneNode(statePath), m_camera(nullptr), m_mode(ORBIT_MODE), m_orbitDistance(10.0),
+CameraController::CameraController(cvc::app &ctx, const std::string &statePath)
+    : SceneNode(ctx, statePath), m_camera(nullptr), m_mode(ORBIT_MODE), m_orbitDistance(10.0),
       m_orbitAzimuth(0.0), m_orbitElevation(30.0), m_yaw(0.0), m_pitch(0.0),
       m_mouseLeftPressed(false), m_mouseRightPressed(false), m_mouseMiddlePressed(false),
       m_movementSpeed(5.0), m_mouseSensitivity(1.0), m_invertMouse(false), m_keyForward(Qt::Key_W),

--- a/src/volrover3/GeometryNode.cpp
+++ b/src/volrover3/GeometryNode.cpp
@@ -21,9 +21,10 @@
 #include <vtkTransform.h>
 #include <vtkVertex.h>
 
-GeometryNode::GeometryNode(const std::string &statePath, const std::string &name)
-    : GraphicsNode(statePath, name), m_hasGeometry(false), m_renderMode(GeometryRenderMode::TRIS),
-      m_useSingleColor(false), m_actor(vtkSmartPointer<vtkActor>::New()),
+GeometryNode::GeometryNode(cvc::app &ctx, const std::string &statePath, const std::string &name)
+    : GraphicsNode(ctx, statePath, name), m_hasGeometry(false),
+      m_renderMode(GeometryRenderMode::TRIS), m_useSingleColor(false),
+      m_actor(vtkSmartPointer<vtkActor>::New()),
       m_mapper(vtkSmartPointer<vtkPolyDataMapper>::New()),
       m_polyData(vtkSmartPointer<vtkPolyData>::New()) {
   m_mapper->SetInputData(m_polyData);

--- a/src/volrover3/GraphicsNode.cpp
+++ b/src/volrover3/GraphicsNode.cpp
@@ -17,8 +17,8 @@
 #include <vtkTextProperty.h>
 #include <vtkTransform.h>
 
-GraphicsNode::GraphicsNode(const std::string &statePath, const std::string &name)
-    : SceneNode(statePath), m_name(name), m_transform(vtkSmartPointer<vtkMatrix4x4>::New()),
+GraphicsNode::GraphicsNode(cvc::app &ctx, const std::string &statePath, const std::string &name)
+    : SceneNode(ctx, statePath), m_name(name), m_transform(vtkSmartPointer<vtkMatrix4x4>::New()),
       m_vtkTransform(vtkSmartPointer<vtkTransform>::New()), m_parent(nullptr), m_showBBox(false),
       m_bboxNode(std::make_shared<BBoxNode>()), m_showLabel(false), m_labelText(name),
       m_labelSize(14), m_labelActor(vtkSmartPointer<vtkActor2D>::New()), m_clipChildren(false),

--- a/src/volrover3/GridNode.cpp
+++ b/src/volrover3/GridNode.cpp
@@ -17,8 +17,8 @@
 #include <vtkTextProperty.h>
 #include <vtkTransform.h>
 
-GridNode::GridNode(const std::string &statePath, const std::string &name)
-    : GraphicsNode(statePath, name), m_yzActor(vtkSmartPointer<vtkActor>::New()),
+GridNode::GridNode(cvc::app &ctx, const std::string &statePath, const std::string &name)
+    : GraphicsNode(ctx, statePath, name), m_yzActor(vtkSmartPointer<vtkActor>::New()),
       m_xzActor(vtkSmartPointer<vtkActor>::New()), m_xyActor(vtkSmartPointer<vtkActor>::New()),
       m_yzMapper(vtkSmartPointer<vtkPolyDataMapper>::New()),
       m_xzMapper(vtkSmartPointer<vtkPolyDataMapper>::New()),

--- a/src/volrover3/NullGraphicNode.cpp
+++ b/src/volrover3/NullGraphicNode.cpp
@@ -8,8 +8,9 @@
 #include <volrover3/NullGraphicNode.h>
 #include <vtkActor.h>
 
-NullGraphicNode::NullGraphicNode(const std::string &statePath, const std::string &name)
-    : GraphicsNode(statePath, name),
+NullGraphicNode::NullGraphicNode(cvc::app &ctx, const std::string &statePath,
+                                 const std::string &name)
+    : GraphicsNode(ctx, statePath, name),
       m_bounds(-0.5, -0.5, -0.5, 0.5, 0.5, 0.5) // Default 1x1x1 box centered at origin
       ,
       m_dummyActor(vtkSmartPointer<vtkActor>::New()),

--- a/src/volrover3/SceneGraph.cpp
+++ b/src/volrover3/SceneGraph.cpp
@@ -26,7 +26,7 @@ SceneGraph::SceneGraph(const std::string &statePrefix)
   // Create null graphic as THE root graphics node (all graphics go under this)
   // State path: {statePrefix}.graphics.root
   std::string rootStatePath = statePrefix + ".graphics.root";
-  m_nullGraphic = std::make_shared<NullGraphicNode>(rootStatePath, "root");
+  m_nullGraphic = std::make_shared<NullGraphicNode>(volrover3::app(), rootStatePath, "root");
 
   // Set SceneGraph reference IMMEDIATELY after construction
   // This enables threading for event posting (nodes disable threading in constructor)

--- a/src/volrover3/SceneNode.cpp
+++ b/src/volrover3/SceneNode.cpp
@@ -54,8 +54,8 @@ void SceneNode::runOnMainThread(std::function<void()> func) {
   func();
 }
 
-SceneNode::SceneNode(const std::string &statePath)
-    : state_object<SceneNode>(statePath), m_visible(true), m_renderer(nullptr),
+SceneNode::SceneNode(cvc::app &ctx, const std::string &statePath)
+    : state_object<SceneNode>(ctx, statePath), m_visible(true), m_renderer(nullptr),
       m_sceneGraph(nullptr) {
   // Disable threading for this instance during construction
   // Will be enabled when SceneGraph reference is set

--- a/src/volrover3/VTKRenderWidget.cpp
+++ b/src/volrover3/VTKRenderWidget.cpp
@@ -5,6 +5,7 @@
 #include <volrover3/CameraController.h>
 #include <volrover3/SceneGraph.h>
 #include <volrover3/VTKRenderWidget.h>
+#include <volrover3/volrover3_app.h>
 #include <vtkCamera.h>
 #include <vtkCornerAnnotation.h>
 #include <vtkGenericOpenGLRenderWindow.h>
@@ -16,7 +17,7 @@ VTKRenderWidget::VTKRenderWidget(QWidget *parent)
     : QVTK_WIDGET_BASE(parent),
       m_renderWindow(vtkSmartPointer<vtkGenericOpenGLRenderWindow>::New()),
       m_renderer(vtkSmartPointer<vtkRenderer>::New()),
-      m_cameraController(std::make_unique<CameraController>()),
+      m_cameraController(std::make_unique<CameraController>(volrover3::app())),
       m_fpsAnnotation(vtkSmartPointer<vtkCornerAnnotation>::New()), m_showFPS(false) {
   initializeVTK();
 

--- a/src/volrover3/VolumeNode.cpp
+++ b/src/volrover3/VolumeNode.cpp
@@ -19,8 +19,8 @@
 #include <vtkVolume.h>
 #include <vtkVolumeProperty.h>
 
-VolumeNode::VolumeNode(const std::string &statePath, const std::string &name)
-    : GraphicsNode(statePath, name), m_hasVolume(false),
+VolumeNode::VolumeNode(cvc::app &ctx, const std::string &statePath, const std::string &name)
+    : GraphicsNode(ctx, statePath, name), m_hasVolume(false),
       m_vtkVolume(vtkSmartPointer<vtkVolume>::New()),
       m_mapper(vtkSmartPointer<vtkSmartVolumeMapper>::New()),
       m_imageData(vtkSmartPointer<vtkImageData>::New()),

--- a/src/volrover3/tests/BoundingBoxSemanticsTest.cpp
+++ b/src/volrover3/tests/BoundingBoxSemanticsTest.cpp
@@ -1,3 +1,4 @@
+#include <cvc/app.h>
 #include <cvc/geometry.h>
 #include <cvc/state.h>
 #include <cvc/volume.h>
@@ -7,6 +8,7 @@
 
 class BoundingBoxSemanticsTest : public ::testing::Test {
 protected:
+  cvc::app ctx;
   void SetUp() override { m_statePrefix = "test_bbox_semantics_" + std::to_string(testCounter++); }
 
   // Helper to create geometry with specific bounds
@@ -31,7 +33,7 @@ int BoundingBoxSemanticsTest::testCounter = 0;
 
 // Test parent node's own bounding box
 TEST_F(BoundingBoxSemanticsTest, ParentOwnBoundingBox) {
-  auto parent = std::make_shared<GeometryNode>("parent");
+  auto parent = std::make_shared<GeometryNode>(ctx, "parent");
   auto geom = createGeometry(0, 0, 0, 10, 10, 10);
   parent->setGeometry(geom);
 
@@ -47,7 +49,7 @@ TEST_F(BoundingBoxSemanticsTest, ParentOwnBoundingBox) {
 
 // Test combined bounding box with no children equals own bounding box
 TEST_F(BoundingBoxSemanticsTest, CombinedBBoxNoChildren) {
-  auto parent = std::make_shared<GeometryNode>("parent");
+  auto parent = std::make_shared<GeometryNode>(ctx, "parent");
   auto geom = createGeometry(5, 5, 5, 15, 15, 15);
   parent->setGeometry(geom);
 
@@ -65,11 +67,11 @@ TEST_F(BoundingBoxSemanticsTest, CombinedBBoxNoChildren) {
 
 // Test combined bounding box includes child
 TEST_F(BoundingBoxSemanticsTest, CombinedBBoxIncludesChild) {
-  auto parent = std::make_shared<GeometryNode>("parent");
+  auto parent = std::make_shared<GeometryNode>(ctx, "parent");
   auto parentGeom = createGeometry(0, 0, 0, 10, 10, 10);
   parent->setGeometry(parentGeom);
 
-  auto child = std::make_shared<GeometryNode>("child");
+  auto child = std::make_shared<GeometryNode>(ctx, "child");
   auto childGeom = createGeometry(15, 15, 15, 25, 25, 25);
   child->setGeometry(childGeom);
 
@@ -92,16 +94,16 @@ TEST_F(BoundingBoxSemanticsTest, CombinedBBoxIncludesChild) {
 
 // Test combined bounding box with multiple children
 TEST_F(BoundingBoxSemanticsTest, CombinedBBoxMultipleChildren) {
-  auto parent = std::make_shared<GeometryNode>("parent");
+  auto parent = std::make_shared<GeometryNode>(ctx, "parent");
   auto parentGeom = createGeometry(10, 10, 10, 20, 20, 20);
   parent->setGeometry(parentGeom);
 
-  auto child1 = std::make_shared<GeometryNode>("child1");
+  auto child1 = std::make_shared<GeometryNode>(ctx, "child1");
   auto child1Geom = createGeometry(0, 0, 0, 5, 5, 5);
   child1->setGeometry(child1Geom);
   parent->addGraphicsChild(child1);
 
-  auto child2 = std::make_shared<GeometryNode>("child2");
+  auto child2 = std::make_shared<GeometryNode>(ctx, "child2");
   auto child2Geom = createGeometry(30, 30, 30, 40, 40, 40);
   child2->setGeometry(child2Geom);
   parent->addGraphicsChild(child2);
@@ -123,16 +125,16 @@ TEST_F(BoundingBoxSemanticsTest, CombinedBBoxMultipleChildren) {
 
 // Test combined bounding box with nested children (grandchildren)
 TEST_F(BoundingBoxSemanticsTest, CombinedBBoxNestedChildren) {
-  auto grandparent = std::make_shared<GeometryNode>("grandparent");
+  auto grandparent = std::make_shared<GeometryNode>(ctx, "grandparent");
   auto grandparentGeom = createGeometry(50, 50, 50, 60, 60, 60);
   grandparent->setGeometry(grandparentGeom);
 
-  auto parent = std::make_shared<GeometryNode>("parent");
+  auto parent = std::make_shared<GeometryNode>(ctx, "parent");
   auto parentGeom = createGeometry(0, 0, 0, 10, 10, 10);
   parent->setGeometry(parentGeom);
   grandparent->addGraphicsChild(parent);
 
-  auto child = std::make_shared<GeometryNode>("child");
+  auto child = std::make_shared<GeometryNode>(ctx, "child");
   auto childGeom = createGeometry(100, 100, 100, 110, 110, 110);
   child->setGeometry(childGeom);
   parent->addGraphicsChild(child);
@@ -155,10 +157,10 @@ TEST_F(BoundingBoxSemanticsTest, CombinedBBoxNestedChildren) {
 
 // Test parent with no geometry but has children
 TEST_F(BoundingBoxSemanticsTest, ParentNoGeometryHasChildren) {
-  auto parent = std::make_shared<GeometryNode>("parent");
+  auto parent = std::make_shared<GeometryNode>(ctx, "parent");
   // No geometry set on parent
 
-  auto child = std::make_shared<GeometryNode>("child");
+  auto child = std::make_shared<GeometryNode>(ctx, "child");
   auto childGeom = createGeometry(10, 20, 30, 40, 50, 60);
   child->setGeometry(childGeom);
   parent->addGraphicsChild(child);
@@ -185,11 +187,11 @@ TEST_F(BoundingBoxSemanticsTest, ParentNoGeometryHasChildren) {
 
 // Test child removed updates combined bbox
 TEST_F(BoundingBoxSemanticsTest, ChildRemovedUpdatesCombinedBBox) {
-  auto parent = std::make_shared<GeometryNode>("parent");
+  auto parent = std::make_shared<GeometryNode>(ctx, "parent");
   auto parentGeom = createGeometry(10, 10, 10, 20, 20, 20);
   parent->setGeometry(parentGeom);
 
-  auto child = std::make_shared<GeometryNode>("child");
+  auto child = std::make_shared<GeometryNode>(ctx, "child");
   auto childGeom = createGeometry(50, 50, 50, 100, 100, 100);
   child->setGeometry(childGeom);
   parent->addGraphicsChild(child);
@@ -211,16 +213,16 @@ TEST_F(BoundingBoxSemanticsTest, ChildRemovedUpdatesCombinedBBox) {
 
 // Test non-overlapping children
 TEST_F(BoundingBoxSemanticsTest, NonOverlappingChildren) {
-  auto parent = std::make_shared<GeometryNode>("parent");
+  auto parent = std::make_shared<GeometryNode>(ctx, "parent");
   auto parentGeom = createGeometry(0, 0, 0, 1, 1, 1);
   parent->setGeometry(parentGeom);
 
-  auto child1 = std::make_shared<GeometryNode>("child1");
+  auto child1 = std::make_shared<GeometryNode>(ctx, "child1");
   auto child1Geom = createGeometry(-100, -100, -100, -90, -90, -90);
   child1->setGeometry(child1Geom);
   parent->addGraphicsChild(child1);
 
-  auto child2 = std::make_shared<GeometryNode>("child2");
+  auto child2 = std::make_shared<GeometryNode>(ctx, "child2");
   auto child2Geom = createGeometry(200, 200, 200, 210, 210, 210);
   child2->setGeometry(child2Geom);
   parent->addGraphicsChild(child2);
@@ -237,11 +239,11 @@ TEST_F(BoundingBoxSemanticsTest, NonOverlappingChildren) {
 
 // Test negative coordinates
 TEST_F(BoundingBoxSemanticsTest, NegativeCoordinates) {
-  auto parent = std::make_shared<GeometryNode>("parent");
+  auto parent = std::make_shared<GeometryNode>(ctx, "parent");
   auto parentGeom = createGeometry(-50, -60, -70, -10, -20, -30);
   parent->setGeometry(parentGeom);
 
-  auto child = std::make_shared<GeometryNode>("child");
+  auto child = std::make_shared<GeometryNode>(ctx, "child");
   auto childGeom = createGeometry(-200, -150, -100, -180, -130, -80);
   child->setGeometry(childGeom);
   parent->addGraphicsChild(child);
@@ -263,8 +265,8 @@ TEST_F(BoundingBoxSemanticsTest, NegativeCoordinates) {
 
 // Test empty parent with empty child
 TEST_F(BoundingBoxSemanticsTest, EmptyParentEmptyChild) {
-  auto parent = std::make_shared<GeometryNode>("parent");
-  auto child = std::make_shared<GeometryNode>("child");
+  auto parent = std::make_shared<GeometryNode>(ctx, "parent");
+  auto child = std::make_shared<GeometryNode>(ctx, "child");
   parent->addGraphicsChild(child);
 
   // Both should have default/empty bboxes
@@ -278,7 +280,7 @@ TEST_F(BoundingBoxSemanticsTest, EmptyParentEmptyChild) {
 
 // Test single point geometry
 TEST_F(BoundingBoxSemanticsTest, SinglePointGeometry) {
-  auto parent = std::make_shared<GeometryNode>("parent");
+  auto parent = std::make_shared<GeometryNode>(ctx, "parent");
   cvc::geometry geom;
   geom.points().resize(1);
   geom.points()[0][0] = 5.5;

--- a/src/volrover3/tests/CameraControllerTest.cpp
+++ b/src/volrover3/tests/CameraControllerTest.cpp
@@ -1,5 +1,6 @@
 #include <QApplication>
 #include <QKeyEvent>
+#include <cvc/app.h>
 #include <cvc/state.h>
 #include <gtest/gtest.h>
 #include <volrover3/AppState.h>
@@ -10,6 +11,7 @@
 
 class CameraControllerTest : public ::testing::Test {
 protected:
+  cvc::app ctx;
   static void SetUpTestSuite() {
     if (!QApplication::instance()) {
       int argc = 0;
@@ -27,7 +29,7 @@ protected:
     // Create unique state path for each test instance
     std::stringstream ss;
     ss << "volrover3.camera.test" << testCounter++;
-    controller = new CameraController(ss.str());
+    controller = new CameraController(ctx, ss.str());
     controller->setCamera(camera);
 
     // Get AppState singleton

--- a/src/volrover3/tests/GraphicsNodeTest.cpp
+++ b/src/volrover3/tests/GraphicsNodeTest.cpp
@@ -48,14 +48,14 @@ int GraphicsNodeTest::testCounter = 0;
 
 // Test basic GeometryNode creation (GraphicsNode is abstract)
 TEST_F(GraphicsNodeTest, Creation) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   EXPECT_EQ(node.getName(), "test_node");
   EXPECT_FALSE(node.hasGeometry());
 }
 
 // Test setting geometry
 TEST_F(GraphicsNodeTest, SetGeometry) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   node.setGeometry(testGeom);
 
   EXPECT_TRUE(node.hasGeometry());
@@ -66,7 +66,7 @@ TEST_F(GraphicsNodeTest, SetGeometry) {
 
 // Test geometry storage in node
 TEST_F(GraphicsNodeTest, GeometryRetrieval) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   node.setGeometry(testGeom);
 
   const cvc::geometry *geom = node.getGeometry();
@@ -81,7 +81,7 @@ TEST_F(GraphicsNodeTest, GeometryRetrieval) {
 
 // Test default transform is identity
 TEST_F(GraphicsNodeTest, DefaultTransformIsIdentity) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   vtkMatrix4x4 *transform = node.getTransform();
 
   ASSERT_NE(transform, nullptr);
@@ -100,7 +100,7 @@ TEST_F(GraphicsNodeTest, DefaultTransformIsIdentity) {
 
 // Test setting position
 TEST_F(GraphicsNodeTest, SetPosition) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   node.setPosition(1.0, 2.0, 3.0);
 
   vtkMatrix4x4 *transform = node.getTransform();
@@ -111,7 +111,7 @@ TEST_F(GraphicsNodeTest, SetPosition) {
 
 // Test setting scale
 TEST_F(GraphicsNodeTest, SetScale) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   node.setScale(2.0, 3.0, 4.0);
 
   vtkMatrix4x4 *transform = node.getTransform();
@@ -122,7 +122,7 @@ TEST_F(GraphicsNodeTest, SetScale) {
 
 // Test reset transform
 TEST_F(GraphicsNodeTest, ResetTransform) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   node.setPosition(1.0, 2.0, 3.0);
   node.resetTransform();
 
@@ -142,7 +142,7 @@ TEST_F(GraphicsNodeTest, ResetTransform) {
 
 // Test metadata storage and retrieval
 TEST_F(GraphicsNodeTest, MetadataStorage) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   node.setMetadata("test_string", std::string("hello"));
   node.setMetadata("test_int", 42);
@@ -164,14 +164,14 @@ TEST_F(GraphicsNodeTest, MetadataStorage) {
 
 // Test default visible metadata
 TEST_F(GraphicsNodeTest, DefaultVisibleMetadata) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   EXPECT_TRUE(node.isVisible());
 }
 
 // Test setVisible updates metadata
 TEST_F(GraphicsNodeTest, SetVisibleUpdatesMetadata) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   node.setVisible(false);
   EXPECT_FALSE(node.isVisible());
@@ -182,7 +182,7 @@ TEST_F(GraphicsNodeTest, SetVisibleUpdatesMetadata) {
 
 // Test type metadata for geometry
 TEST_F(GraphicsNodeTest, TypeMetadata) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   node.setMetadata("type", std::string("geometry"));
 
   EXPECT_TRUE(node.hasMetadata("type"));
@@ -191,9 +191,9 @@ TEST_F(GraphicsNodeTest, TypeMetadata) {
 
 // Test hierarchical structure - adding children
 TEST_F(GraphicsNodeTest, AddChild) {
-  auto parent = std::make_shared<GeometryNode>("test", "parent");
-  auto child1 = std::make_shared<GeometryNode>("test", "child1");
-  auto child2 = std::make_shared<GeometryNode>("test", "child2");
+  auto parent = std::make_shared<GeometryNode>(ctx, "test", "parent");
+  auto child1 = std::make_shared<GeometryNode>(ctx, "test", "child1");
+  auto child2 = std::make_shared<GeometryNode>(ctx, "test", "child2");
 
   parent->addGraphicsChild(child1);
   parent->addGraphicsChild(child2);
@@ -203,9 +203,9 @@ TEST_F(GraphicsNodeTest, AddChild) {
 
 // Test finding child by name
 TEST_F(GraphicsNodeTest, FindChildByName) {
-  auto parent = std::make_shared<GeometryNode>("test", "parent");
-  auto child1 = std::make_shared<GeometryNode>("test", "child1");
-  auto child2 = std::make_shared<GeometryNode>("test", "child2");
+  auto parent = std::make_shared<GeometryNode>(ctx, "test", "parent");
+  auto child1 = std::make_shared<GeometryNode>(ctx, "test", "child1");
+  auto child2 = std::make_shared<GeometryNode>(ctx, "test", "child2");
 
   parent->addGraphicsChild(child1);
   parent->addGraphicsChild(child2);
@@ -220,9 +220,9 @@ TEST_F(GraphicsNodeTest, FindChildByName) {
 
 // Test removing children
 TEST_F(GraphicsNodeTest, RemoveChild) {
-  auto parent = std::make_shared<GeometryNode>("test", "parent");
-  auto child1 = std::make_shared<GeometryNode>("test", "child1");
-  auto child2 = std::make_shared<GeometryNode>("test", "child2");
+  auto parent = std::make_shared<GeometryNode>(ctx, "test", "parent");
+  auto child1 = std::make_shared<GeometryNode>(ctx, "test", "child1");
+  auto child2 = std::make_shared<GeometryNode>(ctx, "test", "child2");
 
   parent->addGraphicsChild(child1);
   parent->addGraphicsChild(child2);
@@ -293,7 +293,7 @@ TEST_F(GraphicsNodeTest, SceneGraphGraphicsRoot) {
 TEST_F(GraphicsNodeTest, SceneGraphRegisterGraphics) {
   SceneGraph sceneGraph(m_statePrefix);
 
-  auto customNode = std::make_shared<GeometryNode>("test", "custom");
+  auto customNode = std::make_shared<GeometryNode>(ctx, "test", "custom");
   sceneGraph.registerGraphics("custom", customNode);
 
   auto retrieved = sceneGraph.getGraphics("custom");
@@ -338,8 +338,8 @@ TEST_F(GraphicsNodeTest, SceneGraphComputeBoundsEmpty) {
 
 // Test world transform calculation for nested nodes
 TEST_F(GraphicsNodeTest, WorldTransformHierarchy) {
-  auto parent = std::make_shared<GeometryNode>("test.parent", "parent");
-  auto child = std::make_shared<GeometryNode>("test.child", "child");
+  auto parent = std::make_shared<GeometryNode>(ctx, "test.parent", "parent");
+  auto child = std::make_shared<GeometryNode>(ctx, "test.child", "child");
 
   // Set parent position
   parent->setPosition(10.0, 0.0, 0.0);
@@ -359,7 +359,7 @@ TEST_F(GraphicsNodeTest, WorldTransformHierarchy) {
 
 // Test that metadata is computed from geometry
 TEST_F(GraphicsNodeTest, MetadataFromGeometry) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   node.setGeometry(testGeom);
 
   // Check that basic stats are computed
@@ -380,7 +380,7 @@ TEST_F(GraphicsNodeTest, MetadataFromGeometry) {
 
 // Test that bounding box metadata is computed
 TEST_F(GraphicsNodeTest, BoundingBoxMetadata) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   node.setGeometry(testGeom);
 
   // Check bounding box metadata exists
@@ -405,7 +405,7 @@ TEST_F(GraphicsNodeTest, BoundingBoxMetadata) {
 
 // Test that extent metadata is computed
 TEST_F(GraphicsNodeTest, ExtentMetadata) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   node.setGeometry(testGeom);
 
   // Check extent metadata exists
@@ -425,7 +425,7 @@ TEST_F(GraphicsNodeTest, ExtentMetadata) {
 
 // Test that center metadata is computed
 TEST_F(GraphicsNodeTest, CenterMetadata) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   node.setGeometry(testGeom);
 
   // Check center metadata exists
@@ -446,7 +446,7 @@ TEST_F(GraphicsNodeTest, CenterMetadata) {
 TEST_F(GraphicsNodeTest, GeometryTypeDetection) {
   // Test triangle mesh
   {
-    GeometryNode node("test", "tri_mesh");
+    GeometryNode node(ctx, "test", "tri_mesh");
     cvc::geometry triGeom;
     triGeom.points().push_back({0.0, 0.0, 0.0});
     triGeom.points().push_back({1.0, 0.0, 0.0});
@@ -460,7 +460,7 @@ TEST_F(GraphicsNodeTest, GeometryTypeDetection) {
 
   // Test quad mesh
   {
-    GeometryNode node("test", "quad_mesh");
+    GeometryNode node(ctx, "test", "quad_mesh");
     cvc::geometry quadGeom;
     quadGeom.points().push_back({0.0, 0.0, 0.0});
     quadGeom.points().push_back({1.0, 0.0, 0.0});
@@ -475,7 +475,7 @@ TEST_F(GraphicsNodeTest, GeometryTypeDetection) {
 
   // Test mixed mesh
   {
-    GeometryNode node("test", "mixed_mesh");
+    GeometryNode node(ctx, "test", "mixed_mesh");
     cvc::geometry mixedGeom;
     mixedGeom.points().push_back({0.0, 0.0, 0.0});
     mixedGeom.points().push_back({1.0, 0.0, 0.0});
@@ -492,7 +492,7 @@ TEST_F(GraphicsNodeTest, GeometryTypeDetection) {
 
 // Test metadata updates when geometry changes
 TEST_F(GraphicsNodeTest, MetadataUpdatesOnGeometryChange) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   // Set initial geometry
   node.setGeometry(testGeom);
@@ -519,7 +519,7 @@ TEST_F(GraphicsNodeTest, MetadataUpdatesOnGeometryChange) {
 
 // Test that empty geometry produces zero metadata
 TEST_F(GraphicsNodeTest, EmptyGeometryMetadata) {
-  GeometryNode node("test", "empty_node");
+  GeometryNode node(ctx, "test", "empty_node");
 
   cvc::geometry emptyGeom;
   node.setGeometry(emptyGeom);
@@ -537,7 +537,7 @@ TEST_F(GraphicsNodeTest, EmptyGeometryMetadata) {
 
 // Test geometry with normals and colors preserves metadata
 TEST_F(GraphicsNodeTest, GeometryWithNormalsAndColors) {
-  GeometryNode node("test", "colored_node");
+  GeometryNode node(ctx, "test", "colored_node");
 
   cvc::geometry coloredGeom;
   coloredGeom.points().push_back({0.0, 0.0, 0.0});
@@ -566,7 +566,7 @@ TEST_F(GraphicsNodeTest, GeometryWithNormalsAndColors) {
 // ============================================================================
 
 TEST_F(GraphicsNodeTest, LabelDefaultState) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   // Label should be off by default
   EXPECT_FALSE(node.getShowLabel());
@@ -583,7 +583,7 @@ TEST_F(GraphicsNodeTest, LabelDefaultState) {
 }
 
 TEST_F(GraphicsNodeTest, SetLabelText) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   node.setLabelText("Custom Label");
   EXPECT_EQ(node.getLabelText(), "Custom Label");
@@ -593,7 +593,7 @@ TEST_F(GraphicsNodeTest, SetLabelText) {
 }
 
 TEST_F(GraphicsNodeTest, SetLabelSize) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   node.setLabelSize(20);
   EXPECT_EQ(node.getLabelSize(), 20);
@@ -607,7 +607,7 @@ TEST_F(GraphicsNodeTest, SetLabelSize) {
 }
 
 TEST_F(GraphicsNodeTest, SetLabelColor) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   node.setLabelColor(0.5, 0.75, 1.0);
 
@@ -619,7 +619,7 @@ TEST_F(GraphicsNodeTest, SetLabelColor) {
 }
 
 TEST_F(GraphicsNodeTest, SetShowLabel) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   EXPECT_FALSE(node.getShowLabel());
 
@@ -634,14 +634,14 @@ TEST_F(GraphicsNodeTest, SetShowLabel) {
 // ============================================================================
 
 TEST_F(GraphicsNodeTest, BBoxDefaultState) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   // BBox should be off by default for regular nodes
   EXPECT_FALSE(node.getShowBBox());
 }
 
 TEST_F(GraphicsNodeTest, SetShowBBox) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   node.setShowBBox(true);
   EXPECT_TRUE(node.getShowBBox());
@@ -650,7 +650,7 @@ TEST_F(GraphicsNodeTest, SetShowBBox) {
   EXPECT_FALSE(node.getShowBBox());
 }
 TEST_F(GraphicsNodeTest, BBoxColor) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
 
   // Set bbox color
   node.setBBoxColor(1.0, 0.0, 0.0);
@@ -664,7 +664,7 @@ TEST_F(GraphicsNodeTest, BBoxColor) {
 }
 
 TEST_F(GraphicsNodeTest, BBoxBounds) {
-  GeometryNode node("test", "test_node");
+  GeometryNode node(ctx, "test", "test_node");
   node.setGeometry(testGeom);
 
   cvc::bounding_box bbox = node.getBoundingBox();
@@ -851,7 +851,7 @@ TEST_F(GraphicsNodeTest, SceneGraphComputeBoundsHierarchical) {
   geom2.points().push_back({1.0, 1.0, 1.0});
 
   auto parent = sceneGraph.addGraphics("parent", geom1);
-  auto child = std::make_shared<GeometryNode>("test", "child");
+  auto child = std::make_shared<GeometryNode>(ctx, "test", "child");
   child->setGeometry(geom2);
 
   // Parent at [10,0,0]
@@ -1005,7 +1005,7 @@ TEST_F(GraphicsNodeTest, ChildrenClipped) {
   childGeom.points().push_back({15.0, 15.0, 15.0});
 
   auto parent = sceneGraph.addGraphics("cliptest.children", parentGeom);
-  auto child = std::make_shared<GeometryNode>("cliptest.children.child", "child");
+  auto child = std::make_shared<GeometryNode>(ctx, "cliptest.children.child", "child");
   child->setGeometry(childGeom);
   parent->addGraphicsChild(child);
 
@@ -1033,7 +1033,7 @@ TEST_F(GraphicsNodeTest, ClippingDisabled) {
   childGeom.points().push_back({5.0, 5.0, 5.0});
 
   auto parent = sceneGraph.addGraphics("cliptest.disabled", parentGeom);
-  auto child = std::make_shared<GeometryNode>("cliptest.disabled.child", "child");
+  auto child = std::make_shared<GeometryNode>(ctx, "cliptest.disabled.child", "child");
   child->setGeometry(childGeom);
   parent->addGraphicsChild(child);
 

--- a/src/volrover3/tests/GridNodeTest.cpp
+++ b/src/volrover3/tests/GridNodeTest.cpp
@@ -1,4 +1,5 @@
 #include <QApplication>
+#include <cvc/app.h>
 #include <cvc/bounding_box.h>
 #include <gtest/gtest.h>
 #include <volrover3/AppState.h>
@@ -10,6 +11,7 @@
 
 class GridNodeTest : public ::testing::Test {
 protected:
+  cvc::app ctx;
   static void SetUpTestSuite() {
     if (!QApplication::instance()) {
       int argc = 0;
@@ -21,7 +23,7 @@ protected:
   }
 
   void SetUp() override {
-    gridNode = new GridNode("test.grid", "grid");
+    gridNode = new GridNode(ctx, "test.grid", "grid");
     renderer = vtkRenderer::New();
     appState = &AppState::instance();
   }

--- a/src/volrover3/tests/NullGraphicNodeTest.cpp
+++ b/src/volrover3/tests/NullGraphicNodeTest.cpp
@@ -1,3 +1,4 @@
+#include <cvc/app.h>
 #include <cvc/geometry.h>
 #include <cvc/state.h>
 #include <cvc/state_object.h>
@@ -8,6 +9,7 @@
 
 class NullGraphicNodeTest : public ::testing::Test {
 protected:
+  cvc::app ctx;
   void SetUp() override {
     // Disable threading for state_object to avoid destruction race conditions
     cvc::state_object<SceneNode>::setUseThreading(false);
@@ -27,7 +29,7 @@ int NullGraphicNodeTest::testCounter = 0;
 
 // Test NullGraphicNode default construction
 TEST_F(NullGraphicNodeTest, DefaultConstruction) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test.null", "test_null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test.null", "test_null");
 
   ASSERT_NE(nullNode, nullptr);
   EXPECT_EQ(nullNode->getName(), "test_null");
@@ -44,7 +46,7 @@ TEST_F(NullGraphicNodeTest, DefaultConstruction) {
 
 // Test NullGraphicNode bounds can be modified
 TEST_F(NullGraphicNodeTest, SetBoundsArray) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test_null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test_null");
 
   cvc::bounding_box newBounds(-50, -25, -10, 50, 25, 10);
   nullNode->setBounds(newBounds);
@@ -60,7 +62,7 @@ TEST_F(NullGraphicNodeTest, SetBoundsArray) {
 
 // Test NullGraphicNode bounds can be set with individual values
 TEST_F(NullGraphicNodeTest, SetBoundsIndividual) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test_null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test_null");
 
   nullNode->setBounds(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
 
@@ -193,7 +195,7 @@ TEST_F(NullGraphicNodeTest, NullGraphicNotInGraphicsMap) {
 
 // Test large custom bounds
 TEST_F(NullGraphicNodeTest, LargeCustomBounds) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test_null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test_null");
 
   nullNode->setBounds(-1000.0, -2000.0, -3000.0, 1000.0, 2000.0, 3000.0);
 
@@ -208,7 +210,7 @@ TEST_F(NullGraphicNodeTest, LargeCustomBounds) {
 
 // Test asymmetric bounds
 TEST_F(NullGraphicNodeTest, AsymmetricBounds) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test_null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test_null");
 
   nullNode->setBounds(-500.0, 100.0, -200.0, 300.0, 1000.0, 500.0);
 
@@ -223,7 +225,7 @@ TEST_F(NullGraphicNodeTest, AsymmetricBounds) {
 
 // Test includeOwnBounds flag - default should be false
 TEST_F(NullGraphicNodeTest, IncludeOwnBoundsDefault) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test_null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test_null");
 
   // Default should be false (typical for root nodes)
   EXPECT_FALSE(nullNode->getIncludeOwnBounds());
@@ -231,7 +233,7 @@ TEST_F(NullGraphicNodeTest, IncludeOwnBoundsDefault) {
 
 // Test setting includeOwnBounds flag
 TEST_F(NullGraphicNodeTest, SetIncludeOwnBounds) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test_null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test_null");
 
   nullNode->setIncludeOwnBounds(true);
   EXPECT_TRUE(nullNode->getIncludeOwnBounds());
@@ -242,7 +244,7 @@ TEST_F(NullGraphicNodeTest, SetIncludeOwnBounds) {
 
 // Test includeOwnBounds state tree synchronization
 TEST_F(NullGraphicNodeTest, IncludeOwnBoundsStateSync) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test.null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test.null");
 
   // Set via method
   nullNode->setIncludeOwnBounds(true);
@@ -260,7 +262,7 @@ TEST_F(NullGraphicNodeTest, IncludeOwnBoundsStateSync) {
 
 // Test syncBoundsWithChildren flag - default should be true
 TEST_F(NullGraphicNodeTest, SyncBoundsWithChildrenDefault) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test_null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test_null");
 
   // Default should be true (auto-sync enabled)
   EXPECT_TRUE(nullNode->getSyncBoundsWithChildren());
@@ -268,7 +270,7 @@ TEST_F(NullGraphicNodeTest, SyncBoundsWithChildrenDefault) {
 
 // Test setting syncBoundsWithChildren flag
 TEST_F(NullGraphicNodeTest, SetSyncBoundsWithChildren) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test_null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test_null");
 
   nullNode->setSyncBoundsWithChildren(false);
   EXPECT_FALSE(nullNode->getSyncBoundsWithChildren());
@@ -279,7 +281,7 @@ TEST_F(NullGraphicNodeTest, SetSyncBoundsWithChildren) {
 
 // Test syncBoundsWithChildren state tree synchronization
 TEST_F(NullGraphicNodeTest, SyncBoundsWithChildrenStateSync) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test.null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test.null");
 
   // Set via method
   nullNode->setSyncBoundsWithChildren(false);
@@ -428,7 +430,7 @@ TEST_F(NullGraphicNodeTest, SyncBoundsToChildrenDisabled) {
 
 // Test bounds state tree synchronization
 TEST_F(NullGraphicNodeTest, BoundsStateTreeSync) {
-  auto nullNode = std::make_shared<NullGraphicNode>("test.null");
+  auto nullNode = std::make_shared<NullGraphicNode>(ctx, "test.null");
 
   // Set bounds via method
   nullNode->setBounds(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
@@ -535,7 +537,7 @@ TEST_F(NullGraphicNodeTest, NestedTransforms) {
   ASSERT_NE(rootNull, nullptr);
 
   // Create child null node
-  auto childNull = std::make_shared<NullGraphicNode>("test.child_null", "child");
+  auto childNull = std::make_shared<NullGraphicNode>(ctx, "test.child_null", "child");
   rootNull->addGraphicsChild(childNull);
 
   // Set transforms

--- a/src/volrover3/tests/TransferFunctionTest.cpp
+++ b/src/volrover3/tests/TransferFunctionTest.cpp
@@ -1,4 +1,5 @@
 #include <QApplication>
+#include <cvc/app.h>
 #include <cvc/state.h>
 #include <gtest/gtest.h>
 #include <volrover3/AppState.h>
@@ -8,6 +9,7 @@
 // Need QApplication for Qt widgets
 class TransferFunctionTest : public ::testing::Test {
 protected:
+  cvc::app ctx;
   static void SetUpTestSuite() {
     if (!QApplication::instance()) {
       int argc = 0;
@@ -189,7 +191,7 @@ TEST_F(TransferFunctionTest, NoFeedbackLoopOnStateUpdate) {
   // This test verifies that the counter mechanism prevents feedback loops
   // by checking that repeated setTransferFunction calls don't cause exponential growth
 
-  auto volume = std::make_shared<VolumeNode>("test_volume");
+  auto volume = std::make_shared<VolumeNode>(ctx, "test_volume");
 
   widget->setDataRange(0.0, 100.0);
   widget->applyPreset("Rainbow");
@@ -215,7 +217,7 @@ TEST_F(TransferFunctionTest, NoFeedbackLoopOnStateUpdate) {
 TEST_F(TransferFunctionTest, StateRoundTripPreservesData) {
   // Test that data survives round-trip through state tree without corruption
 
-  auto volume = std::make_shared<VolumeNode>("test_volume");
+  auto volume = std::make_shared<VolumeNode>(ctx, "test_volume");
 
   widget->setDataRange(0.0, 255.0);
   widget->applyPreset("Rainbow");
@@ -247,8 +249,8 @@ TEST_F(TransferFunctionTest, StateRoundTripPreservesData) {
 TEST_F(TransferFunctionTest, PerVolumeStateSeparation) {
   // Test that each volume has independent transfer function state
 
-  auto volume1 = std::make_shared<VolumeNode>("volume_1");
-  auto volume2 = std::make_shared<VolumeNode>("volume_2");
+  auto volume1 = std::make_shared<VolumeNode>(ctx, "volume_1");
+  auto volume2 = std::make_shared<VolumeNode>(ctx, "volume_2");
 
   // Set different transfer functions for each volume
   widget->setDataRange(0.0, 100.0);
@@ -275,7 +277,7 @@ TEST_F(TransferFunctionTest, PerVolumeStateSeparation) {
 TEST_F(TransferFunctionTest, DefaultTransferFunctionSet) {
   // Test that VolumeNode gets a default transfer function when created
 
-  auto volume = std::make_shared<VolumeNode>("test_volume");
+  auto volume = std::make_shared<VolumeNode>(ctx, "test_volume");
 
   // Set default TF
   volume->setDefaultTransferFunction();

--- a/src/volrover3/tests/VolumeNodeTest.cpp
+++ b/src/volrover3/tests/VolumeNodeTest.cpp
@@ -83,7 +83,7 @@ TEST_F(VolumeNodeTest, VolumeSpanCalculation) {
 }
 
 TEST_F(VolumeNodeTest, VolumeSpacingForVTK) {
-  VolumeNode node("test_volume");
+  VolumeNode node(ctx, "test_volume");
   node.setVolume(largeVolume);
 
   // The critical fix: spacing should be (Max - Min) / Dim, NOT Span() / Dim
@@ -130,7 +130,7 @@ TEST_F(VolumeNodeTest, VolumeSpacingNotSpanDivDim) {
 // ============================================================================
 
 TEST_F(VolumeNodeTest, VolumeDataRange) {
-  VolumeNode node("test_volume");
+  VolumeNode node(ctx, "test_volume");
   node.setVolume(testVolume);
 
   // Verify metadata contains correct data range
@@ -145,7 +145,7 @@ TEST_F(VolumeNodeTest, VolumeDataRange) {
 }
 
 TEST_F(VolumeNodeTest, LargeVolumeDataRange) {
-  VolumeNode node("large_volume");
+  VolumeNode node(ctx, "large_volume");
   node.setVolume(largeVolume);
 
   // Verify the actual data range from the problematic volume
@@ -164,7 +164,7 @@ TEST_F(VolumeNodeTest, LargeVolumeDataRange) {
 // ============================================================================
 
 TEST_F(VolumeNodeTest, VolumeLabelDefaultState) {
-  VolumeNode node("test.volume", "test_volume");
+  VolumeNode node(ctx, "test.volume", "test_volume");
 
   // Label should be off by default
   EXPECT_FALSE(node.getShowLabel());
@@ -179,7 +179,7 @@ TEST_F(VolumeNodeTest, VolumeLabelDefaultState) {
 // ============================================================================
 
 TEST_F(VolumeNodeTest, VolumeBBoxBounds) {
-  VolumeNode node("test_volume");
+  VolumeNode node(ctx, "test_volume");
   node.setVolume(testVolume);
 
   cvc::bounding_box bbox = node.getBoundingBox();
@@ -198,7 +198,7 @@ TEST_F(VolumeNodeTest, VolumeBBoxBounds) {
 // ============================================================================
 
 TEST_F(VolumeNodeTest, VolumeMetadataComplete) {
-  VolumeNode node("test_volume");
+  VolumeNode node(ctx, "test_volume");
   node.setVolume(testVolume);
 
   // Check all expected metadata fields exist
@@ -213,7 +213,7 @@ TEST_F(VolumeNodeTest, VolumeMetadataComplete) {
 }
 
 TEST_F(VolumeNodeTest, VolumeMetadataValues) {
-  VolumeNode node("test_volume");
+  VolumeNode node(ctx, "test_volume");
   node.setVolume(testVolume);
 
   // Verify dimension metadata
@@ -276,7 +276,7 @@ TEST_F(VolumeNodeTest, VolumeClipsGeometryChild) {
   childGeom.points().push_back({15.0, 15.0, 15.0});
 
   auto geomChild =
-      std::make_shared<GeometryNode>("volume_clip_test.vol_parent.geom_child", "child");
+      std::make_shared<GeometryNode>(ctx, "volume_clip_test.vol_parent.geom_child", "child");
   geomChild->setGeometry(childGeom);
   volumeParent->addGraphicsChild(geomChild);
 
@@ -304,7 +304,7 @@ TEST_F(VolumeNodeTest, GeometryClipsVolumeChild) {
 
   // Create a volume child
   auto volumeChild =
-      std::make_shared<VolumeNode>("volume_clip_test.geom_parent.vol_child", "volume");
+      std::make_shared<VolumeNode>(ctx, "volume_clip_test.geom_parent.vol_child", "volume");
   volumeChild->setVolume(testVolume);
   geomParent->addGraphicsChild(volumeChild);
 


### PR DESCRIPTION
Eliminates the singleton fallback used by `SceneNode` and its subclasses.

- `SceneNode`/`GraphicsNode`/`CameraController` and the 5 leaf node types (`AxisNode`, `GridNode`, `VolumeNode`, `GeometryNode`, `NullGraphicNode`) now require `cvc::app&` as their first ctor parameter and forward to `state_object<X>(ctx, statePath)` instead of the 1-arg form.
- `GraphicsNode::addGraphicsChild<T>` and `SceneNode::app()` expose the bound context so factories don't reach for the singleton.
- `SceneGraph` and `VTKRenderWidget` pass `volrover3::app()` at construction sites.
- 7 test fixtures updated: existing `cvc::app ctx;` reused or added; ~120 instantiation sites rewritten (`make_shared`, `new`, and stack decls).

Precursor to deleting `state_object<>`'s 1-arg default ctor (the last remaining user).

590/590 ctest passing locally.