### PR TITLE
state_object: delete legacy 1-arg default ctor that called app::instance()

### DIFF
--- a/inc/cvc/state_object.h
+++ b/inc/cvc/state_object.h
@@ -213,10 +213,6 @@ private:
 template <class This> // This should be the type of the inheriting class
 class state_object {
 public:
-  // Legacy constructor - uses app::instance() singleton
-  state_object(const std::string state_path = std::string())
-      : state_object(app::instance(), state_path) {}
-
   // Constructor with explicit app context
   state_object(app &ctx, const std::string state_path = std::string())
       : _ctx(ctx), _batchDepth(0), _initDepth(0), _hasInstanceThreading(false),


### PR DESCRIPTION
All callers now pass a `cvc::app&` explicitly:
- libcvc internal subclasses migrated in PR #25 (algorithm) and PR #27 (state_test fixtures).
- volrover3 `SceneNode` hierarchy migrated in PR #28.

This was the last user of the singleton inside the `state_object<>` template.

590/590 ctest passing locally.