### PR TITLE
state_object::getState: route through bound app context

### DIFF
--- a/inc/cvc/state_object.h
+++ b/inc/cvc/state_object.h
@@ -261,8 +261,11 @@ public:
   }
 
   // Shortcut for accessing the state corresponding to an instance of this
-  // class or it's children.
-  state &getState(const std::string &s = std::string()) const { return cvcstate(stateName(s)); }
+  // class or it's children. Uses this object's bound app context rather
+  // than the global cvcstate singleton.
+  state &getState(const std::string &s = std::string()) const {
+    return CVC_NAMESPACE::state::instance(_ctx)(stateName(s));
+  }
 
   // Begin batching state changes - handlers are queued instead of spawned
   void beginBatch() {

--- a/src/cvc/state.cpp
+++ b/src/cvc/state.cpp
@@ -544,7 +544,7 @@ void state::traverse(traversal_unary_func func, const std::string &re) {
   func(fullName());
   std::vector<std::string> ch = children(re);
   BOOST_FOREACH (std::string c, ch)
-    cvcstate(c).traverse(func, re);
+    instance(_ctx)(c).traverse(func, re);
   traverseExit();
 }
 

--- a/src/cvc/tests/state_test.cpp
+++ b/src/cvc/tests/state_test.cpp
@@ -2430,8 +2430,8 @@ TEST_F(StateObjectFixture, StateObjectExternalAccess) {
   // Get the state path
   std::string widthPath = config.stateName("width");
 
-  // Access via global state
-  cvcstate(widthPath).value(3840);
+  // Access via the same per-app state root the state_object is bound to
+  cvc::state::instance(ctx)(widthPath).value(3840);
 
   // Wait for handlers to complete
   config.waitForHandlers();

--- a/src/volrover3/tests/CameraControllerTest.cpp
+++ b/src/volrover3/tests/CameraControllerTest.cpp
@@ -254,7 +254,7 @@ TEST_F(CameraControllerTest, StateTreeCameraPosition) {
   controller->setCameraState(testPos, testDir, testUp, testFov);
 
   // Verify state tree contains the values using controller's state path
-  auto &stateTree = cvc::state::instance()(controller->stateName());
+  auto &stateTree = cvc::state::instance(ctx)(controller->stateName());
   EXPECT_NEAR(stateTree("position.x").value<double>(), 10.0, 0.01);
   EXPECT_NEAR(stateTree("position.y").value<double>(), 20.0, 0.01);
   EXPECT_NEAR(stateTree("position.z").value<double>(), 30.0, 0.01);
@@ -268,7 +268,7 @@ TEST_F(CameraControllerTest, StateTreeCameraUpdate) {
   controller->setKeyBindings(Qt::Key_W, Qt::Key_S, Qt::Key_A, Qt::Key_D, Qt::Key_E, Qt::Key_Q);
 
   // Get initial position from state tree using controller's state path
-  auto &stateTree = cvc::state::instance()(controller->stateName());
+  auto &stateTree = cvc::state::instance(ctx)(controller->stateName());
   double initialX = stateTree("position.x").value<double>();
   double initialY = stateTree("position.y").value<double>();
   double initialZ = stateTree("position.z").value<double>();
@@ -297,7 +297,7 @@ TEST_F(CameraControllerTest, CameraChangeCallback) {
   controller->setCameraState(testPos, testDir, testUp, testFov);
 
   // Verify state tree was updated
-  auto &stateTree = cvc::state::instance()(controller->stateName());
+  auto &stateTree = cvc::state::instance(ctx)(controller->stateName());
   EXPECT_NEAR(stateTree("position.x").value<double>(), 5.0, 0.01);
   EXPECT_NEAR(stateTree("fov").value<double>(), 45.0, 0.01);
 }
@@ -322,7 +322,7 @@ TEST_F(CameraControllerTest, CameraStateSymmetry) {
   EXPECT_NEAR(setFov, getFov, 0.01);
 
   // Also verify state tree has correct values
-  auto &stateTree = cvc::state::instance()(controller->stateName());
+  auto &stateTree = cvc::state::instance(ctx)(controller->stateName());
   EXPECT_NEAR(stateTree("position.x").value<double>(), 7.0, 0.01);
   EXPECT_NEAR(stateTree("position.y").value<double>(), 8.0, 0.01);
   EXPECT_NEAR(stateTree("position.z").value<double>(), 9.0, 0.01);


### PR DESCRIPTION
Builds on #30. `state_object::getState()` now resolves via `state::instance(_ctx)` instead of the global `cvcstate` macro, so each state_object reads/writes the state graph of the app it was constructed against.

Also migrates `state::traverse()` to use `state::instance(_ctx)`.

Two tests that crossed the boundary (read via global cvcstate while writing via the fixture's local `ctx`) updated to use the per-app root.

Local: 590/590.