### PR TITLE
state: add per-app on_startup(app&) overload

### DIFF
--- a/inc/cvc/state.h
+++ b/inc/cvc/state.h
@@ -151,7 +151,9 @@ public:
   typedef std::map<std::string, state_ptr> child_map;
   typedef boost::function<void(std::string)> traversal_unary_func;
   typedef boost::function<void()> nullary_func;
+  typedef boost::function<void(app &)> app_init_func;
   typedef std::vector<nullary_func> init_func_vec;
+  typedef std::vector<app_init_func> app_init_func_vec;
 
   // Inline variable so every TU using this header gets its own
   // definition. Avoids needing per-symbol __declspec(dllexport) on
@@ -160,6 +162,7 @@ public:
   // have no DLL export and downstream test TUs would fail to link.
   inline static const std::string SEPARATOR{"."};
   static init_func_vec _startup;
+  static app_init_func_vec _appStartup;
 
   virtual ~state();
 
@@ -398,7 +401,14 @@ public:
   static bool isValidStateName(const std::string &name);
   static std::string sanitizeStateName(const std::string &name);
 
+  // Register a callback fired exactly once per process when the
+  // first state root is created (legacy global-singleton form).
   static void on_startup(const nullary_func &init_func);
+
+  // Register a callback fired once for every distinct app whose
+  // root state is lazily created. Prefer this form for per-app
+  // bootstrap logic so that secondary apps get the same defaults.
+  static void on_startup(const app_init_func &init_func);
 
 protected:
   state(app &ctx, const std::string &n = std::string(), const state *p = NULL);

--- a/src/cvc/state.cpp
+++ b/src/cvc/state.cpp
@@ -44,6 +44,7 @@ namespace CVC_NAMESPACE {
 // explicit __declspec(dllexport), since WINDOWS_EXPORT_ALL_SYMBOLS only
 // covers function symbols, not data members.
 state::init_func_vec state::_startup;
+state::app_init_func_vec state::_appStartup;
 state::state_ptr state::_instance;
 boost::mutex state::_instanceMutex;
 boost::mutex state::_startupMutex;
@@ -104,6 +105,7 @@ state::state_ptr state::instancePtr() { return instancePtr(app::instance()); }
 //                         app::instance().
 state::state_ptr state::instancePtr(app &ctx) {
   bool do_startup = false;
+  bool fire_app_startup = false;
   state_ptr ptr;
   {
     boost::mutex::scoped_lock lock(_instanceMutex);
@@ -116,6 +118,7 @@ state::state_ptr state::instancePtr(app &ctx) {
     if (!ptr) {
       ptr.reset(new state(ctx));
       ctx.data(statekey, ptr);
+      fire_app_startup = true;
       // Cache root of app::instance() for the legacy zero-arg path
       // so existing callers continue to share the same object.
       if (&ctx == &app::instance()) {
@@ -135,6 +138,19 @@ state::state_ptr state::instancePtr(app &ctx) {
   if (do_startup) {
     BOOST_FOREACH (nullary_func &init_func, _startup) {
       init_func();
+    }
+  }
+
+  if (fire_app_startup) {
+    // Snapshot the per-app init list under the startup mutex to be
+    // safe against concurrent on_startup() registrations.
+    app_init_func_vec snapshot;
+    {
+      boost::mutex::scoped_lock lock(_startupMutex);
+      snapshot = _appStartup;
+    }
+    BOOST_FOREACH (app_init_func &init_func, snapshot) {
+      init_func(ctx);
     }
   }
 
@@ -720,6 +736,8 @@ size_t state::numChildren() {
 // 01/12/2014 -- Joe R. -- Creation.
 void state::on_startup(const nullary_func &init_func) { _startup.push_back(init_func); }
 
+void state::on_startup(const app_init_func &init_func) { _appStartup.push_back(init_func); }
+
 // -------------------
 // state::notifyParent
 // -------------------
@@ -823,11 +841,12 @@ namespace {
 // 01/13/2014 -- Joe R. -- Creation.
 class system_init {
 public:
-  static void init() {
+  static void init(CVC_NAMESPACE::app &ctx) {
     using namespace boost::posix_time;
-    cvcstate("__system.start").value(to_simple_string(microsec_clock::universal_time()));
+    CVC_NAMESPACE::state::instance(ctx)("__system.start")
+        .value(to_simple_string(microsec_clock::universal_time()));
   }
 
-  system_init() { CVC_NAMESPACE::state::on_startup(init); }
+  system_init() { CVC_NAMESPACE::state::on_startup(CVC_NAMESPACE::state::app_init_func(init)); }
 } static_init;
 } // namespace

--- a/src/cvc/tests/state_test.cpp
+++ b/src/cvc/tests/state_test.cpp
@@ -1273,7 +1273,7 @@ TEST(StateTest, FullNameConstruction) {
 TEST(StateTest, OnStartupRegistration) {
   bool startup_called = false;
 
-  state::on_startup([&startup_called]() { startup_called = true; });
+  state::on_startup(state::nullary_func([&startup_called]() { startup_called = true; }));
 
   // Startup functions are called on first instance creation
   // We can't easily test this without restarting, but we can verify registration

--- a/src/cvc/xmlrpc_server.cpp
+++ b/src/cvc/xmlrpc_server.cpp
@@ -213,17 +213,15 @@ public:
   // sets a monitor function to observe the value of __system.xmlrpc.
   // If it is set to anything that evaluates to true, the xmlrpc server thread will be started.
   // If it is set to false, the running xmlrpc server will be terminated.
-  static void init() {
-    // The init callback is invoked from state::instancePtr's startup hook,
-    // which only runs in the context of app::instance(). Capture it once
-    // here and pass it explicitly through the monitor chain.
-    CVC_NAMESPACE::app &ctx = CVC_NAMESPACE::app::instance();
+  static void init(CVC_NAMESPACE::app &ctx) {
     CVC_NAMESPACE::state::instance(ctx)("__system.xmlrpc").valueChanged.connect([&ctx]() {
       monitor(ctx);
     });
     monitor(ctx);
   }
 
-  xmlrpc_server_thread_init() { CVC_NAMESPACE::state::on_startup(init); }
+  xmlrpc_server_thread_init() {
+    CVC_NAMESPACE::state::on_startup(CVC_NAMESPACE::state::app_init_func(init));
+  }
 } static_init;
 } // namespace


### PR DESCRIPTION
Adds `state::app_init_func` (`boost::function<void(app&)>`) and a matching `on_startup` overload that fires once per distinct app the first time its root state is created.

This enables per-app system bootstrap callbacks (system_init seeding `__system.start`, xmlrpc_server_thread_init wiring `__system.xmlrpc` on each app) without going through `app::instance()`.

system_init and xmlrpc_server_thread_init migrated to the new overload. The legacy nullary form is preserved for back-compat; one test that used a brace-initialized lambda was explicitly disambiguated to the nullary type.

Local: 590/590 with `-DCVC_USING_XMLRPC=ON` and OFF.