### PR TITLE
libcvc/volrover3: route remaining cvc::state::instance() callers through ctx

### DIFF
--- a/src/cvc/libcvc.cpp
+++ b/src/cvc/libcvc.cpp
@@ -153,9 +153,9 @@ void server(CVC_NAMESPACE::app &ctx, const std::vector<std::string> &args) {
   int port = XMLRPC_DEFAULT_PORT;
   if (!args.empty())
     port = lexical_cast<int>(args[0]);
-  cvcstate("__system.xmlrpc.port").value(port);
-  cvcstate("__system.xmlrpc").value(int(1)); // start the server
-  ctx.wait();                                // wait for the server thread to quit
+  cvc::state::instance(ctx)("__system.xmlrpc.port").value(port);
+  cvc::state::instance(ctx)("__system.xmlrpc").value(int(1)); // start the server
+  ctx.wait();                                                 // wait for the server thread to quit
 }
 
 void client(CVC_NAMESPACE::app &ctx, const std::vector<std::string> &args) {

--- a/src/volrover3/AppState.cpp
+++ b/src/volrover3/AppState.cpp
@@ -6,6 +6,7 @@
 #include <cvc/volume_file_io.h>
 #include <sstream>
 #include <volrover3/AppState.h>
+#include <volrover3/volrover3_app.h>
 
 AppState &AppState::instance() {
   static AppState instance; // Uses default parameter "volrover3"
@@ -68,10 +69,12 @@ void AppState::initializeDefaults() {
 }
 
 cvc::state &AppState::getState(const std::string &path) {
-  return cvc::state::instance()(m_statePrefix)(path);
+  return cvc::state::instance(volrover3::app())(m_statePrefix)(path);
 }
 
-cvc::state &AppState::getRootState() { return cvc::state::instance()(m_statePrefix); }
+cvc::state &AppState::getRootState() {
+  return cvc::state::instance(volrover3::app())(m_statePrefix);
+}
 
 cvc::bounding_box AppState::worldBounds() {
   std::string boundsStr = getState("world_bounds").value();

--- a/src/volrover3/MainWindow.cpp
+++ b/src/volrover3/MainWindow.cpp
@@ -728,7 +728,7 @@ void MainWindow::showStateTree() {
     m_stateTreeWidget->resize(600, 500);
 
     // Set root state to the global state singleton
-    m_stateTreeWidget->setRootState(&cvc::state::instance());
+    m_stateTreeWidget->setRootState(&cvc::state::instance(volrover3::app()));
 
     // Clean up pointer when window is closed
     connect(m_stateTreeWidget, &QObject::destroyed, [this]() { m_stateTreeWidget = nullptr; });

--- a/src/volrover3/SDFDialog.cpp
+++ b/src/volrover3/SDFDialog.cpp
@@ -44,10 +44,11 @@ SDFDialog::SDFDialog(std::shared_ptr<SceneGraph> sceneGraph, QWidget *parent)
     std::string graphicsRootPath = statePrefix + ".graphics.root.children";
 
     m_graphicsChildrenConnection =
-        cvc::state::instance()(graphicsRootPath).childChanged.connect([this](const std::string &) {
-          // Post to Qt event loop to ensure thread safety
-          QMetaObject::invokeMethod(this, "onGraphicsChildrenChanged", Qt::QueuedConnection);
-        });
+        cvc::state::instance(volrover3::app())(graphicsRootPath)
+            .childChanged.connect([this](const std::string &) {
+              // Post to Qt event loop to ensure thread safety
+              QMetaObject::invokeMethod(this, "onGraphicsChildrenChanged", Qt::QueuedConnection);
+            });
   }
 }
 

--- a/src/volrover3/StateTreeWidget.cpp
+++ b/src/volrover3/StateTreeWidget.cpp
@@ -684,7 +684,7 @@ void StateTreeWidget::onAddStateClicked() {
 
   try {
     // Access the state using the full path from the global state singleton
-    cvc::state &newState = cvc::state::instance()(path.toStdString());
+    cvc::state &newState = cvc::state::instance(volrover3::app())(path.toStdString());
     newState.value(value.toStdString());
 
     // Refresh the tree to show the new state

--- a/src/volrover3/TransferFunctionWidget.cpp
+++ b/src/volrover3/TransferFunctionWidget.cpp
@@ -337,10 +337,11 @@ void TransferFunctionWidget::setSceneGraph(SceneGraph *sceneGraph) {
     std::string graphicsRootPath = statePrefix + ".graphics.root.children";
 
     m_graphicsChildrenConnection =
-        cvc::state::instance()(graphicsRootPath).childChanged.connect([this](const std::string &) {
-          // Post to Qt event loop to ensure thread safety
-          QMetaObject::invokeMethod(this, "onGraphicsChildrenChanged", Qt::QueuedConnection);
-        });
+        cvc::state::instance(volrover3::app())(graphicsRootPath)
+            .childChanged.connect([this](const std::string &) {
+              // Post to Qt event loop to ensure thread safety
+              QMetaObject::invokeMethod(this, "onGraphicsChildrenChanged", Qt::QueuedConnection);
+            });
   }
 }
 
@@ -663,19 +664,21 @@ void TransferFunctionWidget::connectToVolumeState(std::shared_ptr<VolumeNode> vo
 
   // Use DirectConnection instead of QueuedConnection to ensure m_updatingFromState flag works
   // correctly
-  m_colorTFConnection = cvc::state::instance()(colorTFPath).valueChanged.connect([this]() {
-    // Only reload if we're not currently updating state from widget
-    if (m_updatingFromState == 0) {
-      onVolumeTransferFunctionChanged();
-    }
-  });
+  m_colorTFConnection =
+      cvc::state::instance(volrover3::app())(colorTFPath).valueChanged.connect([this]() {
+        // Only reload if we're not currently updating state from widget
+        if (m_updatingFromState == 0) {
+          onVolumeTransferFunctionChanged();
+        }
+      });
 
-  m_opacityTFConnection = cvc::state::instance()(opacityTFPath).valueChanged.connect([this]() {
-    // Only reload if we're not currently updating state from widget
-    if (m_updatingFromState == 0) {
-      onVolumeTransferFunctionChanged();
-    }
-  });
+  m_opacityTFConnection =
+      cvc::state::instance(volrover3::app())(opacityTFPath).valueChanged.connect([this]() {
+        // Only reload if we're not currently updating state from widget
+        if (m_updatingFromState == 0) {
+          onVolumeTransferFunctionChanged();
+        }
+      });
 }
 
 void TransferFunctionWidget::disconnectFromVolumeState() {

--- a/src/volrover3/tests/GeometryDialogTest.cpp
+++ b/src/volrover3/tests/GeometryDialogTest.cpp
@@ -9,6 +9,7 @@
 #include <volrover3/GeometryDialog.h>
 #include <volrover3/GeometryNode.h>
 #include <volrover3/SceneGraph.h>
+#include <volrover3/volrover3_app.h>
 
 class GeometryDialogTest : public ::testing::Test {
 protected:
@@ -313,7 +314,7 @@ TEST_F(GeometryDialogTest, SafeGeometryDeletion) {
   // State tree should still be accessible without crashes (even if nodes remain)
   std::string statePrefix = sceneGraph->getStatePrefix();
   EXPECT_NO_THROW({
-    auto &state = cvc::state::instance()(statePrefix + ".graphics.root.children");
+    auto &state = cvc::state::instance(volrover3::app())(statePrefix + ".graphics.root.children");
     // State tree nodes may persist, but accessing them shouldn't crash
     size_t childCount = state.numChildren();
     EXPECT_GE(childCount, 0); // Just verify we can read without crashing
@@ -337,7 +338,7 @@ TEST_F(GeometryDialogTest, MultipleAddRemoveCycles) {
   // State tree should still be valid
   std::string statePrefix = sceneGraph->getStatePrefix();
   EXPECT_NO_THROW({
-    auto &state = cvc::state::instance()(statePrefix + ".graphics.root");
+    auto &state = cvc::state::instance(volrover3::app())(statePrefix + ".graphics.root");
     EXPECT_TRUE(true); // Just verify no crash accessing state
   });
 }

--- a/src/volrover3/tests/SceneGraphTest.cpp
+++ b/src/volrover3/tests/SceneGraphTest.cpp
@@ -13,6 +13,7 @@
 #include <volrover3/GridNode.h>
 #include <volrover3/SceneGraph.h>
 #include <volrover3/VolumeNode.h>
+#include <volrover3/volrover3_app.h>
 
 class SceneGraphTest : public ::testing::Test {
 protected:
@@ -172,7 +173,7 @@ TEST_F(SceneGraphTest, WorldBoundsUpdate) {
   sceneGraph->updateGrid(bounds);
 
   // Verify state tree has the bounds
-  auto &stateTree = cvc::state::instance()("volrover3");
+  auto &stateTree = cvc::state::instance(volrover3::app())("volrover3");
   auto values = stateTree("world_bounds").values();
   ASSERT_EQ(values.size(), size_t(6));
 

--- a/src/volrover3/tests/StateTreeWidgetTest.cpp
+++ b/src/volrover3/tests/StateTreeWidgetTest.cpp
@@ -3,12 +3,13 @@
 #include <gtest/gtest.h>
 #include <volrover3/AppState.h>
 #include <volrover3/StateTreeWidget.h>
+#include <volrover3/volrover3_app.h>
 
 class StateTreeWidgetTest : public ::testing::Test {
 protected:
   void SetUp() override {
     // Create a temporary state tree for testing
-    testState = &cvc::state::instance()("test_widget");
+    testState = &cvc::state::instance(volrover3::app())("test_widget");
 
     // Create some test states
     testState->operator()("child1").value("value1");

--- a/src/volrover3/tests/TransferFunctionTest.cpp
+++ b/src/volrover3/tests/TransferFunctionTest.cpp
@@ -5,6 +5,7 @@
 #include <volrover3/AppState.h>
 #include <volrover3/TransferFunctionWidget.h>
 #include <volrover3/VolumeNode.h>
+#include <volrover3/volrover3_app.h>
 
 // Need QApplication for Qt widgets
 class TransferFunctionTest : public ::testing::Test {
@@ -316,7 +317,7 @@ TEST_F(TransferFunctionTest, TransferFunctionStateStorage) {
     appState->setTransferFunctionOpacityTable(opacityTable);
 
     // Verify state tree has the data
-    auto& stateTree = cvc::state::instance()("volrover3");
+    auto& stateTree = cvc::state::instance(volrover3::app())("volrover3");
     EXPECT_TRUE(stateTree("transfer_function_color").initialized());
     EXPECT_TRUE(stateTree("transfer_function_opacity").initialized());
 
@@ -337,7 +338,7 @@ TEST_F(TransferFunctionTest, TransferFunctionCallback) {
     });
 
     // Clear transfer_function_changed flag
-    auto& stateTree = cvc::state::instance()("volrover3");
+    auto& stateTree = cvc::state::instance(volrover3::app())("volrover3");
     stateTree("transfer_function_changed").value(false);
 
     // Change transfer function via AppState (simulating MainWindow)

--- a/src/volrover3/tests/VolumeDialogTest.cpp
+++ b/src/volrover3/tests/VolumeDialogTest.cpp
@@ -10,6 +10,7 @@
 #include <volrover3/SceneGraph.h>
 #include <volrover3/VolumeDialog.h>
 #include <volrover3/VolumeNode.h>
+#include <volrover3/volrover3_app.h>
 
 class VolumeDialogTest : public ::testing::Test {
 protected:
@@ -456,7 +457,7 @@ TEST_F(VolumeDialogTest, SafeVolumeDeletion) {
   // State tree should still be accessible without crashes (even if nodes remain)
   std::string statePrefix = sceneGraph->getStatePrefix();
   EXPECT_NO_THROW({
-    auto &state = cvc::state::instance()(statePrefix + ".graphics.root.children");
+    auto &state = cvc::state::instance(volrover3::app())(statePrefix + ".graphics.root.children");
     // State tree nodes may persist, but accessing them shouldn't crash
     size_t childCount = state.numChildren();
     EXPECT_GE(childCount, 0); // Just verify we can read without crashing
@@ -480,7 +481,7 @@ TEST_F(VolumeDialogTest, MultipleVolumeAddRemoveCycles) {
   // State tree should still be valid
   std::string statePrefix = sceneGraph->getStatePrefix();
   EXPECT_NO_THROW({
-    auto &state = cvc::state::instance()(statePrefix + ".graphics.root");
+    auto &state = cvc::state::instance(volrover3::app())(statePrefix + ".graphics.root");
     EXPECT_TRUE(true); // Just verify no crash accessing state
   });
 }
@@ -535,7 +536,7 @@ TEST_F(VolumeDialogTest, VolumeReplacementSafety) {
   // Verify state tree is still accessible (doesn't crash)
   std::string statePrefix = sceneGraph->getStatePrefix();
   EXPECT_NO_THROW({
-    auto &state = cvc::state::instance()(statePrefix + ".graphics.root.children");
+    auto &state = cvc::state::instance(volrover3::app())(statePrefix + ".graphics.root.children");
     size_t childCount = state.numChildren();
     EXPECT_GE(childCount, 0); // Just verify we can read without crashing
   });


### PR DESCRIPTION
Migrates the last production callers of zero-arg `cvc::state::instance()` onto the per-app overload added in #30.

* `src/cvc/libcvc.cpp` `server()` now writes `__system.xmlrpc[.port]` via `cvc::state::instance(ctx)` (the `app&` ctx is already in the signature).
* `volrover3` production code (AppState, TransferFunctionWidget, SDFDialog, MainWindow, StateTreeWidget) routes through `cvc::state::instance(volrover3::app())`.
* Dependent volrover3 tests (SceneGraphTest, StateTreeWidgetTest, GeometryDialogTest, VolumeDialogTest, TransferFunctionTest) updated to read from the same per-app root.

Local: 590/590 with `-DCVC_USING_XMLRPC=ON` and OFF.