### PR TITLE
state_test/state.h: route cvcstate through file-scope cvc::app; fix valueData<T> ctx

### DIFF
--- a/inc/cvc/state.h
+++ b/inc/cvc/state.h
@@ -359,8 +359,8 @@ public:
     vector<T> ret_data;
     BOOST_FOREACH (string dkey, vals) {
       trim(dkey);
-      if (CVC_NAMESPACE::state::instance()(dkey).isData<T>())
-        ret_data.push_back(CVC_NAMESPACE::state::instance()(dkey).data<T>());
+      if (CVC_NAMESPACE::state::instance(_ctx)(dkey).isData<T>())
+        ret_data.push_back(CVC_NAMESPACE::state::instance(_ctx)(dkey).data<T>());
     }
     return ret_data;
   }

--- a/src/cvc/tests/state_test.cpp
+++ b/src/cvc/tests/state_test.cpp
@@ -48,14 +48,22 @@ protected:
   cvc::app ctx;
 };
 
+// File-scope cvc::app used by the broad TEST(StateTest, ...) cases.
+// Replaces the deprecated `cvc::state::instance(test_ctx)` macro / `cvc::state::instance()`
+// global singleton. Routing all TEST(StateTest) cases through this
+// shared app preserves the existing "shared root" semantics those
+// tests were written against, while keeping the global cvc::app
+// singleton out of the picture.
+static cvc::app test_ctx;
+
 // ===========================
 // Basic Singleton Tests
 // ===========================
 
 TEST(StateTest, SingletonInstance) {
   // Test that instance() returns a valid reference
-  state &state1 = cvcstate;
-  state &state2 = cvcstate;
+  state &state1 = cvc::state::instance(test_ctx);
+  state &state2 = cvc::state::instance(test_ctx);
 
   // Both references should point to the same singleton
   EXPECT_EQ(&state1, &state2);
@@ -67,50 +75,50 @@ TEST(StateTest, SingletonInstance) {
 
 TEST(StateTest, ValueSetAndGet) {
   std::string test_value = "test_string_value";
-  cvcstate("test.value.simple").value(test_value);
+  cvc::state::instance(test_ctx)("test.value.simple").value(test_value);
 
-  EXPECT_EQ(cvcstate("test.value.simple").value(), test_value);
-  EXPECT_TRUE(cvcstate("test.value.simple").initialized());
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.value.simple").value(), test_value);
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.value.simple").initialized());
 
   // Clean up
-  cvcstate("test.value.simple").reset();
+  cvc::state::instance(test_ctx)("test.value.simple").reset();
 }
 
 TEST(StateTest, ValueTypeInt) {
   int test_value = 42;
-  cvcstate("test.value.int").value(test_value);
+  cvc::state::instance(test_ctx)("test.value.int").value(test_value);
 
-  EXPECT_EQ(cvcstate("test.value.int").value<int>(), test_value);
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.value.int").value<int>(), test_value);
 
   // Clean up
-  cvcstate("test.value.int").reset();
+  cvc::state::instance(test_ctx)("test.value.int").reset();
 }
 
 TEST(StateTest, ValueTypeDouble) {
   double test_value = 3.14159;
-  cvcstate("test.value.double").value(test_value);
+  cvc::state::instance(test_ctx)("test.value.double").value(test_value);
 
-  EXPECT_DOUBLE_EQ(cvcstate("test.value.double").value<double>(), test_value);
+  EXPECT_DOUBLE_EQ(cvc::state::instance(test_ctx)("test.value.double").value<double>(), test_value);
 
   // Clean up
-  cvcstate("test.value.double").reset();
+  cvc::state::instance(test_ctx)("test.value.double").reset();
 }
 
 TEST(StateTest, ValueTypeBool) {
   bool test_value = true;
-  cvcstate("test.value.bool").value(test_value);
+  cvc::state::instance(test_ctx)("test.value.bool").value(test_value);
 
-  EXPECT_EQ(cvcstate("test.value.bool").value<bool>(), test_value);
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.value.bool").value<bool>(), test_value);
 
   // Clean up
-  cvcstate("test.value.bool").reset();
+  cvc::state::instance(test_ctx)("test.value.bool").reset();
 }
 
 TEST(StateTest, ValueCommaList) {
   std::string list_value = "item1,item2,item3";
-  cvcstate("test.value.list").value(list_value);
+  cvc::state::instance(test_ctx)("test.value.list").value(list_value);
 
-  std::vector<std::string> values = cvcstate("test.value.list").values();
+  std::vector<std::string> values = cvc::state::instance(test_ctx)("test.value.list").values();
 
   ASSERT_EQ(values.size(), 3);
   EXPECT_EQ(values[0], "item1");
@@ -118,14 +126,15 @@ TEST(StateTest, ValueCommaList) {
   EXPECT_EQ(values[2], "item3");
 
   // Clean up
-  cvcstate("test.value.list").reset();
+  cvc::state::instance(test_ctx)("test.value.list").reset();
 }
 
 TEST(StateTest, ValueCommaListWithSpaces) {
   std::string list_value = "item1 , item2 , item3";
-  cvcstate("test.value.list.spaces").value(list_value);
+  cvc::state::instance(test_ctx)("test.value.list.spaces").value(list_value);
 
-  std::vector<std::string> values = cvcstate("test.value.list.spaces").values();
+  std::vector<std::string> values =
+      cvc::state::instance(test_ctx)("test.value.list.spaces").values();
 
   ASSERT_EQ(values.size(), 3);
   EXPECT_EQ(values[0], "item1");
@@ -133,32 +142,33 @@ TEST(StateTest, ValueCommaListWithSpaces) {
   EXPECT_EQ(values[2], "item3");
 
   // Clean up
-  cvcstate("test.value.list.spaces").reset();
+  cvc::state::instance(test_ctx)("test.value.list.spaces").reset();
 }
 
 TEST(StateTest, ValueListUnique) {
   std::string list_value = "item1,item2,item1,item3,item2";
-  cvcstate("test.value.list.unique").value(list_value);
+  cvc::state::instance(test_ctx)("test.value.list.unique").value(list_value);
 
-  std::vector<std::string> values = cvcstate("test.value.list.unique").values(true);
+  std::vector<std::string> values =
+      cvc::state::instance(test_ctx)("test.value.list.unique").values(true);
 
   // Should have only unique items
   EXPECT_EQ(values.size(), 3);
 
   // Clean up
-  cvcstate("test.value.list.unique").reset();
+  cvc::state::instance(test_ctx)("test.value.list.unique").reset();
 }
 
 TEST(StateTest, ValueConversion) {
   // Test conversion to std::string
   std::string test_value = "conversion_test";
-  cvcstate("test.value.conversion").value(test_value);
+  cvc::state::instance(test_ctx)("test.value.conversion").value(test_value);
 
-  std::string converted = cvcstate("test.value.conversion");
+  std::string converted = cvc::state::instance(test_ctx)("test.value.conversion");
   EXPECT_EQ(converted, test_value);
 
   // Clean up
-  cvcstate("test.value.conversion").reset();
+  cvc::state::instance(test_ctx)("test.value.conversion").reset();
 }
 
 // ===========================
@@ -167,35 +177,35 @@ TEST(StateTest, ValueConversion) {
 
 TEST(StateTest, DataSetAndGet) {
   std::string test_data = "test_data_string";
-  cvcstate("test.data.simple").data(test_data);
+  cvc::state::instance(test_ctx)("test.data.simple").data(test_data);
 
-  ASSERT_TRUE(cvcstate("test.data.simple").isData<std::string>());
-  EXPECT_EQ(cvcstate("test.data.simple").data<std::string>(), test_data);
+  ASSERT_TRUE(cvc::state::instance(test_ctx)("test.data.simple").isData<std::string>());
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.data.simple").data<std::string>(), test_data);
 
   // Clean up
-  cvcstate("test.data.simple").reset();
+  cvc::state::instance(test_ctx)("test.data.simple").reset();
 }
 
 TEST(StateTest, DataTypeInt) {
   int test_data = 123;
-  cvcstate("test.data.int").data(test_data);
+  cvc::state::instance(test_ctx)("test.data.int").data(test_data);
 
-  ASSERT_TRUE(cvcstate("test.data.int").isData<int>());
-  EXPECT_EQ(cvcstate("test.data.int").data<int>(), test_data);
+  ASSERT_TRUE(cvc::state::instance(test_ctx)("test.data.int").isData<int>());
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.data.int").data<int>(), test_data);
 
   // Clean up
-  cvcstate("test.data.int").reset();
+  cvc::state::instance(test_ctx)("test.data.int").reset();
 }
 
 TEST(StateTest, DataTypeDouble) {
   double test_data = 2.71828;
-  cvcstate("test.data.double").data(test_data);
+  cvc::state::instance(test_ctx)("test.data.double").data(test_data);
 
-  ASSERT_TRUE(cvcstate("test.data.double").isData<double>());
-  EXPECT_DOUBLE_EQ(cvcstate("test.data.double").data<double>(), test_data);
+  ASSERT_TRUE(cvc::state::instance(test_ctx)("test.data.double").isData<double>());
+  EXPECT_DOUBLE_EQ(cvc::state::instance(test_ctx)("test.data.double").data<double>(), test_data);
 
   // Clean up
-  cvcstate("test.data.double").reset();
+  cvc::state::instance(test_ctx)("test.data.double").reset();
 }
 
 // ===========================
@@ -204,75 +214,77 @@ TEST(StateTest, DataTypeDouble) {
 
 TEST(StateTest, ChildCreation) {
   // Create a child state
-  cvcstate("parent.child").value("child_value");
+  cvc::state::instance(test_ctx)("parent.child").value("child_value");
 
-  EXPECT_EQ(cvcstate("parent.child").value(), "child_value");
-  EXPECT_EQ(cvcstate("parent.child").name(), "child");
-  EXPECT_EQ(cvcstate("parent").name(), "parent");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("parent.child").value(), "child_value");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("parent.child").name(), "child");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("parent").name(), "parent");
 
   // Clean up
-  cvcstate("parent").reset();
+  cvc::state::instance(test_ctx)("parent").reset();
 }
 
 TEST(StateTest, FullName) {
-  cvcstate("level1.level2.level3").value("deep");
+  cvc::state::instance(test_ctx)("level1.level2.level3").value("deep");
 
-  EXPECT_EQ(cvcstate("level1.level2.level3").fullName(), "level1.level2.level3");
-  EXPECT_EQ(cvcstate("level1.level2.level3").name(), "level3");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("level1.level2.level3").fullName(),
+            "level1.level2.level3");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("level1.level2.level3").name(), "level3");
 
   // Clean up
-  cvcstate("level1").reset();
+  cvc::state::instance(test_ctx)("level1").reset();
 }
 
 TEST(StateTest, ParentName) {
-  cvcstate("parent.child.grandchild").value("test");
+  cvc::state::instance(test_ctx)("parent.child.grandchild").value("test");
 
-  std::string parent_name = cvcstate("parent.child.grandchild").parentName();
+  std::string parent_name = cvc::state::instance(test_ctx)("parent.child.grandchild").parentName();
   EXPECT_EQ(parent_name, "parent.child");
 
   // Clean up
-  cvcstate("parent").reset();
+  cvc::state::instance(test_ctx)("parent").reset();
 }
 
 TEST(StateTest, ChildrenListing) {
   // Create multiple children
-  cvcstate("test.children.child1").value("value1");
-  cvcstate("test.children.child2").value("value2");
-  cvcstate("test.children.child3").value("value3");
+  cvc::state::instance(test_ctx)("test.children.child1").value("value1");
+  cvc::state::instance(test_ctx)("test.children.child2").value("value2");
+  cvc::state::instance(test_ctx)("test.children.child3").value("value3");
 
-  std::vector<std::string> children = cvcstate("test.children").children();
+  std::vector<std::string> children = cvc::state::instance(test_ctx)("test.children").children();
 
   EXPECT_GE(children.size(), 3);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, NumChildren) {
   // Create children
-  cvcstate("test.count.child1").value("1");
-  cvcstate("test.count.child2").value("2");
+  cvc::state::instance(test_ctx)("test.count.child1").value("1");
+  cvc::state::instance(test_ctx)("test.count.child2").value("2");
 
-  size_t count = cvcstate("test.count").numChildren();
+  size_t count = cvc::state::instance(test_ctx)("test.count").numChildren();
   EXPECT_EQ(count, 2);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ChildrenWithRegex) {
   // Create children with different names
-  cvcstate("test.regex.foo1").value("1");
-  cvcstate("test.regex.foo2").value("2");
-  cvcstate("test.regex.bar1").value("3");
+  cvc::state::instance(test_ctx)("test.regex.foo1").value("1");
+  cvc::state::instance(test_ctx)("test.regex.foo2").value("2");
+  cvc::state::instance(test_ctx)("test.regex.bar1").value("3");
 
   // Search for children matching pattern
-  std::vector<std::string> foo_children = cvcstate("test.regex").children(".*foo.*");
+  std::vector<std::string> foo_children =
+      cvc::state::instance(test_ctx)("test.regex").children(".*foo.*");
 
   EXPECT_GE(foo_children.size(), 2);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -281,175 +293,184 @@ TEST(StateTest, ChildrenWithRegex) {
 
 TEST(StateTest, CommentSetAndGet) {
   std::string comment = "This is a test comment";
-  cvcstate("test.comment").comment(comment);
+  cvc::state::instance(test_ctx)("test.comment").comment(comment);
 
-  EXPECT_EQ(cvcstate("test.comment").comment(), comment);
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.comment").comment(), comment);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, HiddenFlag) {
-  cvcstate("test.hidden").hidden(true);
-  EXPECT_TRUE(cvcstate("test.hidden").hidden());
+  cvc::state::instance(test_ctx)("test.hidden").hidden(true);
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.hidden").hidden());
 
-  cvcstate("test.hidden").hidden(false);
-  EXPECT_FALSE(cvcstate("test.hidden").hidden());
+  cvc::state::instance(test_ctx)("test.hidden").hidden(false);
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.hidden").hidden());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ReadOnlyFlag) {
   // Test setting and getting read-only flag
-  cvcstate("test.readonly").readOnly(true);
-  EXPECT_TRUE(cvcstate("test.readonly").readOnly());
+  cvc::state::instance(test_ctx)("test.readonly").readOnly(true);
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.readonly").readOnly());
 
-  cvcstate("test.readonly").readOnly(false);
-  EXPECT_FALSE(cvcstate("test.readonly").readOnly());
+  cvc::state::instance(test_ctx)("test.readonly").readOnly(false);
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.readonly").readOnly());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ReadOnlyBlocksValueModification) {
   // Set initial value
-  cvcstate("test.readonly_value").value("initial");
-  EXPECT_EQ(cvcstate("test.readonly_value").value(), "initial");
+  cvc::state::instance(test_ctx)("test.readonly_value").value("initial");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.readonly_value").value(), "initial");
 
   // Mark as read-only
-  cvcstate("test.readonly_value").readOnly(true);
+  cvc::state::instance(test_ctx)("test.readonly_value").readOnly(true);
 
   // Attempt to modify should throw
-  EXPECT_THROW({ cvcstate("test.readonly_value").value("modified"); }, read_only_error);
+  EXPECT_THROW(
+      { cvc::state::instance(test_ctx)("test.readonly_value").value("modified"); },
+      read_only_error);
 
   // Value should remain unchanged
-  EXPECT_EQ(cvcstate("test.readonly_value").value(), "initial");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.readonly_value").value(), "initial");
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ReadOnlyBlocksDataModification) {
   // Set initial data
-  cvcstate("test.readonly_data").data(42);
-  EXPECT_EQ(cvcstate("test.readonly_data").data<int>(), 42);
+  cvc::state::instance(test_ctx)("test.readonly_data").data(42);
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.readonly_data").data<int>(), 42);
 
   // Mark as read-only
-  cvcstate("test.readonly_data").readOnly(true);
+  cvc::state::instance(test_ctx)("test.readonly_data").readOnly(true);
 
   // Attempt to modify should throw
-  EXPECT_THROW({ cvcstate("test.readonly_data").data(100); }, read_only_error);
+  EXPECT_THROW(
+      { cvc::state::instance(test_ctx)("test.readonly_data").data(100); }, read_only_error);
 
   // Data should remain unchanged
-  EXPECT_EQ(cvcstate("test.readonly_data").data<int>(), 42);
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.readonly_data").data<int>(), 42);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ReadOnlyAllowsReadOperations) {
   // Set value and mark read-only
-  cvcstate("test.readonly_read").value("readable");
-  cvcstate("test.readonly_read").readOnly(true);
+  cvc::state::instance(test_ctx)("test.readonly_read").value("readable");
+  cvc::state::instance(test_ctx)("test.readonly_read").readOnly(true);
 
   // Reading should still work
   EXPECT_NO_THROW({
-    std::string val = cvcstate("test.readonly_read").value();
+    std::string val = cvc::state::instance(test_ctx)("test.readonly_read").value();
     EXPECT_EQ(val, "readable");
   });
 
   // Getting read-only status should work
-  EXPECT_TRUE(cvcstate("test.readonly_read").readOnly());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.readonly_read").readOnly());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ReadOnlyCanBeUnset) {
   // Set value and mark read-only
-  cvcstate("test.readonly_unset").value("initial");
-  cvcstate("test.readonly_unset").readOnly(true);
+  cvc::state::instance(test_ctx)("test.readonly_unset").value("initial");
+  cvc::state::instance(test_ctx)("test.readonly_unset").readOnly(true);
 
   // Verify it's read-only
-  EXPECT_TRUE(cvcstate("test.readonly_unset").readOnly());
-  EXPECT_THROW({ cvcstate("test.readonly_unset").value("should_fail"); }, read_only_error);
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.readonly_unset").readOnly());
+  EXPECT_THROW(
+      { cvc::state::instance(test_ctx)("test.readonly_unset").value("should_fail"); },
+      read_only_error);
 
   // Unset read-only
-  cvcstate("test.readonly_unset").readOnly(false);
+  cvc::state::instance(test_ctx)("test.readonly_unset").readOnly(false);
 
   // Now modification should work
-  EXPECT_NO_THROW({ cvcstate("test.readonly_unset").value("modified"); });
-  EXPECT_EQ(cvcstate("test.readonly_unset").value(), "modified");
+  EXPECT_NO_THROW({ cvc::state::instance(test_ctx)("test.readonly_unset").value("modified"); });
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.readonly_unset").value(), "modified");
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ReadOnlySignalEmission) {
   bool signal_received = false;
 
   // Connect to readOnlyChanged signal
-  auto connection = cvcstate("test.readonly_signal").readOnlyChanged.connect([&signal_received]() {
-    signal_received = true;
-  });
+  auto connection = cvc::state::instance(test_ctx)("test.readonly_signal")
+                        .readOnlyChanged.connect([&signal_received]() { signal_received = true; });
 
   // Setting read-only should trigger signal
-  cvcstate("test.readonly_signal").readOnly(true);
+  cvc::state::instance(test_ctx)("test.readonly_signal").readOnly(true);
   EXPECT_TRUE(signal_received);
 
   // Reset flag and test again
   signal_received = false;
-  cvcstate("test.readonly_signal").readOnly(false);
+  cvc::state::instance(test_ctx)("test.readonly_signal").readOnly(false);
   EXPECT_TRUE(signal_received);
 
   // Setting to same value should not trigger signal
   signal_received = false;
-  cvcstate("test.readonly_signal").readOnly(false);
+  cvc::state::instance(test_ctx)("test.readonly_signal").readOnly(false);
   EXPECT_FALSE(signal_received);
 
   // Clean up
   connection.disconnect();
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ReadOnlyInitializesFlag) {
-  EXPECT_FALSE(cvcstate("test.init.readonly").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.init.readonly").initialized());
 
-  cvcstate("test.init.readonly").readOnly(true);
-  EXPECT_TRUE(cvcstate("test.init.readonly").initialized());
+  cvc::state::instance(test_ctx)("test.init.readonly").readOnly(true);
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.init.readonly").initialized());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ReadOnlyWithTemplateValue) {
   // Test with int
-  cvcstate("test.readonly_template_int").value<int>(42);
-  cvcstate("test.readonly_template_int").readOnly(true);
+  cvc::state::instance(test_ctx)("test.readonly_template_int").value<int>(42);
+  cvc::state::instance(test_ctx)("test.readonly_template_int").readOnly(true);
 
-  EXPECT_THROW({ cvcstate("test.readonly_template_int").value<int>(100); }, read_only_error);
+  EXPECT_THROW(
+      { cvc::state::instance(test_ctx)("test.readonly_template_int").value<int>(100); },
+      read_only_error);
 
-  EXPECT_EQ(cvcstate("test.readonly_template_int").value<int>(), 42);
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.readonly_template_int").value<int>(), 42);
 
   // Test with double
-  cvcstate("test.readonly_template_double").value<double>(3.14);
-  cvcstate("test.readonly_template_double").readOnly(true);
+  cvc::state::instance(test_ctx)("test.readonly_template_double").value<double>(3.14);
+  cvc::state::instance(test_ctx)("test.readonly_template_double").readOnly(true);
 
-  EXPECT_THROW({ cvcstate("test.readonly_template_double").value<double>(2.71); }, read_only_error);
+  EXPECT_THROW(
+      { cvc::state::instance(test_ctx)("test.readonly_template_double").value<double>(2.71); },
+      read_only_error);
 
-  EXPECT_DOUBLE_EQ(cvcstate("test.readonly_template_double").value<double>(), 3.14);
+  EXPECT_DOUBLE_EQ(cvc::state::instance(test_ctx)("test.readonly_template_double").value<double>(),
+                   3.14);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ReadOnlyExceptionMessage) {
-  cvcstate("test.readonly_exception").value("test");
-  cvcstate("test.readonly_exception").readOnly(true);
+  cvc::state::instance(test_ctx)("test.readonly_exception").value("test");
+  cvc::state::instance(test_ctx)("test.readonly_exception").readOnly(true);
 
   try {
-    cvcstate("test.readonly_exception").value("modified");
+    cvc::state::instance(test_ctx)("test.readonly_exception").value("modified");
     FAIL() << "Expected read_only_error to be thrown";
   } catch (const read_only_error &e) {
     // Verify exception contains useful information
@@ -462,35 +483,35 @@ TEST(StateTest, ReadOnlyExceptionMessage) {
   }
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, InitializedFlag) {
   // Before setting anything, should not be initialized
-  EXPECT_FALSE(cvcstate("test.uninitialized").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.uninitialized").initialized());
 
   // After setting a value, should be initialized
-  cvcstate("test.initialized").value("test");
-  EXPECT_TRUE(cvcstate("test.initialized").initialized());
+  cvc::state::instance(test_ctx)("test.initialized").value("test");
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.initialized").initialized());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, LastModification) {
   using namespace boost::posix_time;
 
   ptime before = microsec_clock::universal_time();
-  cvcstate("test.lastmod").value("test");
+  cvc::state::instance(test_ctx)("test.lastmod").value("test");
   ptime after = microsec_clock::universal_time();
 
-  ptime lastMod = cvcstate("test.lastmod").lastMod();
+  ptime lastMod = cvc::state::instance(test_ctx)("test.lastmod").lastMod();
 
   EXPECT_GE(lastMod, before);
   EXPECT_LE(lastMod, after);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -500,35 +521,35 @@ TEST(StateTest, LastModification) {
 TEST(StateTest, Touch) {
   using namespace boost::posix_time;
 
-  cvcstate("test.touch").value("initial");
-  ptime first_mod = cvcstate("test.touch").lastMod();
+  cvc::state::instance(test_ctx)("test.touch").value("initial");
+  ptime first_mod = cvc::state::instance(test_ctx)("test.touch").lastMod();
 
   // Sleep briefly to ensure time difference
   boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
 
-  cvcstate("test.touch").touch();
-  ptime second_mod = cvcstate("test.touch").lastMod();
+  cvc::state::instance(test_ctx)("test.touch").touch();
+  ptime second_mod = cvc::state::instance(test_ctx)("test.touch").lastMod();
 
   EXPECT_GT(second_mod, first_mod);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, Reset) {
-  cvcstate("test.reset").value("value");
-  cvcstate("test.reset").data(123);
-  cvcstate("test.reset").comment("comment");
-  cvcstate("test.reset").hidden(true);
+  cvc::state::instance(test_ctx)("test.reset").value("value");
+  cvc::state::instance(test_ctx)("test.reset").data(123);
+  cvc::state::instance(test_ctx)("test.reset").comment("comment");
+  cvc::state::instance(test_ctx)("test.reset").hidden(true);
 
-  EXPECT_TRUE(cvcstate("test.reset").initialized());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset").initialized());
 
-  cvcstate("test.reset").reset();
+  cvc::state::instance(test_ctx)("test.reset").reset();
 
-  EXPECT_FALSE(cvcstate("test.reset").initialized());
-  EXPECT_TRUE(cvcstate("test.reset").value().empty());
-  EXPECT_TRUE(cvcstate("test.reset").comment().empty());
-  EXPECT_FALSE(cvcstate("test.reset").hidden());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset").initialized());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset").value().empty());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset").comment().empty());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset").hidden());
 }
 
 // ===========================
@@ -536,50 +557,50 @@ TEST(StateTest, Reset) {
 // ===========================
 
 TEST(StateTest, PropertyTreeConversion) {
-  cvcstate("test.ptree.item1").value("value1");
-  cvcstate("test.ptree.item2").value("value2");
-  cvcstate("test.ptree.nested.item3").value("value3");
+  cvc::state::instance(test_ctx)("test.ptree.item1").value("value1");
+  cvc::state::instance(test_ctx)("test.ptree.item2").value("value2");
+  cvc::state::instance(test_ctx)("test.ptree.nested.item3").value("value3");
 
-  boost::property_tree::ptree pt = cvcstate("test.ptree").ptree();
+  boost::property_tree::ptree pt = cvc::state::instance(test_ctx)("test.ptree").ptree();
 
   EXPECT_FALSE(pt.empty());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, PropertyTreeRoundTrip) {
-  cvcstate("test.roundtrip.a").value("alpha");
-  cvcstate("test.roundtrip.b").value("beta");
-  cvcstate("test.roundtrip.c").value("gamma");
+  cvc::state::instance(test_ctx)("test.roundtrip.a").value("alpha");
+  cvc::state::instance(test_ctx)("test.roundtrip.b").value("beta");
+  cvc::state::instance(test_ctx)("test.roundtrip.c").value("gamma");
 
-  boost::property_tree::ptree pt = cvcstate("test.roundtrip").ptree();
+  boost::property_tree::ptree pt = cvc::state::instance(test_ctx)("test.roundtrip").ptree();
 
   // Verify property tree contains the values
   EXPECT_FALSE(pt.empty());
 
   // Reset the state
-  cvcstate("test.roundtrip").reset();
+  cvc::state::instance(test_ctx)("test.roundtrip").reset();
 
   // Note: The ptree() method returns only the values, not a full tree structure
   // for restoration. This is a limitation of the current implementation.
   // For now, we verify that the property tree was created successfully.
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, JsonConversion) {
-  cvcstate("test.json.x").value("10");
-  cvcstate("test.json.y").value("20");
+  cvc::state::instance(test_ctx)("test.json.x").value("10");
+  cvc::state::instance(test_ctx)("test.json.y").value("20");
 
-  std::string json = cvcstate("test.json").json();
+  std::string json = cvc::state::instance(test_ctx)("test.json").json();
 
   EXPECT_FALSE(json.empty());
   EXPECT_TRUE(json.find("test.json.x") != std::string::npos || json.find("x") != std::string::npos);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -598,15 +619,15 @@ TEST_F(StateDataFixture, ValueData) {
   EXPECT_TRUE(ctx.isData<int>("test.vd.obj3"));
 
   // Create states that the valueData method will look for
-  cvcstate("test.vd.obj1").data(100);
-  cvcstate("test.vd.obj2").data(200);
-  cvcstate("test.vd.obj3").data(300);
+  cvc::state::instance(ctx)("test.vd.obj1").data(100);
+  cvc::state::instance(ctx)("test.vd.obj2").data(200);
+  cvc::state::instance(ctx)("test.vd.obj3").data(300);
 
   // Create a state that references these objects
-  cvcstate("test.valuedata.list").value("test.vd.obj1,test.vd.obj2,test.vd.obj3");
+  cvc::state::instance(ctx)("test.valuedata.list").value("test.vd.obj1,test.vd.obj2,test.vd.obj3");
 
   // Get the data objects (from state, not app)
-  std::vector<int> data = cvcstate("test.valuedata.list").valueData<int>();
+  std::vector<int> data = cvc::state::instance(ctx)("test.valuedata.list").valueData<int>();
 
   ASSERT_EQ(data.size(), 3);
   EXPECT_EQ(data[0], 100);
@@ -614,7 +635,7 @@ TEST_F(StateDataFixture, ValueData) {
   EXPECT_EQ(data[2], 300);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(ctx)("test").reset();
   ctx.data("test.vd.obj1", boost::any());
   ctx.data("test.vd.obj2", boost::any());
   ctx.data("test.vd.obj3", boost::any());
@@ -626,38 +647,38 @@ TEST_F(StateDataFixture, ValueData) {
 
 TEST(StateTest, Traverse) {
   // Create a tree structure
-  cvcstate("test.traverse.a").value("1");
-  cvcstate("test.traverse.b").value("2");
-  cvcstate("test.traverse.c.d").value("3");
+  cvc::state::instance(test_ctx)("test.traverse.a").value("1");
+  cvc::state::instance(test_ctx)("test.traverse.b").value("2");
+  cvc::state::instance(test_ctx)("test.traverse.c.d").value("3");
 
   // Count how many states are visited
   int visit_count = 0;
   state::traversal_unary_func counter = [&visit_count](std::string) { visit_count++; };
 
-  cvcstate("test.traverse").traverse(counter);
+  cvc::state::instance(test_ctx)("test.traverse").traverse(counter);
 
   EXPECT_GT(visit_count, 0);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, TraverseWithRegex) {
   // Create mixed structure
-  cvcstate("test.regex.match1").value("a");
-  cvcstate("test.regex.match2").value("b");
-  cvcstate("test.regex.other").value("c");
+  cvc::state::instance(test_ctx)("test.regex.match1").value("a");
+  cvc::state::instance(test_ctx)("test.regex.match2").value("b");
+  cvc::state::instance(test_ctx)("test.regex.other").value("c");
 
   std::vector<std::string> visited;
   state::traversal_unary_func collector = [&visited](std::string name) { visited.push_back(name); };
 
   // Traverse with regex filter
-  cvcstate("test.regex").traverse(collector, ".*match.*");
+  cvc::state::instance(test_ctx)("test.regex").traverse(collector, ".*match.*");
 
   EXPECT_GT(visited.size(), 0);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -666,28 +687,28 @@ TEST(StateTest, TraverseWithRegex) {
 
 TEST(StateTest, PropertyTreeRoundtrip) {
   // Set up a state tree
-  cvcstate("test.ptree2.value1").value("first");
-  cvcstate("test.ptree2.value2").value("second");
+  cvc::state::instance(test_ctx)("test.ptree2.value1").value("first");
+  cvc::state::instance(test_ctx)("test.ptree2.value2").value("second");
 
   // Convert to property tree
-  boost::property_tree::ptree pt = cvcstate("test.ptree2").ptree();
+  boost::property_tree::ptree pt = cvc::state::instance(test_ctx)("test.ptree2").ptree();
   EXPECT_FALSE(pt.empty());
 
   // Property tree can be created
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, PropertyTreeImplicitConversion) {
-  cvcstate("test.pt.a").value("alpha");
-  cvcstate("test.pt.b").value("beta");
+  cvc::state::instance(test_ctx)("test.pt.a").value("alpha");
+  cvc::state::instance(test_ctx)("test.pt.b").value("beta");
 
   // Test implicit conversion operator
-  boost::property_tree::ptree pt = cvcstate("test.pt");
+  boost::property_tree::ptree pt = cvc::state::instance(test_ctx)("test.pt");
   EXPECT_FALSE(pt.empty());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -696,16 +717,16 @@ TEST(StateTest, PropertyTreeImplicitConversion) {
 
 TEST(StateTest, JSONRoundtrip) {
   // Set up state
-  cvcstate("test.json2.field1").value("json_value1");
-  cvcstate("test.json2.field2").value("json_value2");
+  cvc::state::instance(test_ctx)("test.json2.field1").value("json_value1");
+  cvc::state::instance(test_ctx)("test.json2.field2").value("json_value2");
 
   // Convert to JSON
-  std::string json_str = cvcstate("test.json2").json();
+  std::string json_str = cvc::state::instance(test_ctx)("test.json2").json();
   EXPECT_FALSE(json_str.empty());
 
   // JSON conversion works
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -717,11 +738,11 @@ TEST(StateTest, SaveAndRestore) {
       (std::filesystem::temp_directory_path() / "test_state_save.json").string();
 
   // Create state
-  cvcstate("test.file2.x").value("saved_x");
-  cvcstate("test.file2.y").value("saved_y");
+  cvc::state::instance(test_ctx)("test.file2.x").value("saved_x");
+  cvc::state::instance(test_ctx)("test.file2.y").value("saved_y");
 
   // Save to file
-  cvcstate("test.file2").save(temp_file);
+  cvc::state::instance(test_ctx)("test.file2").save(temp_file);
 
   // File should be created
   std::ifstream check(temp_file);
@@ -729,7 +750,7 @@ TEST(StateTest, SaveAndRestore) {
   check.close();
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
   std::remove(temp_file.c_str());
 }
 
@@ -740,34 +761,34 @@ TEST(StateTest, SaveAndRestore) {
 TEST(StateTest, LastModTracking) {
   boost::posix_time::ptime before = boost::posix_time::microsec_clock::universal_time();
 
-  cvcstate("test.lastmod").value("trigger_mod");
+  cvc::state::instance(test_ctx)("test.lastmod").value("trigger_mod");
 
   boost::posix_time::ptime after = boost::posix_time::microsec_clock::universal_time();
-  boost::posix_time::ptime mod_time = cvcstate("test.lastmod").lastMod();
+  boost::posix_time::ptime mod_time = cvc::state::instance(test_ctx)("test.lastmod").lastMod();
 
   EXPECT_GE(mod_time, before);
   EXPECT_LE(mod_time, after);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, TouchTriggersSignals) {
-  cvcstate("test.touch").value("initial");
+  cvc::state::instance(test_ctx)("test.touch").value("initial");
 
   // Touch should update lastMod even without value change
-  boost::posix_time::ptime before = cvcstate("test.touch").lastMod();
+  boost::posix_time::ptime before = cvc::state::instance(test_ctx)("test.touch").lastMod();
 
   // Small delay to ensure time difference
   boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
 
-  cvcstate("test.touch").touch();
+  cvc::state::instance(test_ctx)("test.touch").touch();
 
-  boost::posix_time::ptime after = cvcstate("test.touch").lastMod();
+  boost::posix_time::ptime after = cvc::state::instance(test_ctx)("test.touch").lastMod();
   EXPECT_GT(after, before);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -775,55 +796,55 @@ TEST(StateTest, TouchTriggersSignals) {
 // ===========================
 
 TEST(StateTest, ParentChildRelationship) {
-  cvcstate("test.parent.child").value("child_value");
+  cvc::state::instance(test_ctx)("test.parent.child").value("child_value");
 
-  EXPECT_EQ(cvcstate("test.parent.child").name(), "child");
-  EXPECT_EQ(cvcstate("test.parent.child").parentName(), "test.parent");
-  EXPECT_EQ(cvcstate("test.parent.child").fullName(), "test.parent.child");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.parent.child").name(), "child");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.parent.child").parentName(), "test.parent");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.parent.child").fullName(), "test.parent.child");
 
-  const state *parent = cvcstate("test.parent.child").parent();
+  const state *parent = cvc::state::instance(test_ctx)("test.parent.child").parent();
   ASSERT_NE(parent, nullptr);
   EXPECT_EQ(parent->name(), "parent");
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ChildrenListingMultiple) {
-  cvcstate("test.children.a").value("1");
-  cvcstate("test.children.b").value("2");
-  cvcstate("test.children.c").value("3");
+  cvc::state::instance(test_ctx)("test.children.a").value("1");
+  cvc::state::instance(test_ctx)("test.children.b").value("2");
+  cvc::state::instance(test_ctx)("test.children.c").value("3");
 
-  std::vector<std::string> children = cvcstate("test.children").children();
+  std::vector<std::string> children = cvc::state::instance(test_ctx)("test.children").children();
 
   EXPECT_GE(children.size(), 3);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, NumChildrenCount) {
-  cvcstate("test.numch.x").value("1");
-  cvcstate("test.numch.y").value("2");
+  cvc::state::instance(test_ctx)("test.numch.x").value("1");
+  cvc::state::instance(test_ctx)("test.numch.y").value("2");
 
-  size_t num = cvcstate("test.numch").numChildren();
+  size_t num = cvc::state::instance(test_ctx)("test.numch").numChildren();
   EXPECT_GE(num, 2);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ChildrenFilterByRegex) {
-  cvcstate("test.chre.apple").value("1");
-  cvcstate("test.chre.apricot").value("2");
-  cvcstate("test.chre.banana").value("3");
+  cvc::state::instance(test_ctx)("test.chre.apple").value("1");
+  cvc::state::instance(test_ctx)("test.chre.apricot").value("2");
+  cvc::state::instance(test_ctx)("test.chre.banana").value("3");
 
   // Get all children first
-  std::vector<std::string> children = cvcstate("test.chre").children();
+  std::vector<std::string> children = cvc::state::instance(test_ctx)("test.chre").children();
   EXPECT_GE(children.size(), 3);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -831,18 +852,18 @@ TEST(StateTest, ChildrenFilterByRegex) {
 // ===========================
 
 TEST(StateTest, ValueTypeNameTracking) {
-  cvcstate("test.typename.int").value(42);
-  std::string type_name = cvcstate("test.typename.int").valueTypeName();
+  cvc::state::instance(test_ctx)("test.typename.int").value(42);
+  std::string type_name = cvc::state::instance(test_ctx)("test.typename.int").valueTypeName();
 
   EXPECT_FALSE(type_name.empty());
 
-  cvcstate("test.typename.string").value("text");
-  type_name = cvcstate("test.typename.string").valueTypeName();
+  cvc::state::instance(test_ctx)("test.typename.string").value("text");
+  type_name = cvc::state::instance(test_ctx)("test.typename.string").valueTypeName();
 
   EXPECT_FALSE(type_name.empty());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -851,13 +872,13 @@ TEST(StateTest, ValueTypeNameTracking) {
 
 TEST(StateTest, DataTypeNameRetrieval) {
   int test_data = 999;
-  cvcstate("test.datatypename").data(test_data);
+  cvc::state::instance(test_ctx)("test.datatypename").data(test_data);
 
-  std::string type_name = cvcstate("test.datatypename").dataTypeName();
+  std::string type_name = cvc::state::instance(test_ctx)("test.datatypename").dataTypeName();
   EXPECT_FALSE(type_name.empty());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -866,13 +887,13 @@ TEST(StateTest, DataTypeNameRetrieval) {
 
 TEST(StateTest, StringConversionOperator) {
   std::string test_val = "conversion_test";
-  cvcstate("test.conversion").value(test_val);
+  cvc::state::instance(test_ctx)("test.conversion").value(test_val);
 
-  std::string converted = cvcstate("test.conversion");
+  std::string converted = cvc::state::instance(test_ctx)("test.conversion");
   EXPECT_EQ(converted, test_val);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -881,14 +902,14 @@ TEST(StateTest, StringConversionOperator) {
 
 TEST(StateTest, OperationChaining) {
   // Test that value() returns reference for chaining
-  cvcstate("test.chain").value("step1").comment("Test comment").hidden(false);
+  cvc::state::instance(test_ctx)("test.chain").value("step1").comment("Test comment").hidden(false);
 
-  EXPECT_EQ(cvcstate("test.chain").value(), "step1");
-  EXPECT_EQ(cvcstate("test.chain").comment(), "Test comment");
-  EXPECT_FALSE(cvcstate("test.chain").hidden());
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.chain").value(), "step1");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.chain").comment(), "Test comment");
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.chain").hidden());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -897,54 +918,56 @@ TEST(StateTest, OperationChaining) {
 
 TEST(StateTest, EmptyValueHandling) {
   // Set a non-empty value first
-  cvcstate("test.empty").value("nonempty");
+  cvc::state::instance(test_ctx)("test.empty").value("nonempty");
   // Then set to empty
-  cvcstate("test.empty").value("");
-  EXPECT_TRUE(cvcstate("test.empty").value().empty());
+  cvc::state::instance(test_ctx)("test.empty").value("");
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.empty").value().empty());
   // Since we changed from non-empty to empty, initialized should be true
-  EXPECT_TRUE(cvcstate("test.empty").initialized());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.empty").initialized());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, NestedPathCreation) {
   // Deep nesting should create intermediate nodes
-  cvcstate("test.very.deep.nested.path.value").value("deep");
+  cvc::state::instance(test_ctx)("test.very.deep.nested.path.value").value("deep");
 
-  EXPECT_EQ(cvcstate("test.very.deep.nested.path.value").value(), "deep");
-  EXPECT_EQ(cvcstate("test.very.deep.nested.path.value").name(), "value");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.very.deep.nested.path.value").value(), "deep");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.very.deep.nested.path.value").name(), "value");
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, RepeatedValueSetting) {
   // Setting same value multiple times
-  cvcstate("test.repeated").value("same");
-  boost::posix_time::ptime first = cvcstate("test.repeated").lastMod();
+  cvc::state::instance(test_ctx)("test.repeated").value("same");
+  boost::posix_time::ptime first = cvc::state::instance(test_ctx)("test.repeated").lastMod();
 
   // Setting same value shouldn't update lastMod
-  cvcstate("test.repeated").value("same");
-  boost::posix_time::ptime second = cvcstate("test.repeated").lastMod();
+  cvc::state::instance(test_ctx)("test.repeated").value("same");
+  boost::posix_time::ptime second = cvc::state::instance(test_ctx)("test.repeated").lastMod();
 
   EXPECT_EQ(first, second);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ValuesUniqueFlag) {
-  cvcstate("test.values.unique").value("a,b,a,c,b,d");
+  cvc::state::instance(test_ctx)("test.values.unique").value("a,b,a,c,b,d");
 
-  std::vector<std::string> unique_vals = cvcstate("test.values.unique").values(true);
-  std::vector<std::string> all_vals = cvcstate("test.values.unique").values(false);
+  std::vector<std::string> unique_vals =
+      cvc::state::instance(test_ctx)("test.values.unique").values(true);
+  std::vector<std::string> all_vals =
+      cvc::state::instance(test_ctx)("test.values.unique").values(false);
 
   EXPECT_EQ(unique_vals.size(), 4); // a,b,c,d
   EXPECT_EQ(all_vals.size(), 6);    // a,b,a,c,b,d
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -954,48 +977,50 @@ TEST(StateTest, ValuesUniqueFlag) {
 TEST(StateTest, ValueChangedSignal) {
   bool signal_fired = false;
 
-  auto connection = cvcstate("test.signal.value").valueChanged.connect([&signal_fired]() {
-    signal_fired = true;
-  });
+  auto connection =
+      cvc::state::instance(test_ctx)("test.signal.value").valueChanged.connect([&signal_fired]() {
+        signal_fired = true;
+      });
 
-  cvcstate("test.signal.value").value("trigger");
+  cvc::state::instance(test_ctx)("test.signal.value").value("trigger");
 
   EXPECT_TRUE(signal_fired);
 
   connection.disconnect();
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, DataChangedSignal) {
   bool signal_fired = false;
 
   auto connection =
-      cvcstate("test.signal.data").dataChanged.connect([&signal_fired]() { signal_fired = true; });
+      cvc::state::instance(test_ctx)("test.signal.data").dataChanged.connect([&signal_fired]() {
+        signal_fired = true;
+      });
 
-  cvcstate("test.signal.data").data(42);
+  cvc::state::instance(test_ctx)("test.signal.data").data(42);
 
   EXPECT_TRUE(signal_fired);
 
   connection.disconnect();
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ChildChangedSignal) {
   int signal_count = 0;
 
   auto connection =
-      cvcstate("test.signal.parent").childChanged.connect([&signal_count](const std::string &) {
-        signal_count++;
-      });
+      cvc::state::instance(test_ctx)("test.signal.parent")
+          .childChanged.connect([&signal_count](const std::string &) { signal_count++; });
 
   // Create child state - should trigger parent's childChanged
-  cvcstate("test.signal.parent.child1").value("value1");
-  cvcstate("test.signal.parent.child2").value("value2");
+  cvc::state::instance(test_ctx)("test.signal.parent.child1").value("value1");
+  cvc::state::instance(test_ctx)("test.signal.parent.child2").value("value2");
 
   EXPECT_GT(signal_count, 0);
 
   connection.disconnect();
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ChildChangedSignalUsesRelativeName) {
@@ -1003,13 +1028,13 @@ TEST(StateTest, ChildChangedSignalUsesRelativeName) {
   // not full path (e.g., "test.parent.child")
   std::vector<std::string> received_names;
 
-  auto connection = cvcstate("test.parent")
+  auto connection = cvc::state::instance(test_ctx)("test.parent")
                         .childChanged.connect([&received_names](const std::string &childState) {
                           received_names.push_back(childState);
                         });
 
   // Modify child state - parent should receive just "child", not "test.parent.child"
-  cvcstate("test.parent.child").value("test_value");
+  cvc::state::instance(test_ctx)("test.parent.child").value("test_value");
 
   // Give signal time to fire
   boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
@@ -1022,7 +1047,7 @@ TEST(StateTest, ChildChangedSignalUsesRelativeName) {
       << "Expected relative name 'child', but got: '" << received_names[0] << "'";
 
   connection.disconnect();
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -1032,28 +1057,28 @@ TEST(StateTest, ChildChangedSignalUsesRelativeName) {
 TEST(StateTest, DeepHierarchyNavigation) {
   // Create deep nested structure
   std::string deep_path = "level1.level2.level3.level4.level5";
-  cvcstate(deep_path).value("deep_value");
+  cvc::state::instance(test_ctx)(deep_path).value("deep_value");
 
-  EXPECT_EQ(cvcstate(deep_path).value(), "deep_value");
-  EXPECT_EQ(cvcstate(deep_path).name(), "level5");
+  EXPECT_EQ(cvc::state::instance(test_ctx)(deep_path).value(), "deep_value");
+  EXPECT_EQ(cvc::state::instance(test_ctx)(deep_path).name(), "level5");
 
   // Test parent navigation
-  const state *level4 = cvcstate(deep_path).parent();
+  const state *level4 = cvc::state::instance(test_ctx)(deep_path).parent();
   ASSERT_NE(level4, nullptr);
   EXPECT_EQ(level4->name(), "level4");
 
   // Clean up
-  cvcstate("level1").reset();
+  cvc::state::instance(test_ctx)("level1").reset();
 }
 
 TEST(StateTest, OperatorChaining) {
   // Test deep path traversal using operator()
-  cvcstate("chain")("a")("b")("c").value("chained");
+  cvc::state::instance(test_ctx)("chain")("a")("b")("c").value("chained");
 
-  EXPECT_EQ(cvcstate("chain.a.b.c").value(), "chained");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("chain.a.b.c").value(), "chained");
 
   // Clean up
-  cvcstate("chain").reset();
+  cvc::state::instance(test_ctx)("chain").reset();
 }
 
 // ===========================
@@ -1062,23 +1087,23 @@ TEST(StateTest, OperatorChaining) {
 
 TEST(StateTest, EmptyKeyHandling) {
   // operator() with empty string should return self
-  state &self1 = cvcstate("test.empty.key");
-  state &self2 = cvcstate("test.empty.key")("");
+  state &self1 = cvc::state::instance(test_ctx)("test.empty.key");
+  state &self2 = cvc::state::instance(test_ctx)("test.empty.key")("");
 
   EXPECT_EQ(&self1, &self2);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, SeparatorInPath) {
   // Test paths with multiple separators
-  cvcstate("test...multi...sep").value("multi_sep_value");
+  cvc::state::instance(test_ctx)("test...multi...sep").value("multi_sep_value");
 
-  EXPECT_EQ(cvcstate("test.multi.sep").value(), "multi_sep_value");
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.multi.sep").value(), "multi_sep_value");
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -1086,46 +1111,46 @@ TEST(StateTest, SeparatorInPath) {
 // ===========================
 
 TEST(StateTest, InitializedFlagBehavior) {
-  EXPECT_FALSE(cvcstate("test.init.new").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.init.new").initialized());
 
-  cvcstate("test.init.new").value("now_initialized");
-  EXPECT_TRUE(cvcstate("test.init.new").initialized());
+  cvc::state::instance(test_ctx)("test.init.new").value("now_initialized");
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.init.new").initialized());
 
-  cvcstate("test.init.new").reset();
-  EXPECT_FALSE(cvcstate("test.init.new").initialized());
+  cvc::state::instance(test_ctx)("test.init.new").reset();
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.init.new").initialized());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, DataInitializesFlag) {
-  EXPECT_FALSE(cvcstate("test.init.data").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.init.data").initialized());
 
-  cvcstate("test.init.data").data(std::string("data_init"));
-  EXPECT_TRUE(cvcstate("test.init.data").initialized());
+  cvc::state::instance(test_ctx)("test.init.data").data(std::string("data_init"));
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.init.data").initialized());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, CommentInitializesFlag) {
-  EXPECT_FALSE(cvcstate("test.init.comment").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.init.comment").initialized());
 
-  cvcstate("test.init.comment").comment("test comment");
-  EXPECT_TRUE(cvcstate("test.init.comment").initialized());
+  cvc::state::instance(test_ctx)("test.init.comment").comment("test comment");
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.init.comment").initialized());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, HiddenInitializesFlag) {
-  EXPECT_FALSE(cvcstate("test.init.hidden").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.init.hidden").initialized());
 
-  cvcstate("test.init.hidden").hidden(true);
-  EXPECT_TRUE(cvcstate("test.init.hidden").initialized());
+  cvc::state::instance(test_ctx)("test.init.hidden").hidden(true);
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.init.hidden").initialized());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -1134,19 +1159,20 @@ TEST(StateTest, HiddenInitializesFlag) {
 
 TEST(StateTest, ChildrenRecursiveListing) {
   // Create nested structure
-  cvcstate("test.recursive.a.a1").value("1");
-  cvcstate("test.recursive.a.a2").value("2");
-  cvcstate("test.recursive.b.b1").value("3");
-  cvcstate("test.recursive.b.b2.deep").value("4");
+  cvc::state::instance(test_ctx)("test.recursive.a.a1").value("1");
+  cvc::state::instance(test_ctx)("test.recursive.a.a2").value("2");
+  cvc::state::instance(test_ctx)("test.recursive.b.b1").value("3");
+  cvc::state::instance(test_ctx)("test.recursive.b.b2.deep").value("4");
 
   // Get all children recursively
-  std::vector<std::string> all_children = cvcstate("test.recursive").children();
+  std::vector<std::string> all_children =
+      cvc::state::instance(test_ctx)("test.recursive").children();
 
   // Should include nested children
   EXPECT_GT(all_children.size(), 2);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -1154,29 +1180,29 @@ TEST(StateTest, ChildrenRecursiveListing) {
 // ===========================
 
 TEST(StateTest, ChildrenRegexMatching) {
-  cvcstate("test.regex2.alpha").value("a");
-  cvcstate("test.regex2.beta").value("b");
-  cvcstate("test.regex2.gamma").value("c");
-  cvcstate("test.regex2.delta").value("d");
+  cvc::state::instance(test_ctx)("test.regex2.alpha").value("a");
+  cvc::state::instance(test_ctx)("test.regex2.beta").value("b");
+  cvc::state::instance(test_ctx)("test.regex2.gamma").value("c");
+  cvc::state::instance(test_ctx)("test.regex2.delta").value("d");
 
   // Try to get children with regex (may not work depending on implementation)
-  std::vector<std::string> all = cvcstate("test.regex2").children();
+  std::vector<std::string> all = cvc::state::instance(test_ctx)("test.regex2").children();
   EXPECT_GE(all.size(), 4);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, ChildrenEmptyRegex) {
-  cvcstate("test.noreg.x").value("1");
-  cvcstate("test.noreg.y").value("2");
+  cvc::state::instance(test_ctx)("test.noreg.x").value("1");
+  cvc::state::instance(test_ctx)("test.noreg.y").value("2");
 
   // Empty regex should return all children
-  std::vector<std::string> children = cvcstate("test.noreg").children("");
+  std::vector<std::string> children = cvc::state::instance(test_ctx)("test.noreg").children("");
   EXPECT_GE(children.size(), 2);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -1185,16 +1211,16 @@ TEST(StateTest, ChildrenEmptyRegex) {
 
 TEST(StateTest, ValueTypeLexicalCast) {
   // Test lexical cast for value retrieval
-  cvcstate("test.lexical.int").value(12345);
-  int val = cvcstate("test.lexical.int").value<int>();
+  cvc::state::instance(test_ctx)("test.lexical.int").value(12345);
+  int val = cvc::state::instance(test_ctx)("test.lexical.int").value<int>();
   EXPECT_EQ(val, 12345);
 
-  cvcstate("test.lexical.double").value(3.14159);
-  double dval = cvcstate("test.lexical.double").value<double>();
+  cvc::state::instance(test_ctx)("test.lexical.double").value(3.14159);
+  double dval = cvc::state::instance(test_ctx)("test.lexical.double").value<double>();
   EXPECT_NEAR(dval, 3.14159, 0.0001);
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -1203,22 +1229,22 @@ TEST(StateTest, ValueTypeLexicalCast) {
 
 TEST(StateTest, ResetRecursive) {
   // Create hierarchy with values
-  cvcstate("test.reset.parent").value("parent_value");
-  cvcstate("test.reset.parent.child1").value("child1_value");
-  cvcstate("test.reset.parent.child2").value("child2_value");
-  cvcstate("test.reset.parent.child1").data(100);
+  cvc::state::instance(test_ctx)("test.reset.parent").value("parent_value");
+  cvc::state::instance(test_ctx)("test.reset.parent.child1").value("child1_value");
+  cvc::state::instance(test_ctx)("test.reset.parent.child2").value("child2_value");
+  cvc::state::instance(test_ctx)("test.reset.parent.child1").data(100);
 
   // Reset parent (should reset children too)
-  cvcstate("test.reset.parent").reset();
+  cvc::state::instance(test_ctx)("test.reset.parent").reset();
 
-  EXPECT_TRUE(cvcstate("test.reset.parent").value().empty());
-  EXPECT_TRUE(cvcstate("test.reset.parent.child1").value().empty());
-  EXPECT_TRUE(cvcstate("test.reset.parent.child2").value().empty());
-  EXPECT_FALSE(cvcstate("test.reset.parent").initialized());
-  EXPECT_FALSE(cvcstate("test.reset.parent.child1").initialized());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset.parent").value().empty());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset.parent.child1").value().empty());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset.parent.child2").value().empty());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset.parent").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset.parent.child1").initialized());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -1230,23 +1256,27 @@ TEST(StateTest, TraversalEnterExitSignals) {
   int exit_count = 0;
 
   auto enter_conn =
-      cvcstate("test.trav.signals").traverseEnter.connect([&enter_count]() { enter_count++; });
+      cvc::state::instance(test_ctx)("test.trav.signals").traverseEnter.connect([&enter_count]() {
+        enter_count++;
+      });
 
   auto exit_conn =
-      cvcstate("test.trav.signals").traverseExit.connect([&exit_count]() { exit_count++; });
+      cvc::state::instance(test_ctx)("test.trav.signals").traverseExit.connect([&exit_count]() {
+        exit_count++;
+      });
 
-  cvcstate("test.trav.signals.a").value("1");
-  cvcstate("test.trav.signals.b").value("2");
+  cvc::state::instance(test_ctx)("test.trav.signals.a").value("1");
+  cvc::state::instance(test_ctx)("test.trav.signals.b").value("2");
 
   state::traversal_unary_func noop = [](std::string) {};
-  cvcstate("test.trav.signals").traverse(noop);
+  cvc::state::instance(test_ctx)("test.trav.signals").traverse(noop);
 
   EXPECT_GT(enter_count, 0);
   EXPECT_GT(exit_count, 0);
 
   enter_conn.disconnect();
   exit_conn.disconnect();
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -1254,16 +1284,16 @@ TEST(StateTest, TraversalEnterExitSignals) {
 // ===========================
 
 TEST(StateTest, FullNameConstruction) {
-  cvcstate("fullname.test.deep.path").value("test");
+  cvc::state::instance(test_ctx)("fullname.test.deep.path").value("test");
 
-  std::string full = cvcstate("fullname.test.deep.path").fullName();
+  std::string full = cvc::state::instance(test_ctx)("fullname.test.deep.path").fullName();
   EXPECT_EQ(full, "fullname.test.deep.path");
 
-  std::string parent_full = cvcstate("fullname.test.deep").fullName();
+  std::string parent_full = cvc::state::instance(test_ctx)("fullname.test.deep").fullName();
   EXPECT_EQ(parent_full, "fullname.test.deep");
 
   // Clean up
-  cvcstate("fullname").reset();
+  cvc::state::instance(test_ctx)("fullname").reset();
 }
 
 // ===========================
@@ -1286,24 +1316,24 @@ TEST(StateTest, OnStartupRegistration) {
 // ===========================
 
 TEST(StateTest, IsDataTemplateMethod) {
-  cvcstate("test.isdata.int").data(42);
+  cvc::state::instance(test_ctx)("test.isdata.int").data(42);
 
-  EXPECT_TRUE(cvcstate("test.isdata.int").isData<int>());
-  EXPECT_FALSE(cvcstate("test.isdata.int").isData<std::string>());
-  EXPECT_FALSE(cvcstate("test.isdata.int").isData<double>());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.isdata.int").isData<int>());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.isdata.int").isData<std::string>());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.isdata.int").isData<double>());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 TEST(StateTest, IsDataWithException) {
   // State with no data
-  cvcstate("test.nodata").value("just_a_value");
+  cvc::state::instance(test_ctx)("test.nodata").value("just_a_value");
 
-  EXPECT_FALSE(cvcstate("test.nodata").isData<int>());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.nodata").isData<int>());
 
   // Clean up
-  cvcstate("test").reset();
+  cvc::state::instance(test_ctx)("test").reset();
 }
 
 // ===========================
@@ -1312,7 +1342,7 @@ TEST(StateTest, IsDataWithException) {
 
 TEST(StateTest, ConcurrentValueReads) {
   // Set up initial state
-  cvcstate("test.concurrent.reads").value("initial_value");
+  cvc::state::instance(test_ctx)("test.concurrent.reads").value("initial_value");
 
   const int num_threads = 10;
   const int reads_per_thread = 100;
@@ -1324,7 +1354,7 @@ TEST(StateTest, ConcurrentValueReads) {
     threads.emplace_back([&successful_reads, reads_per_thread]() {
       for (int j = 0; j < reads_per_thread; ++j) {
         try {
-          std::string val = cvcstate("test.concurrent.reads").value();
+          std::string val = cvc::state::instance(test_ctx)("test.concurrent.reads").value();
           if (!val.empty()) {
             successful_reads++;
           }
@@ -1345,7 +1375,7 @@ TEST(StateTest, ConcurrentValueReads) {
   EXPECT_EQ(successful_reads.load(), num_threads * reads_per_thread);
 
   // Clean up
-  cvcstate("test.concurrent").reset();
+  cvc::state::instance(test_ctx)("test.concurrent").reset();
 }
 
 TEST(StateTest, ConcurrentValueWrites) {
@@ -1362,7 +1392,7 @@ TEST(StateTest, ConcurrentValueWrites) {
       for (int j = 0; j < writes_per_thread; ++j) {
         try {
           std::string val = "value_" + boost::lexical_cast<std::string>(j);
-          cvcstate(key).value(val);
+          cvc::state::instance(test_ctx)(key).value(val);
           successful_writes++;
         } catch (...) {
           FAIL() << "Exception during concurrent write";
@@ -1382,11 +1412,11 @@ TEST(StateTest, ConcurrentValueWrites) {
   for (int i = 0; i < num_threads; ++i) {
     std::string key = "test.concurrent.writes.thread" + boost::lexical_cast<std::string>(i);
     std::string expected = "value_" + boost::lexical_cast<std::string>(writes_per_thread - 1);
-    EXPECT_EQ(cvcstate(key).value(), expected);
+    EXPECT_EQ(cvc::state::instance(test_ctx)(key).value(), expected);
   }
 
   // Clean up
-  cvcstate("test.concurrent").reset();
+  cvc::state::instance(test_ctx)("test.concurrent").reset();
 }
 
 TEST(StateTest, ConcurrentWritesToSameNode) {
@@ -1396,7 +1426,7 @@ TEST(StateTest, ConcurrentWritesToSameNode) {
   std::atomic<int> total_writes(0);
   std::vector<boost::thread> threads;
 
-  cvcstate("test.concurrent.contention").value("initial");
+  cvc::state::instance(test_ctx)("test.concurrent.contention").value("initial");
 
   // All threads write to the same node
   for (int i = 0; i < num_threads; ++i) {
@@ -1405,7 +1435,7 @@ TEST(StateTest, ConcurrentWritesToSameNode) {
         try {
           std::string val = "thread" + boost::lexical_cast<std::string>(i) + "_write" +
                             boost::lexical_cast<std::string>(j);
-          cvcstate("test.concurrent.contention").value(val);
+          cvc::state::instance(test_ctx)("test.concurrent.contention").value(val);
           total_writes++;
         } catch (...) {
           FAIL() << "Exception during high-contention write";
@@ -1422,12 +1452,12 @@ TEST(StateTest, ConcurrentWritesToSameNode) {
   EXPECT_EQ(total_writes.load(), num_threads * writes_per_thread);
 
   // The final value should be from one of the threads
-  std::string final_value = cvcstate("test.concurrent.contention").value();
+  std::string final_value = cvc::state::instance(test_ctx)("test.concurrent.contention").value();
   EXPECT_FALSE(final_value.empty());
   EXPECT_NE(final_value, "initial");
 
   // Clean up
-  cvcstate("test.concurrent").reset();
+  cvc::state::instance(test_ctx)("test.concurrent").reset();
 }
 
 TEST(StateTest, ConcurrentDataOperations) {
@@ -1445,7 +1475,7 @@ TEST(StateTest, ConcurrentDataOperations) {
         std::string key = "test.concurrent.data.writer" + boost::lexical_cast<std::string>(i);
         for (int j = 0; j < 50; ++j) {
           try {
-            cvcstate(key).data(j * 100 + i);
+            cvc::state::instance(test_ctx)(key).data(j * 100 + i);
             data_set_count++;
           } catch (...) {
             FAIL() << "Exception during concurrent data write";
@@ -1459,8 +1489,8 @@ TEST(StateTest, ConcurrentDataOperations) {
         for (int j = 0; j < 50; ++j) {
           try {
             // May or may not have data yet, but shouldn't crash
-            if (cvcstate(key).isData<int>()) {
-              int val = cvcstate(key).data<int>();
+            if (cvc::state::instance(test_ctx)(key).isData<int>()) {
+              int val = cvc::state::instance(test_ctx)(key).data<int>();
               (void)val; // Suppress unused warning
               data_read_count++;
             }
@@ -1481,7 +1511,7 @@ TEST(StateTest, ConcurrentDataOperations) {
   EXPECT_GT(data_read_count.load(), 0);
 
   // Clean up
-  cvcstate("test.concurrent").reset();
+  cvc::state::instance(test_ctx)("test.concurrent").reset();
 }
 
 TEST(StateTest, ConcurrentSignalHandling) {
@@ -1491,7 +1521,7 @@ TEST(StateTest, ConcurrentSignalHandling) {
   std::vector<std::string> signal_paths;
 
   // Connect to childChanged signal
-  auto connection = cvcstate("test.concurrent.signals")
+  auto connection = cvc::state::instance(test_ctx)("test.concurrent.signals")
                         .childChanged.connect(
                             [&signal_count, &signal_mutex, &signal_paths](const std::string &path) {
                               signal_count++;
@@ -1509,7 +1539,7 @@ TEST(StateTest, ConcurrentSignalHandling) {
       for (int j = 0; j < ops_per_thread; ++j) {
         std::string key = "test.concurrent.signals.child" + boost::lexical_cast<std::string>(i) +
                           "." + boost::lexical_cast<std::string>(j);
-        cvcstate(key).value("signal_test");
+        cvc::state::instance(test_ctx)(key).value("signal_test");
       }
     });
   }
@@ -1525,7 +1555,7 @@ TEST(StateTest, ConcurrentSignalHandling) {
   EXPECT_GT(signal_count.load(), 0);
 
   connection.disconnect();
-  cvcstate("test.concurrent").reset();
+  cvc::state::instance(test_ctx)("test.concurrent").reset();
 }
 
 TEST(StateTest, ConcurrentHierarchyCreation) {
@@ -1543,7 +1573,8 @@ TEST(StateTest, ConcurrentHierarchyCreation) {
       for (int d = 0; d < depth; ++d) {
         path += ".level" + boost::lexical_cast<std::string>(d);
         try {
-          cvcstate(path).value("depth_" + boost::lexical_cast<std::string>(d));
+          cvc::state::instance(test_ctx)(path).value("depth_" +
+                                                     boost::lexical_cast<std::string>(d));
           nodes_created++;
         } catch (...) {
           FAIL() << "Exception during hierarchy creation";
@@ -1561,11 +1592,11 @@ TEST(StateTest, ConcurrentHierarchyCreation) {
   // Verify hierarchies exist
   for (int i = 0; i < num_threads; ++i) {
     std::string base = "test.concurrent.hierarchy.branch" + boost::lexical_cast<std::string>(i);
-    size_t children = cvcstate(base).numChildren();
+    size_t children = cvc::state::instance(test_ctx)(base).numChildren();
     EXPECT_GE(children, 1);
   }
 
-  cvcstate("test.concurrent").reset();
+  cvc::state::instance(test_ctx)("test.concurrent").reset();
 }
 
 TEST(StateTest, ConcurrentTraversal) {
@@ -1574,7 +1605,7 @@ TEST(StateTest, ConcurrentTraversal) {
     for (int j = 0; j < 3; ++j) {
       std::string key = "test.concurrent.traversal.parent" + boost::lexical_cast<std::string>(i) +
                         ".child" + boost::lexical_cast<std::string>(j);
-      cvcstate(key).value("traverse_me");
+      cvc::state::instance(test_ctx)(key).value("traverse_me");
     }
   }
 
@@ -1588,9 +1619,8 @@ TEST(StateTest, ConcurrentTraversal) {
     threads.emplace_back([&traverse_count, &stop_flag]() {
       while (!stop_flag.load()) {
         try {
-          cvcstate("test.concurrent.traversal").traverse([&traverse_count](std::string) {
-            traverse_count++;
-          });
+          cvc::state::instance(test_ctx)("test.concurrent.traversal")
+              .traverse([&traverse_count](std::string) { traverse_count++; });
         } catch (...) {
           FAIL() << "Exception during concurrent traversal";
         }
@@ -1603,7 +1633,7 @@ TEST(StateTest, ConcurrentTraversal) {
   threads.emplace_back([&stop_flag]() {
     for (int i = 0; i < 10; ++i) {
       std::string key = "test.concurrent.traversal.newnode" + boost::lexical_cast<std::string>(i);
-      cvcstate(key).value("new");
+      cvc::state::instance(test_ctx)(key).value("new");
       boost::this_thread::sleep_for(boost::chrono::milliseconds(5));
     }
     stop_flag.store(true);
@@ -1615,7 +1645,7 @@ TEST(StateTest, ConcurrentTraversal) {
 
   EXPECT_GT(traverse_count.load(), 0);
 
-  cvcstate("test.concurrent").reset();
+  cvc::state::instance(test_ctx)("test.concurrent").reset();
 }
 
 TEST(StateTest, ConcurrentResetOperations) {
@@ -1626,7 +1656,9 @@ TEST(StateTest, ConcurrentResetOperations) {
 
   // Populate initial state
   for (int i = 0; i < 20; ++i) {
-    cvcstate("test.concurrent.reset.item" + boost::lexical_cast<std::string>(i)).value("data");
+    cvc::state::instance(test_ctx)("test.concurrent.reset.item" +
+                                   boost::lexical_cast<std::string>(i))
+        .value("data");
   }
 
   // Some threads reset, others read/write
@@ -1636,7 +1668,7 @@ TEST(StateTest, ConcurrentResetOperations) {
       threads.emplace_back([&reset_count]() {
         for (int j = 0; j < 5; ++j) {
           try {
-            cvcstate("test.concurrent.reset").reset();
+            cvc::state::instance(test_ctx)("test.concurrent.reset").reset();
             reset_count++;
             boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
           } catch (...) {
@@ -1650,8 +1682,9 @@ TEST(StateTest, ConcurrentResetOperations) {
         for (int j = 0; j < 20; ++j) {
           try {
             std::string key = "test.concurrent.reset.item" + boost::lexical_cast<std::string>(j);
-            cvcstate(key).value("updated_" + boost::lexical_cast<std::string>(i));
-            std::string val = cvcstate(key).value();
+            cvc::state::instance(test_ctx)(key).value("updated_" +
+                                                      boost::lexical_cast<std::string>(i));
+            std::string val = cvc::state::instance(test_ctx)(key).value();
             (void)val;
           } catch (...) {
             // May fail if reset happens - that's okay
@@ -1668,7 +1701,7 @@ TEST(StateTest, ConcurrentResetOperations) {
 
   EXPECT_GT(reset_count.load(), 0);
 
-  cvcstate("test.concurrent").reset();
+  cvc::state::instance(test_ctx)("test.concurrent").reset();
 }
 
 TEST(StateTest, ConcurrentPropertyTreeOperations) {
@@ -1679,7 +1712,8 @@ TEST(StateTest, ConcurrentPropertyTreeOperations) {
 
   // Set up initial state
   for (int i = 0; i < 10; ++i) {
-    cvcstate("test.concurrent.ptree.item" + boost::lexical_cast<std::string>(i))
+    cvc::state::instance(test_ctx)("test.concurrent.ptree.item" +
+                                   boost::lexical_cast<std::string>(i))
         .value("value" + boost::lexical_cast<std::string>(i));
   }
 
@@ -1691,10 +1725,10 @@ TEST(StateTest, ConcurrentPropertyTreeOperations) {
       threads.emplace_back([&ptree_ops, &json_ops]() {
         for (int j = 0; j < 10; ++j) {
           try {
-            auto pt = cvcstate("test.concurrent.ptree").ptree();
+            auto pt = cvc::state::instance(test_ctx)("test.concurrent.ptree").ptree();
             ptree_ops++;
 
-            std::string json_str = cvcstate("test.concurrent.ptree").json();
+            std::string json_str = cvc::state::instance(test_ctx)("test.concurrent.ptree").json();
             if (!json_str.empty()) {
               json_ops++;
             }
@@ -1711,8 +1745,9 @@ TEST(StateTest, ConcurrentPropertyTreeOperations) {
           try {
             std::string key =
                 "test.concurrent.ptree.item" + boost::lexical_cast<std::string>(j % 10);
-            cvcstate(key).value("thread" + boost::lexical_cast<std::string>(i) + "_" +
-                                boost::lexical_cast<std::string>(j));
+            cvc::state::instance(test_ctx)(key).value("thread" +
+                                                      boost::lexical_cast<std::string>(i) + "_" +
+                                                      boost::lexical_cast<std::string>(j));
           } catch (...) {
             FAIL() << "Exception during modification";
           }
@@ -1729,7 +1764,7 @@ TEST(StateTest, ConcurrentPropertyTreeOperations) {
   EXPECT_GT(ptree_ops.load(), 0);
   EXPECT_GT(json_ops.load(), 0);
 
-  cvcstate("test.concurrent").reset();
+  cvc::state::instance(test_ctx)("test.concurrent").reset();
 }
 
 TEST(StateTest, DeadlockDetectionValueAndSignal) {
@@ -1738,23 +1773,25 @@ TEST(StateTest, DeadlockDetectionValueAndSignal) {
   std::atomic<bool> deadlock_detected(false);
   boost::mutex test_mutex;
 
-  auto connection = cvcstate("test.deadlock.node").valueChanged.connect([&]() {
-    signal_fires++;
-    // Try to access state from within signal handler
-    try {
-      std::string val = cvcstate("test.deadlock.node").value();
-      boost::mutex::scoped_lock lock(test_mutex);
-      cvcstate("test.deadlock.counter")
-          .value(boost::lexical_cast<std::string>(signal_fires.load()));
-    } catch (...) {
-      deadlock_detected.store(true);
-    }
-  });
+  auto connection =
+      cvc::state::instance(test_ctx)("test.deadlock.node").valueChanged.connect([&]() {
+        signal_fires++;
+        // Try to access state from within signal handler
+        try {
+          std::string val = cvc::state::instance(test_ctx)("test.deadlock.node").value();
+          boost::mutex::scoped_lock lock(test_mutex);
+          cvc::state::instance(test_ctx)("test.deadlock.counter")
+              .value(boost::lexical_cast<std::string>(signal_fires.load()));
+        } catch (...) {
+          deadlock_detected.store(true);
+        }
+      });
 
   // Rapidly change value
   boost::thread writer([&deadlock_detected]() {
     for (int i = 0; i < 50 && !deadlock_detected.load(); ++i) {
-      cvcstate("test.deadlock.node").value("iteration_" + boost::lexical_cast<std::string>(i));
+      cvc::state::instance(test_ctx)("test.deadlock.node")
+          .value("iteration_" + boost::lexical_cast<std::string>(i));
       boost::this_thread::sleep_for(boost::chrono::milliseconds(2));
     }
   });
@@ -1772,7 +1809,7 @@ TEST(StateTest, DeadlockDetectionValueAndSignal) {
   EXPECT_GT(signal_fires.load(), 0);
 
   connection.disconnect();
-  cvcstate("test.deadlock").reset();
+  cvc::state::instance(test_ctx)("test.deadlock").reset();
 }
 
 // ===========================
@@ -2107,7 +2144,7 @@ TEST_F(StateObjectFixture, StateObjectLockDoesNotBlockParent) {
   });
 
   // Try to modify parent state - should NOT block
-  boost::thread parentModifier([&config, &parent_modified]() {
+  boost::thread parentModifier([&config, &parent_modified, this]() {
     boost::this_thread::sleep_for(boost::chrono::milliseconds(20));
 
     // Get parent state path (everything before the instance address)
@@ -2118,7 +2155,7 @@ TEST_F(StateObjectFixture, StateObjectLockDoesNotBlockParent) {
 
       // This modification is to parent state, not config's state
       // So it should NOT be blocked by config's lock
-      cvcstate(parentPath + ".other_instance").value("parent_data");
+      cvc::state::instance(ctx)(parentPath + ".other_instance").value("parent_data");
       parent_modified.store(true);
     }
   });
@@ -2590,9 +2627,10 @@ TEST(StateTest, StressTestCombinedOperations) {
       while (!stop_flag.load()) {
         try {
           std::string key = "test.stress.writer" + boost::lexical_cast<std::string>(i);
-          cvcstate(key).value("val_" + boost::lexical_cast<std::string>(ops));
-          cvcstate(key).data(ops);
-          cvcstate(key).comment("comment_" + boost::lexical_cast<std::string>(ops));
+          cvc::state::instance(test_ctx)(key).value("val_" + boost::lexical_cast<std::string>(ops));
+          cvc::state::instance(test_ctx)(key).data(ops);
+          cvc::state::instance(test_ctx)(key).comment("comment_" +
+                                                      boost::lexical_cast<std::string>(ops));
           ops++;
         } catch (...) {
           FAIL() << "Exception in writer thread";
@@ -2609,9 +2647,9 @@ TEST(StateTest, StressTestCombinedOperations) {
       while (!stop_flag.load()) {
         try {
           std::string key = "test.stress.writer" + boost::lexical_cast<std::string>(i % 3);
-          std::string val = cvcstate(key).value();
-          if (cvcstate(key).isData<int>()) {
-            int data = cvcstate(key).data<int>();
+          std::string val = cvc::state::instance(test_ctx)(key).value();
+          if (cvc::state::instance(test_ctx)(key).isData<int>()) {
+            int data = cvc::state::instance(test_ctx)(key).data<int>();
             (void)data;
           }
           ops++;
@@ -2628,7 +2666,7 @@ TEST(StateTest, StressTestCombinedOperations) {
     int ops = 0;
     while (!stop_flag.load()) {
       try {
-        cvcstate("test.stress").traverse([](std::string) {});
+        cvc::state::instance(test_ctx)("test.stress").traverse([](std::string) {});
         ops++;
       } catch (...) {
         FAIL() << "Exception in traversal thread";
@@ -2650,7 +2688,7 @@ TEST(StateTest, StressTestCombinedOperations) {
   EXPECT_GT(total_ops.load(), 0);
   std::cout << "Stress test completed " << total_ops.load() << " operations without deadlock\n";
 
-  cvcstate("test.stress").reset();
+  cvc::state::instance(test_ctx)("test.stress").reset();
 }
 
 TEST(StateTest, StressTestHierarchyRaceConditions) {
@@ -2673,12 +2711,13 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
       try {
         for (int p = 0; p < num_parents; ++p) {
           std::string parent = "test.hierarchy.parent" + boost::lexical_cast<std::string>(p);
-          cvcstate(parent).value("parent_value");
+          cvc::state::instance(test_ctx)(parent).value("parent_value");
 
           for (int c = 0; c < children_per_parent; ++c) {
             std::string child = parent + ".child" + boost::lexical_cast<std::string>(c);
-            cvcstate(child).value("child_value_" + boost::lexical_cast<std::string>(ops));
-            cvcstate(child).data(ops);
+            cvc::state::instance(test_ctx)(child).value("child_value_" +
+                                                        boost::lexical_cast<std::string>(ops));
+            cvc::state::instance(test_ctx)(child).data(ops);
             ops++;
           }
         }
@@ -2696,7 +2735,7 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
       try {
         for (int p = 0; p < num_parents; ++p) {
           std::string parent = "test.hierarchy.parent" + boost::lexical_cast<std::string>(p);
-          cvcstate(parent).reset(); // Should clean up all children
+          cvc::state::instance(test_ctx)(parent).reset(); // Should clean up all children
           ops++;
         }
         boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
@@ -2712,9 +2751,9 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
     int ops = 0;
     while (!stop_flag.load()) {
       try {
-        cvcstate("test.hierarchy").traverse([](std::string key) {
+        cvc::state::instance(test_ctx)("test.hierarchy").traverse([](std::string key) {
           // Try to access each node during traversal
-          cvcstate(key).value();
+          cvc::state::instance(test_ctx)(key).value();
         });
         ops++;
       } catch (...) {
@@ -2736,13 +2775,14 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
                             ".child" + boost::lexical_cast<std::string>(c);
 
         // Write
-        cvcstate(child).value("updated_" + boost::lexical_cast<std::string>(ops));
-        cvcstate(child).data(ops * 2);
+        cvc::state::instance(test_ctx)(child).value("updated_" +
+                                                    boost::lexical_cast<std::string>(ops));
+        cvc::state::instance(test_ctx)(child).data(ops * 2);
 
         // Read back
-        std::string val = cvcstate(child).value();
-        if (cvcstate(child).isData<int>()) {
-          int data = cvcstate(child).data<int>();
+        std::string val = cvc::state::instance(test_ctx)(child).value();
+        if (cvc::state::instance(test_ctx)(child).isData<int>()) {
+          int data = cvc::state::instance(test_ctx)(child).data<int>();
           (void)data;
         }
         ops++;
@@ -2763,11 +2803,11 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
         // Create hierarchy
         for (int i = 0; i < 5; ++i) {
           std::string path = base + ".level1.level2.node" + boost::lexical_cast<std::string>(i);
-          cvcstate(path).value("deep_value");
+          cvc::state::instance(test_ctx)(path).value("deep_value");
         }
 
         // Destroy it
-        cvcstate(base).reset();
+        cvc::state::instance(test_ctx)(base).reset();
         ops++;
       } catch (...) {
         hierarchy_errors++;
@@ -2786,13 +2826,13 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
           std::string parent = "test.hierarchy.parent" + boost::lexical_cast<std::string>(p);
 
           // Get children list
-          std::vector<std::string> children = cvcstate(parent).children();
+          std::vector<std::string> children = cvc::state::instance(test_ctx)(parent).children();
 
           // Verify we can access each child
           for (const auto &child : children) {
             try {
-              std::string fullName = cvcstate(child).fullName();
-              std::string parentName = cvcstate(child).parentName();
+              std::string fullName = cvc::state::instance(test_ctx)(child).fullName();
+              std::string parentName = cvc::state::instance(test_ctx)(child).parentName();
 
               // Check parent/child relationship
               if (parentName != parent) {
@@ -2820,9 +2860,11 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
       try {
         for (int p = 0; p < num_parents; ++p) {
           std::string parent = "test.hierarchy.parent" + boost::lexical_cast<std::string>(p);
-          cvcstate(parent).value("modified_" + boost::lexical_cast<std::string>(ops));
-          cvcstate(parent).comment("comment_" + boost::lexical_cast<std::string>(ops));
-          cvcstate(parent).data(ops);
+          cvc::state::instance(test_ctx)(parent).value("modified_" +
+                                                       boost::lexical_cast<std::string>(ops));
+          cvc::state::instance(test_ctx)(parent).comment("comment_" +
+                                                         boost::lexical_cast<std::string>(ops));
+          cvc::state::instance(test_ctx)(parent).data(ops);
           ops++;
         }
       } catch (...) {
@@ -2847,7 +2889,8 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
                 std::string path = root + ".l1_" + boost::lexical_cast<std::string>(l1) + ".l2_" +
                                    boost::lexical_cast<std::string>(l2) + ".l3_" +
                                    boost::lexical_cast<std::string>(l3);
-                cvcstate(path).value("deep_" + boost::lexical_cast<std::string>(ops));
+                cvc::state::instance(test_ctx)(path).value("deep_" +
+                                                           boost::lexical_cast<std::string>(ops));
                 ops++;
               }
             }
@@ -2855,7 +2898,7 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
 
           // Reset entire hierarchy
           if (ops % 20 == 0) {
-            cvcstate(root).reset();
+            cvc::state::instance(test_ctx)(root).reset();
           }
         }
       } catch (...) {
@@ -2871,16 +2914,16 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
     while (!stop_flag.load()) {
       try {
         // Check that all accessible children have valid parents
-        cvcstate("test.hierarchy").traverse([&](std::string key) {
+        cvc::state::instance(test_ctx)("test.hierarchy").traverse([&](std::string key) {
           try {
-            std::string parent = cvcstate(key).parentName();
+            std::string parent = cvc::state::instance(test_ctx)(key).parentName();
             if (!parent.empty() && parent != "test.hierarchy") {
               // Parent should be accessible
-              std::string parent_value = cvcstate(parent).value();
+              std::string parent_value = cvc::state::instance(test_ctx)(parent).value();
               (void)parent_value;
 
               // This node should be in parent's children list
-              std::vector<std::string> siblings = cvcstate(parent).children();
+              std::vector<std::string> siblings = cvc::state::instance(test_ctx)(parent).children();
               bool found = false;
               for (const auto &sibling : siblings) {
                 if (sibling == key) {
@@ -2919,16 +2962,18 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
         std::string childB = parentB + "." + child_name;
 
         // Create under parent A
-        cvcstate(childA).value("under_A_" + boost::lexical_cast<std::string>(ops));
-        cvcstate(childA).data(ops);
+        cvc::state::instance(test_ctx)(childA).value("under_A_" +
+                                                     boost::lexical_cast<std::string>(ops));
+        cvc::state::instance(test_ctx)(childA).data(ops);
 
         // Try to create same-named child under parent B
-        cvcstate(childB).value("under_B_" + boost::lexical_cast<std::string>(ops));
-        cvcstate(childB).data(ops + 1000);
+        cvc::state::instance(test_ctx)(childB).value("under_B_" +
+                                                     boost::lexical_cast<std::string>(ops));
+        cvc::state::instance(test_ctx)(childB).data(ops + 1000);
 
         // Verify both exist independently
-        std::string valA = cvcstate(childA).value();
-        std::string valB = cvcstate(childB).value();
+        std::string valA = cvc::state::instance(test_ctx)(childA).value();
+        std::string valB = cvc::state::instance(test_ctx)(childB).value();
         (void)valA;
         (void)valB;
 
@@ -2964,7 +3009,7 @@ TEST(StateTest, StressTestHierarchyRaceConditions) {
             << (orphan_errors.load() == 0 ? "PERFECT" : "ACCEPTABLE (concurrent modifications)")
             << "\n";
 
-  cvcstate("test.hierarchy").reset();
+  cvc::state::instance(test_ctx)("test.hierarchy").reset();
 }
 
 // ===========================
@@ -3007,7 +3052,7 @@ TEST(StateTest, PerformanceHierarchyBenchmark) {
     std::string key = "perf.test.L" + boost::lexical_cast<std::string>(level) + ".B" +
                       boost::lexical_cast<std::string>(branch) + ".item" +
                       boost::lexical_cast<std::string>(i);
-    cvcstate(key).value(i);
+    cvc::state::instance(test_ctx)(key).value(i);
     total_data_size += sizeof(int);
     operations_completed++;
 
@@ -3036,7 +3081,7 @@ TEST(StateTest, PerformanceHierarchyBenchmark) {
     std::string key = "perf.test.L" + boost::lexical_cast<std::string>(level) + ".B" +
                       boost::lexical_cast<std::string>(branch) + ".item" +
                       boost::lexical_cast<std::string>(i);
-    int val = cvcstate(key).value<int>();
+    int val = cvc::state::instance(test_ctx)(key).value<int>();
     ASSERT_EQ(val, i);
     operations_completed++;
 
@@ -3062,7 +3107,7 @@ TEST(StateTest, PerformanceHierarchyBenchmark) {
     std::string key = "perf.strings.item" + boost::lexical_cast<std::string>(i);
     std::string value = "String_" + boost::lexical_cast<std::string>(i) + "_" +
                         std::string(i % 100, 'x'); // Variable length
-    cvcstate(key).value(value);
+    cvc::state::instance(test_ctx)(key).value(value);
     total_data_size += value.size();
     operations_completed++;
 
@@ -3088,7 +3133,7 @@ TEST(StateTest, PerformanceHierarchyBenchmark) {
     std::string key = "perf.strings.item" + boost::lexical_cast<std::string>(i);
     std::string expected =
         "String_" + boost::lexical_cast<std::string>(i) + "_" + std::string(i % 100, 'x');
-    std::string val = cvcstate(key).value();
+    std::string val = cvc::state::instance(test_ctx)(key).value();
     ASSERT_EQ(val, expected);
     operations_completed++;
 
@@ -3118,7 +3163,7 @@ TEST(StateTest, PerformanceHierarchyBenchmark) {
         list_value += ",";
       list_value += boost::lexical_cast<std::string>(i * 10 + j);
     }
-    cvcstate(key).value(list_value);
+    cvc::state::instance(test_ctx)(key).value(list_value);
     total_data_size += list_value.size();
     operations_completed++;
 
@@ -3142,7 +3187,7 @@ TEST(StateTest, PerformanceHierarchyBenchmark) {
   std::cout << "Test 6: Reading and parsing 100k lists...\n";
   for (int i = 0; i < 100000; ++i) {
     std::string key = "perf.lists.item" + boost::lexical_cast<std::string>(i);
-    std::string list_str = cvcstate(key).value();
+    std::string list_str = cvc::state::instance(test_ctx)(key).value();
 
     // Parse comma-separated values
     std::vector<int> values;
@@ -3190,7 +3235,7 @@ TEST(StateTest, PerformanceHierarchyBenchmark) {
       array[j] = static_cast<unsigned char>((i + j) % 256);
     }
 
-    cvcstate(key).data(array);
+    cvc::state::instance(test_ctx)(key).data(array);
     total_data_size += ARRAY_SIZE;
     operations_completed++;
 
@@ -3215,7 +3260,8 @@ TEST(StateTest, PerformanceHierarchyBenchmark) {
   std::cout << "Test 8: Reading 10k binary arrays...\n";
   for (int i = 0; i < 10000; ++i) {
     std::string key = "perf.arrays.item" + boost::lexical_cast<std::string>(i);
-    std::vector<unsigned char> array = cvcstate(key).data<std::vector<unsigned char>>();
+    std::vector<unsigned char> array =
+        cvc::state::instance(test_ctx)(key).data<std::vector<unsigned char>>();
 
     ASSERT_EQ(array.size(), ARRAY_SIZE);
 
@@ -3249,12 +3295,12 @@ TEST(StateTest, PerformanceHierarchyBenchmark) {
 
     if (i % 2 == 0) {
       // Write integer using data()
-      cvcstate(key).data(i);
+      cvc::state::instance(test_ctx)(key).data(i);
     } else {
       // Read back if exists and is int type
       try {
-        if (cvcstate(key).isData<int>()) {
-          int val = cvcstate(key).data<int>();
+        if (cvc::state::instance(test_ctx)(key).isData<int>()) {
+          int val = cvc::state::instance(test_ctx)(key).data<int>();
           (void)val;
         }
       } catch (...) {
@@ -3282,7 +3328,7 @@ TEST(StateTest, PerformanceHierarchyBenchmark) {
   // Test 10: Hierarchy traversal
   std::cout << "Test 10: Traversing entire hierarchy (100k items)...\n";
   std::atomic<int> traverse_count(0);
-  cvcstate("perf").traverse([&](std::string key) {
+  cvc::state::instance(test_ctx)("perf").traverse([&](std::string key) {
     traverse_count++;
     operations_completed++;
   });
@@ -3332,7 +3378,7 @@ TEST(StateTest, PerformanceHierarchyBenchmark) {
             << " ops/sec\n";
 
   // Cleanup
-  cvcstate("perf").reset();
+  cvc::state::instance(test_ctx)("perf").reset();
 }
 
 TEST(StateTest, PerformanceCallbackChains) {
@@ -3361,7 +3407,7 @@ TEST(StateTest, PerformanceCallbackChains) {
     std::string current = "perf.chain.linear." + boost::lexical_cast<std::string>(i);
     std::string next = "perf.chain.linear." + boost::lexical_cast<std::string>(i + 1);
 
-    auto conn = cvcstate(current).valueChanged.connect(
+    auto conn = cvc::state::instance(test_ctx)(current).valueChanged.connect(
         [&total_callbacks, next, i, &chain_depth, &max_depth_reached]() {
           total_callbacks++;
           int current_depth = chain_depth.fetch_add(1) + 1;
@@ -3374,7 +3420,7 @@ TEST(StateTest, PerformanceCallbackChains) {
           }
 
           // Trigger next in chain
-          cvcstate(next).value(i + 1);
+          cvc::state::instance(test_ctx)(next).value(i + 1);
 
           chain_depth.fetch_sub(1);
         });
@@ -3384,14 +3430,14 @@ TEST(StateTest, PerformanceCallbackChains) {
   // Initialize all nodes first
   for (int i = 0; i < MAX_CHAIN_DEPTH; ++i) {
     std::string key = "perf.chain.linear." + boost::lexical_cast<std::string>(i);
-    cvcstate(key).value(0);
+    cvc::state::instance(test_ctx)(key).value(0);
   }
 
   // Trigger the chain
   total_callbacks.store(0);
   chain_depth.store(0);
   max_depth_reached.store(0);
-  cvcstate("perf.chain.linear.0").value(1);
+  cvc::state::instance(test_ctx)("perf.chain.linear.0").value(1);
 
   // Wait for chain to complete (small delay)
   boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
@@ -3421,13 +3467,13 @@ TEST(StateTest, PerformanceCallbackChains) {
   std::atomic<int> child_callbacks(0);
 
   // Parent callback triggers writes to all children
-  auto parent_conn = cvcstate("perf.chain.fanout.parent")
+  auto parent_conn = cvc::state::instance(test_ctx)("perf.chain.fanout.parent")
                          .valueChanged.connect([&fanout_callbacks, FAN_OUT_COUNT]() {
                            fanout_callbacks++;
                            for (int i = 0; i < FAN_OUT_COUNT; ++i) {
                              std::string child =
                                  "perf.chain.fanout.child." + boost::lexical_cast<std::string>(i);
-                             cvcstate(child).value(i);
+                             cvc::state::instance(test_ctx)(child).value(i);
                            }
                          });
 
@@ -3435,14 +3481,15 @@ TEST(StateTest, PerformanceCallbackChains) {
   std::vector<boost::signals2::connection> child_conns;
   for (int i = 0; i < FAN_OUT_COUNT; ++i) {
     std::string child = "perf.chain.fanout.child." + boost::lexical_cast<std::string>(i);
-    auto conn = cvcstate(child).valueChanged.connect([&child_callbacks]() { child_callbacks++; });
+    auto conn = cvc::state::instance(test_ctx)(child).valueChanged.connect(
+        [&child_callbacks]() { child_callbacks++; });
     child_conns.push_back(conn);
   }
 
   // Trigger fan-out
   fanout_callbacks.store(0);
   child_callbacks.store(0);
-  cvcstate("perf.chain.fanout.parent").value(42);
+  cvc::state::instance(test_ctx)("perf.chain.fanout.parent").value(42);
 
   boost::this_thread::sleep_for(boost::chrono::milliseconds(50));
 
@@ -3471,31 +3518,31 @@ TEST(StateTest, PerformanceCallbackChains) {
   const int MAX_ITERATIONS = 10; // Safety limit
 
   // Node A triggers B (with iteration limit)
-  auto connA =
-      cvcstate("perf.chain.loop.A").valueChanged.connect([&nodeA_callbacks, MAX_ITERATIONS]() {
-        int count = nodeA_callbacks.fetch_add(1);
-        if (count < MAX_ITERATIONS) {
-          cvcstate("perf.chain.loop.B").value(count);
-        }
-      });
+  auto connA = cvc::state::instance(test_ctx)("perf.chain.loop.A")
+                   .valueChanged.connect([&nodeA_callbacks, MAX_ITERATIONS]() {
+                     int count = nodeA_callbacks.fetch_add(1);
+                     if (count < MAX_ITERATIONS) {
+                       cvc::state::instance(test_ctx)("perf.chain.loop.B").value(count);
+                     }
+                   });
 
   // Node B triggers A (with iteration limit)
-  auto connB =
-      cvcstate("perf.chain.loop.B").valueChanged.connect([&nodeB_callbacks, MAX_ITERATIONS]() {
-        int count = nodeB_callbacks.fetch_add(1);
-        if (count < MAX_ITERATIONS) {
-          cvcstate("perf.chain.loop.A").value(count);
-        }
-      });
+  auto connB = cvc::state::instance(test_ctx)("perf.chain.loop.B")
+                   .valueChanged.connect([&nodeB_callbacks, MAX_ITERATIONS]() {
+                     int count = nodeB_callbacks.fetch_add(1);
+                     if (count < MAX_ITERATIONS) {
+                       cvc::state::instance(test_ctx)("perf.chain.loop.A").value(count);
+                     }
+                   });
 
   // Initialize
-  cvcstate("perf.chain.loop.A").value(0);
-  cvcstate("perf.chain.loop.B").value(0);
+  cvc::state::instance(test_ctx)("perf.chain.loop.A").value(0);
+  cvc::state::instance(test_ctx)("perf.chain.loop.B").value(0);
 
   // Trigger potential loop
   nodeA_callbacks.store(0);
   nodeB_callbacks.store(0);
-  cvcstate("perf.chain.loop.A").value(1);
+  cvc::state::instance(test_ctx)("perf.chain.loop.A").value(1);
 
   boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
 
@@ -3535,7 +3582,7 @@ TEST(StateTest, PerformanceCallbackChains) {
 
       // Do work (trigger another state)
       if (trigger_key != "self") {
-        cvcstate(trigger_key).value(callback_count.load());
+        cvc::state::instance(test_ctx)(trigger_key).value(callback_count.load());
       }
 
       // Release flag
@@ -3547,22 +3594,24 @@ TEST(StateTest, PerformanceCallbackChains) {
   GuardedCallback guardD;
 
   // C triggers D, D triggers C - but guards prevent infinite loop
-  auto connC = cvcstate("perf.chain.guard.C").valueChanged.connect([&guardC]() {
-    guardC("perf.chain.guard.D");
-  });
+  auto connC =
+      cvc::state::instance(test_ctx)("perf.chain.guard.C").valueChanged.connect([&guardC]() {
+        guardC("perf.chain.guard.D");
+      });
 
-  auto connD = cvcstate("perf.chain.guard.D").valueChanged.connect([&guardD]() {
-    guardD("perf.chain.guard.C");
-  });
+  auto connD =
+      cvc::state::instance(test_ctx)("perf.chain.guard.D").valueChanged.connect([&guardD]() {
+        guardD("perf.chain.guard.C");
+      });
 
   // Initialize
-  cvcstate("perf.chain.guard.C").value(0);
-  cvcstate("perf.chain.guard.D").value(0);
+  cvc::state::instance(test_ctx)("perf.chain.guard.C").value(0);
+  cvc::state::instance(test_ctx)("perf.chain.guard.D").value(0);
 
   // Trigger
   guardC.callback_count.store(0);
   guardD.callback_count.store(0);
-  cvcstate("perf.chain.guard.C").value(1);
+  cvc::state::instance(test_ctx)("perf.chain.guard.C").value(1);
 
   boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
 
@@ -3594,29 +3643,30 @@ TEST(StateTest, PerformanceCallbackChains) {
     std::string current = "perf.chain.hier.level" + boost::lexical_cast<std::string>(level);
     std::string next = "perf.chain.hier.level" + boost::lexical_cast<std::string>(level + 1);
 
-    auto conn = cvcstate(current).valueChanged.connect([&hierarchy_callbacks, next, level]() {
-      hierarchy_callbacks++;
-      // Update next level with incremented value
-      cvcstate(next).value(level + 2);
-    });
+    auto conn = cvc::state::instance(test_ctx)(current).valueChanged.connect(
+        [&hierarchy_callbacks, next, level]() {
+          hierarchy_callbacks++;
+          // Update next level with incremented value
+          cvc::state::instance(test_ctx)(next).value(level + 2);
+        });
     hier_conns.push_back(conn);
   }
 
   // Last level just counts
-  auto last_conn =
-      cvcstate("perf.chain.hier.level" + boost::lexical_cast<std::string>(HIER_LEVELS - 1))
-          .valueChanged.connect([&hierarchy_callbacks]() { hierarchy_callbacks++; });
+  auto last_conn = cvc::state::instance(test_ctx)("perf.chain.hier.level" +
+                                                  boost::lexical_cast<std::string>(HIER_LEVELS - 1))
+                       .valueChanged.connect([&hierarchy_callbacks]() { hierarchy_callbacks++; });
   hier_conns.push_back(last_conn);
 
   // Initialize all levels
   for (int level = 0; level < HIER_LEVELS; ++level) {
     std::string key = "perf.chain.hier.level" + boost::lexical_cast<std::string>(level);
-    cvcstate(key).value(0);
+    cvc::state::instance(test_ctx)(key).value(0);
   }
 
   // Trigger from root level
   hierarchy_callbacks.store(0);
-  cvcstate("perf.chain.hier.level0").value(1);
+  cvc::state::instance(test_ctx)("perf.chain.hier.level0").value(1);
 
   boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
 
@@ -3645,7 +3695,7 @@ TEST(StateTest, PerformanceCallbackChains) {
   for (int i = 0; i < CONCURRENT_NODES; ++i) {
     std::string key = "perf.chain.concurrent." + boost::lexical_cast<std::string>(i);
 
-    auto conn = cvcstate(key).valueChanged.connect([&concurrent_callbacks]() {
+    auto conn = cvc::state::instance(test_ctx)(key).valueChanged.connect([&concurrent_callbacks]() {
       concurrent_callbacks++;
       // Simulate some work
       volatile int dummy = 0;
@@ -3657,14 +3707,14 @@ TEST(StateTest, PerformanceCallbackChains) {
     concurrent_conns.push_back(conn);
 
     // Initialize with -1 so any value >= 0 will trigger change
-    cvcstate(key).value(-1);
+    cvc::state::instance(test_ctx)(key).value(-1);
   }
 
   // Trigger all simultaneously
   concurrent_callbacks.store(0);
   for (int i = 0; i < CONCURRENT_NODES; ++i) {
     std::string key = "perf.chain.concurrent." + boost::lexical_cast<std::string>(i);
-    cvcstate(key).value(i);
+    cvc::state::instance(test_ctx)(key).value(i);
   }
 
   boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
@@ -3706,7 +3756,7 @@ TEST(StateTest, PerformanceCallbackChains) {
       << "Callback tests should complete quickly";
 
   // Cleanup
-  cvcstate("perf.chain").reset();
+  cvc::state::instance(test_ctx)("perf.chain").reset();
 }
 
 // ===========================
@@ -3725,13 +3775,13 @@ TEST(StateTest, ValueWithCallback) {
   };
 
   // Connect and get initial value
-  cvcstate("test.future.callback").value(42);
-  int initial = cvcstate("test.future.callback").value<int>(callback);
+  cvc::state::instance(test_ctx)("test.future.callback").value(42);
+  int initial = cvc::state::instance(test_ctx)("test.future.callback").value<int>(callback);
   EXPECT_EQ(initial, 42);
 
   // Change value several times
   for (int i = 0; i < 5; ++i) {
-    cvcstate("test.future.callback").value(100 + i);
+    cvc::state::instance(test_ctx)("test.future.callback").value(100 + i);
     boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
   }
 
@@ -3739,7 +3789,7 @@ TEST(StateTest, ValueWithCallback) {
   EXPECT_GT(callback_count.load(), 0);
   EXPECT_EQ(last_value.load(), 104);
 
-  cvcstate("test.future").reset();
+  cvc::state::instance(test_ctx)("test.future").reset();
 }
 
 TEST(StateTest, WaitForValue) {
@@ -3748,23 +3798,24 @@ TEST(StateTest, WaitForValue) {
   // Thread that sets value after delay
   boost::thread writer([]() {
     boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
-    cvcstate("test.future.wait").value(12345);
+    cvc::state::instance(test_ctx)("test.future.wait").value(12345);
   });
 
   // Wait for value to be set
-  int val = cvcstate("test.future.wait").wait_for_value<int>();
+  int val = cvc::state::instance(test_ctx)("test.future.wait").wait_for_value<int>();
 
   EXPECT_EQ(val, 12345);
-  EXPECT_TRUE(cvcstate("test.future.wait").initialized());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.future.wait").initialized());
 
   writer.join();
-  cvcstate("test.future").reset();
+  cvc::state::instance(test_ctx)("test.future").reset();
 }
 
 TEST(StateTest, WaitForValueWithTimeout) {
   // Test wait with timeout - should timeout
   try {
-    cvcstate("test.future.timeout").wait_for_value<int>(boost::chrono::milliseconds(50));
+    cvc::state::instance(test_ctx)("test.future.timeout")
+        .wait_for_value<int>(boost::chrono::milliseconds(50));
     FAIL() << "Should have thrown timeout exception";
   } catch (const cvc::timeout_error &e) {
     EXPECT_TRUE(std::string(e.what()).find("Timeout") != std::string::npos);
@@ -3773,24 +3824,25 @@ TEST(StateTest, WaitForValueWithTimeout) {
   // Test wait with timeout - should succeed
   boost::thread writer([]() {
     boost::this_thread::sleep_for(boost::chrono::milliseconds(50));
-    cvcstate("test.future.timeout2").value(999);
+    cvc::state::instance(test_ctx)("test.future.timeout2").value(999);
   });
 
-  int val = cvcstate("test.future.timeout2").wait_for_value<int>(boost::chrono::milliseconds(200));
+  int val = cvc::state::instance(test_ctx)("test.future.timeout2")
+                .wait_for_value<int>(boost::chrono::milliseconds(200));
   EXPECT_EQ(val, 999);
 
   writer.join();
-  cvcstate("test.future").reset();
+  cvc::state::instance(test_ctx)("test.future").reset();
 }
 
 TEST(StateTest, ValueFutureGet) {
   // Test state_future blocking get
   boost::thread writer([]() {
     boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
-    cvcstate("test.future.get").value("future_value");
+    cvc::state::instance(test_ctx)("test.future.get").value("future_value");
   });
 
-  auto future = cvcstate("test.future.get").value_future<std::string>();
+  auto future = cvc::state::instance(test_ctx)("test.future.get").value_future<std::string>();
 
   EXPECT_FALSE(future.is_ready());
 
@@ -3800,31 +3852,31 @@ TEST(StateTest, ValueFutureGet) {
   EXPECT_EQ(val, "future_value");
 
   writer.join();
-  cvcstate("test.future").reset();
+  cvc::state::instance(test_ctx)("test.future").reset();
 }
 
 TEST(StateTest, ValueFutureWaitFor) {
   // Test state_future with timeout
-  auto future = cvcstate("test.future.waitfor").value_future<int>();
+  auto future = cvc::state::instance(test_ctx)("test.future.waitfor").value_future<int>();
 
   // Should timeout
   EXPECT_FALSE(future.wait_for(boost::chrono::milliseconds(50)));
   EXPECT_FALSE(future.is_ready());
 
   // Set value
-  cvcstate("test.future.waitfor").value(777);
+  cvc::state::instance(test_ctx)("test.future.waitfor").value(777);
 
   // Should succeed immediately
   EXPECT_TRUE(future.wait_for(boost::chrono::milliseconds(10)));
   EXPECT_TRUE(future.is_ready());
   EXPECT_EQ(future.get(), 777);
 
-  cvcstate("test.future").reset();
+  cvc::state::instance(test_ctx)("test.future").reset();
 }
 
 TEST(StateTest, ValueFutureGetFor) {
   // Test state_future get with timeout
-  auto future = cvcstate("test.future.getfor").value_future<double>();
+  auto future = cvc::state::instance(test_ctx)("test.future.getfor").value_future<double>();
 
   // Should timeout
   try {
@@ -3837,7 +3889,7 @@ TEST(StateTest, ValueFutureGetFor) {
   // Start writer thread
   boost::thread writer([]() {
     boost::this_thread::sleep_for(boost::chrono::milliseconds(50));
-    cvcstate("test.future.getfor").value(3.14159);
+    cvc::state::instance(test_ctx)("test.future.getfor").value(3.14159);
   });
 
   // Should succeed with longer timeout
@@ -3845,7 +3897,7 @@ TEST(StateTest, ValueFutureGetFor) {
   EXPECT_DOUBLE_EQ(val, 3.14159);
 
   writer.join();
-  cvcstate("test.future").reset();
+  cvc::state::instance(test_ctx)("test.future").reset();
 }
 
 TEST(StateTest, DataWithCallback) {
@@ -3861,40 +3913,43 @@ TEST(StateTest, DataWithCallback) {
   };
 
   // Set initial data and connect callback
-  cvcstate("test.future.datacb").data(std::string("initial"));
-  std::string initial = cvcstate("test.future.datacb").data<std::string>(callback);
+  cvc::state::instance(test_ctx)("test.future.datacb").data(std::string("initial"));
+  std::string initial =
+      cvc::state::instance(test_ctx)("test.future.datacb").data<std::string>(callback);
   EXPECT_EQ(initial, "initial");
 
   // Change data several times
   for (int i = 0; i < 5; ++i) {
-    cvcstate("test.future.datacb").data(std::string("data_") + boost::lexical_cast<std::string>(i));
+    cvc::state::instance(test_ctx)("test.future.datacb")
+        .data(std::string("data_") + boost::lexical_cast<std::string>(i));
     boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
   }
 
   EXPECT_GT(callback_count.load(), 0);
 
-  cvcstate("test.future").reset();
+  cvc::state::instance(test_ctx)("test.future").reset();
 }
 
 TEST(StateTest, WaitForData) {
   // Test blocking wait for data
   boost::thread writer([]() {
     boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
-    cvcstate("test.future.waitdata").data(42);
+    cvc::state::instance(test_ctx)("test.future.waitdata").data(42);
   });
 
-  int val = cvcstate("test.future.waitdata").wait_for_data<int>();
+  int val = cvc::state::instance(test_ctx)("test.future.waitdata").wait_for_data<int>();
 
   EXPECT_EQ(val, 42);
 
   writer.join();
-  cvcstate("test.future").reset();
+  cvc::state::instance(test_ctx)("test.future").reset();
 }
 
 TEST(StateTest, WaitForDataWithTimeout) {
   // Test data wait with timeout - should timeout
   try {
-    cvcstate("test.future.datatimeout").wait_for_data<int>(boost::chrono::milliseconds(50));
+    cvc::state::instance(test_ctx)("test.future.datatimeout")
+        .wait_for_data<int>(boost::chrono::milliseconds(50));
     FAIL() << "Should have thrown timeout exception";
   } catch (const cvc::timeout_error &e) {
     EXPECT_TRUE(std::string(e.what()).find("Timeout") != std::string::npos);
@@ -3903,15 +3958,15 @@ TEST(StateTest, WaitForDataWithTimeout) {
   // Test wait with timeout - should succeed
   boost::thread writer([]() {
     boost::this_thread::sleep_for(boost::chrono::milliseconds(50));
-    cvcstate("test.future.datatimeout2").data(std::string("success"));
+    cvc::state::instance(test_ctx)("test.future.datatimeout2").data(std::string("success"));
   });
 
-  std::string val = cvcstate("test.future.datatimeout2")
+  std::string val = cvc::state::instance(test_ctx)("test.future.datatimeout2")
                         .wait_for_data<std::string>(boost::chrono::milliseconds(200));
   EXPECT_EQ(val, "success");
 
   writer.join();
-  cvcstate("test.future").reset();
+  cvc::state::instance(test_ctx)("test.future").reset();
 }
 
 TEST(StateTest, MultipleFuturesOnSameState) {
@@ -3923,7 +3978,7 @@ TEST(StateTest, MultipleFuturesOnSameState) {
   for (int i = 0; i < num_futures; ++i) {
     threads.emplace_back([&success_count]() {
       try {
-        auto future = cvcstate("test.future.multiple").value_future<int>();
+        auto future = cvc::state::instance(test_ctx)("test.future.multiple").value_future<int>();
         int val = future.get_for(boost::chrono::milliseconds(500));
         if (val == 888) {
           success_count++;
@@ -3938,7 +3993,7 @@ TEST(StateTest, MultipleFuturesOnSameState) {
   boost::this_thread::sleep_for(boost::chrono::milliseconds(50));
 
   // Set value - all futures should be notified
-  cvcstate("test.future.multiple").value(888);
+  cvc::state::instance(test_ctx)("test.future.multiple").value(888);
 
   for (auto &t : threads) {
     t.join();
@@ -3946,7 +4001,7 @@ TEST(StateTest, MultipleFuturesOnSameState) {
 
   EXPECT_EQ(success_count.load(), num_futures);
 
-  cvcstate("test.future").reset();
+  cvc::state::instance(test_ctx)("test.future").reset();
 }
 
 TEST(StateTest, FutureProducerConsumerPattern) {
@@ -3958,7 +4013,8 @@ TEST(StateTest, FutureProducerConsumerPattern) {
   boost::thread consumer([&consumed, num_items]() {
     for (int i = 0; i < num_items; ++i) {
       std::string key = "test.future.queue.item" + boost::lexical_cast<std::string>(i);
-      int val = cvcstate(key).wait_for_value<int>(boost::chrono::milliseconds(1000));
+      int val = cvc::state::instance(test_ctx)(key).wait_for_value<int>(
+          boost::chrono::milliseconds(1000));
       EXPECT_EQ(val, i * 10);
       consumed++;
     }
@@ -3969,7 +4025,7 @@ TEST(StateTest, FutureProducerConsumerPattern) {
     for (int i = 0; i < num_items; ++i) {
       boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
       std::string key = "test.future.queue.item" + boost::lexical_cast<std::string>(i);
-      cvcstate(key).value(i * 10);
+      cvc::state::instance(test_ctx)(key).value(i * 10);
     }
   });
 
@@ -3978,7 +4034,7 @@ TEST(StateTest, FutureProducerConsumerPattern) {
 
   EXPECT_EQ(consumed.load(), num_items);
 
-  cvcstate("test.future").reset();
+  cvc::state::instance(test_ctx)("test.future").reset();
 }
 
 // ===========================
@@ -4216,162 +4272,166 @@ TEST_F(StateDataFixture, UnregisteredTypeReturnsMangled) {
 
 TEST(StateTest, ResetWithoutChildren) {
   // Create a state hierarchy
-  cvcstate("test.reset_params.parent").value("parent_value");
-  cvcstate("test.reset_params.parent.child1").value("child1_value");
-  cvcstate("test.reset_params.parent.child2").value("child2_value");
+  cvc::state::instance(test_ctx)("test.reset_params.parent").value("parent_value");
+  cvc::state::instance(test_ctx)("test.reset_params.parent.child1").value("child1_value");
+  cvc::state::instance(test_ctx)("test.reset_params.parent.child2").value("child2_value");
 
-  EXPECT_TRUE(cvcstate("test.reset_params.parent").initialized());
-  EXPECT_TRUE(cvcstate("test.reset_params.parent.child1").initialized());
-  EXPECT_TRUE(cvcstate("test.reset_params.parent.child2").initialized());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset_params.parent").initialized());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset_params.parent.child1").initialized());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset_params.parent.child2").initialized());
 
   // Reset parent without resetting children
-  cvcstate("test.reset_params.parent").reset(false, true);
+  cvc::state::instance(test_ctx)("test.reset_params.parent").reset(false, true);
 
   // Parent should be reset
-  EXPECT_FALSE(cvcstate("test.reset_params.parent").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset_params.parent").initialized());
 
   // Children are detached - accessing them via parent path creates new states
   // The old children exist as shared_ptrs elsewhere but are no longer accessible via parent
   // This is the expected behavior of reset(false, ...)
-  EXPECT_FALSE(cvcstate("test.reset_params.parent.child1").initialized());
-  EXPECT_FALSE(cvcstate("test.reset_params.parent.child2").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset_params.parent.child1").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset_params.parent.child2").initialized());
 
   // Clean up
-  cvcstate("test.reset_params").reset();
+  cvc::state::instance(test_ctx)("test.reset_params").reset();
 }
 
 TEST(StateTest, ResetWithChildren) {
   // Create a state hierarchy
-  cvcstate("test.reset_children.parent").value("parent_value");
-  cvcstate("test.reset_children.parent.child1").value("child1_value");
-  cvcstate("test.reset_children.parent.child2").value("child2_value");
-  cvcstate("test.reset_children.parent.child2.grandchild").value("grandchild_value");
+  cvc::state::instance(test_ctx)("test.reset_children.parent").value("parent_value");
+  cvc::state::instance(test_ctx)("test.reset_children.parent.child1").value("child1_value");
+  cvc::state::instance(test_ctx)("test.reset_children.parent.child2").value("child2_value");
+  cvc::state::instance(test_ctx)("test.reset_children.parent.child2.grandchild")
+      .value("grandchild_value");
 
-  EXPECT_TRUE(cvcstate("test.reset_children.parent").initialized());
-  EXPECT_TRUE(cvcstate("test.reset_children.parent.child1").initialized());
-  EXPECT_TRUE(cvcstate("test.reset_children.parent.child2").initialized());
-  EXPECT_TRUE(cvcstate("test.reset_children.parent.child2.grandchild").initialized());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset_children.parent").initialized());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset_children.parent.child1").initialized());
+  EXPECT_TRUE(cvc::state::instance(test_ctx)("test.reset_children.parent.child2").initialized());
+  EXPECT_TRUE(
+      cvc::state::instance(test_ctx)("test.reset_children.parent.child2.grandchild").initialized());
 
   // Reset parent with children (default behavior)
-  cvcstate("test.reset_children.parent").reset(true, true);
+  cvc::state::instance(test_ctx)("test.reset_children.parent").reset(true, true);
 
   // Parent and all children should be reset
-  EXPECT_FALSE(cvcstate("test.reset_children.parent").initialized());
-  EXPECT_FALSE(cvcstate("test.reset_children.parent.child1").initialized());
-  EXPECT_FALSE(cvcstate("test.reset_children.parent.child2").initialized());
-  EXPECT_FALSE(cvcstate("test.reset_children.parent.child2.grandchild").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset_children.parent").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset_children.parent.child1").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset_children.parent.child2").initialized());
+  EXPECT_FALSE(
+      cvc::state::instance(test_ctx)("test.reset_children.parent.child2.grandchild").initialized());
 
   // Clean up
-  cvcstate("test.reset_children").reset();
+  cvc::state::instance(test_ctx)("test.reset_children").reset();
 }
 
 TEST(StateTest, ResetWithoutCallbacks) {
   // Track callback invocations
   std::atomic<int> callbackCount(0);
 
-  auto conn = cvcstate("test.reset_callbacks.watched").valueChanged.connect([&callbackCount]() {
-    callbackCount++;
-  });
+  auto conn = cvc::state::instance(test_ctx)("test.reset_callbacks.watched")
+                  .valueChanged.connect([&callbackCount]() { callbackCount++; });
 
-  cvcstate("test.reset_callbacks.watched").value("initial_value");
+  cvc::state::instance(test_ctx)("test.reset_callbacks.watched").value("initial_value");
   int initialCount = callbackCount.load();
   EXPECT_GT(initialCount, 0);
 
   // Reset without firing callbacks
-  cvcstate("test.reset_callbacks.watched").reset(true, false);
+  cvc::state::instance(test_ctx)("test.reset_callbacks.watched").reset(true, false);
 
   // Callback should not have been triggered by reset
   EXPECT_EQ(callbackCount.load(), initialCount);
-  EXPECT_FALSE(cvcstate("test.reset_callbacks.watched").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset_callbacks.watched").initialized());
 
   // Clean up
-  cvcstate("test.reset_callbacks").reset();
+  cvc::state::instance(test_ctx)("test.reset_callbacks").reset();
 }
 
 TEST(StateTest, ResetWithCallbacks) {
   // Track callback invocations
   std::atomic<int> callbackCount(0);
 
-  auto conn =
-      cvcstate("test.reset_with_callbacks.watched").valueChanged.connect([&callbackCount]() {
-        callbackCount++;
-      });
+  auto conn = cvc::state::instance(test_ctx)("test.reset_with_callbacks.watched")
+                  .valueChanged.connect([&callbackCount]() { callbackCount++; });
 
-  cvcstate("test.reset_with_callbacks.watched").value("initial_value");
+  cvc::state::instance(test_ctx)("test.reset_with_callbacks.watched").value("initial_value");
   callbackCount.store(0); // Reset counter after initialization
 
   // Reset with firing callbacks (default behavior)
-  cvcstate("test.reset_with_callbacks.watched").reset(true, true);
+  cvc::state::instance(test_ctx)("test.reset_with_callbacks.watched").reset(true, true);
 
   // Callback should have been triggered by reset
   EXPECT_GT(callbackCount.load(), 0);
-  EXPECT_FALSE(cvcstate("test.reset_with_callbacks.watched").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.reset_with_callbacks.watched").initialized());
 
   // Clean up
-  cvcstate("test.reset_with_callbacks").reset();
+  cvc::state::instance(test_ctx)("test.reset_with_callbacks").reset();
 }
 
 TEST(StateTest, ResetParameterCombinations) {
   // Test all four combinations of resetChildren and fireCallbacks
 
   // Setup 1: reset(false, false) - no children, no callbacks
-  cvcstate("test.combinations.case1.parent").value("value");
-  cvcstate("test.combinations.case1.parent.child").value("child_value");
+  cvc::state::instance(test_ctx)("test.combinations.case1.parent").value("value");
+  cvc::state::instance(test_ctx)("test.combinations.case1.parent.child").value("child_value");
 
   std::atomic<int> count1(0);
-  auto conn1 =
-      cvcstate("test.combinations.case1.parent").valueChanged.connect([&count1]() { count1++; });
+  auto conn1 = cvc::state::instance(test_ctx)("test.combinations.case1.parent")
+                   .valueChanged.connect([&count1]() { count1++; });
   count1.store(0);
 
-  cvcstate("test.combinations.case1.parent").reset(false, false);
-  EXPECT_FALSE(cvcstate("test.combinations.case1.parent").initialized());
-  EXPECT_FALSE(cvcstate("test.combinations.case1.parent.child").initialized()); // Detached
+  cvc::state::instance(test_ctx)("test.combinations.case1.parent").reset(false, false);
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.combinations.case1.parent").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.combinations.case1.parent.child")
+                   .initialized()); // Detached
   EXPECT_EQ(count1.load(), 0);
 
   // Setup 2: reset(false, true) - no children, yes callbacks
-  cvcstate("test.combinations.case2.parent").value("value");
-  cvcstate("test.combinations.case2.parent.child").value("child_value");
+  cvc::state::instance(test_ctx)("test.combinations.case2.parent").value("value");
+  cvc::state::instance(test_ctx)("test.combinations.case2.parent.child").value("child_value");
 
   std::atomic<int> count2(0);
-  auto conn2 =
-      cvcstate("test.combinations.case2.parent").valueChanged.connect([&count2]() { count2++; });
+  auto conn2 = cvc::state::instance(test_ctx)("test.combinations.case2.parent")
+                   .valueChanged.connect([&count2]() { count2++; });
   count2.store(0);
 
-  cvcstate("test.combinations.case2.parent").reset(false, true);
-  EXPECT_FALSE(cvcstate("test.combinations.case2.parent").initialized());
-  EXPECT_FALSE(cvcstate("test.combinations.case2.parent.child").initialized()); // Detached
+  cvc::state::instance(test_ctx)("test.combinations.case2.parent").reset(false, true);
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.combinations.case2.parent").initialized());
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.combinations.case2.parent.child")
+                   .initialized()); // Detached
   EXPECT_GT(count2.load(), 0);
 
   // Setup 3: reset(true, false) - yes children, no callbacks
-  cvcstate("test.combinations.case3.parent").value("value");
-  cvcstate("test.combinations.case3.parent.child").value("child_value");
+  cvc::state::instance(test_ctx)("test.combinations.case3.parent").value("value");
+  cvc::state::instance(test_ctx)("test.combinations.case3.parent.child").value("child_value");
 
   std::atomic<int> count3(0);
-  auto conn3 =
-      cvcstate("test.combinations.case3.parent").valueChanged.connect([&count3]() { count3++; });
+  auto conn3 = cvc::state::instance(test_ctx)("test.combinations.case3.parent")
+                   .valueChanged.connect([&count3]() { count3++; });
   count3.store(0);
 
-  cvcstate("test.combinations.case3.parent").reset(true, false);
-  EXPECT_FALSE(cvcstate("test.combinations.case3.parent").initialized());
-  EXPECT_FALSE(cvcstate("test.combinations.case3.parent.child").initialized());
+  cvc::state::instance(test_ctx)("test.combinations.case3.parent").reset(true, false);
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.combinations.case3.parent").initialized());
+  EXPECT_FALSE(
+      cvc::state::instance(test_ctx)("test.combinations.case3.parent.child").initialized());
   EXPECT_EQ(count3.load(), 0);
 
   // Setup 4: reset(true, true) - yes children, yes callbacks (default)
-  cvcstate("test.combinations.case4.parent").value("value");
-  cvcstate("test.combinations.case4.parent.child").value("child_value");
+  cvc::state::instance(test_ctx)("test.combinations.case4.parent").value("value");
+  cvc::state::instance(test_ctx)("test.combinations.case4.parent.child").value("child_value");
 
   std::atomic<int> count4(0);
-  auto conn4 =
-      cvcstate("test.combinations.case4.parent").valueChanged.connect([&count4]() { count4++; });
+  auto conn4 = cvc::state::instance(test_ctx)("test.combinations.case4.parent")
+                   .valueChanged.connect([&count4]() { count4++; });
   count4.store(0);
 
-  cvcstate("test.combinations.case4.parent").reset(true, true);
-  EXPECT_FALSE(cvcstate("test.combinations.case4.parent").initialized());
-  EXPECT_FALSE(cvcstate("test.combinations.case4.parent.child").initialized());
+  cvc::state::instance(test_ctx)("test.combinations.case4.parent").reset(true, true);
+  EXPECT_FALSE(cvc::state::instance(test_ctx)("test.combinations.case4.parent").initialized());
+  EXPECT_FALSE(
+      cvc::state::instance(test_ctx)("test.combinations.case4.parent.child").initialized());
   EXPECT_GT(count4.load(), 0);
 
   // Clean up
-  cvcstate("test.combinations").reset();
+  cvc::state::instance(test_ctx)("test.combinations").reset();
 }
 
 // ===========================


### PR DESCRIPTION
Migrates the broad `TEST(StateTest, ...)` cases off the deprecated `cvcstate` macro / zero-arg `cvc::state::instance()` singleton onto a file-scope `cvc::app test_ctx` plus `cvc::state::instance(test_ctx)`.

Fixture-based tests (`StateDataFixture`, `StateObjectFixture`) continue to use their per-test `cvc::app ctx` member, so each test still gets its own isolated app.

Also fixes `state::valueData<T>()` in `inc/cvc/state.h`: it was looking up referenced data nodes through the global zero-arg singleton, which caused `StateDataFixture.ValueData` to fail once that fixture stopped using the global root. It now routes through the bound `_ctx` so it shares the per-app state root the parent node belongs to.

Local: 590/590 with `-DCVC_USING_XMLRPC=ON` and OFF (one rare flaky concurrency test, pre-existing).