### PR TITLE
state: drop legacy zero-arg singleton, _instance cache, and cvcstate macro

### DIFF
--- a/inc/cvc/state.h
+++ b/inc/cvc/state.h
@@ -168,9 +168,6 @@ public:
 
   // ***** Main API
 
-  // Use instance() to grab a reference to the singleton application object.
-  static state &instance();
-
   // Per-app root state. Lazily creates and caches a root state on the
   // given app's data map, decoupling state ownership from app::instance().
   // Fires registered _startup callbacks the first time a root is created.
@@ -436,9 +433,7 @@ protected:
   boost::condition_variable _valueCondition;
   boost::condition_variable _dataCondition;
 
-  static state_ptr instancePtr();
   static state_ptr instancePtr(app &ctx);
-  static state_ptr _instance;
   static boost::mutex _instanceMutex;
   static boost::mutex _startupMutex;
   static bool _startupFired;
@@ -461,9 +456,6 @@ state_future<T>::state_future(state *s) : _state(s), _ready(false), _has_value(f
 
 template <typename T> T state_future<T>::getValue() { return _state->template value<T>(); }
 } // namespace CVC_NAMESPACE
-
-// Shorthand to access the cvc::state object from anywhere
-#define cvcstate CVC_NAMESPACE::state::instance()
 
 // PascalCase aliases for consumer compat shims bypassed on case-insensitive
 // filesystems (macOS).

--- a/src/cvc/state.cpp
+++ b/src/cvc/state.cpp
@@ -45,7 +45,6 @@ namespace CVC_NAMESPACE {
 // covers function symbols, not data members.
 state::init_func_vec state::_startup;
 state::app_init_func_vec state::_appStartup;
-state::state_ptr state::_instance;
 boost::mutex state::_instanceMutex;
 boost::mutex state::_startupMutex;
 bool state::_startupFired = false;
@@ -82,16 +81,6 @@ state::~state() { destroyed(); }
 // ------------------
 // state::instancePtr
 // ------------------
-// Purpose:
-//   Returns a pointer to the root state object singleton. Currently
-//   stores the root state object on the cvcapp datamap, though this
-//   might not always be the case.
-// ---- Change History ----
-// 02/18/2012 -- Joe R. -- Creation.
-// 01/12/2014 -- Joe R. -- Added startup function calls to do initialization based on cvcstate.
-//                         Also moved xmlrpc server thread start elsewhere.
-state::state_ptr state::instancePtr() { return instancePtr(app::instance()); }
-
 // ------------------
 // state::instancePtr
 // ------------------
@@ -101,8 +90,11 @@ state::state_ptr state::instancePtr() { return instancePtr(app::instance()); }
 //   _startup callbacks once per process the first time any root is
 //   created.
 // ---- Change History ----
+// 02/18/2012 -- Joe R. -- Creation.
+// 01/12/2014 -- Joe R. -- Added startup function calls to do initialization based on cvcstate.
+//                         Also moved xmlrpc server thread start elsewhere.
 // 05/03/2026 -- Joe R. -- Per-app overload, decoupling state root from
-//                         app::instance().
+//                         app::instance(). Legacy zero-arg form removed.
 state::state_ptr state::instancePtr(app &ctx) {
   bool do_startup = false;
   bool fire_app_startup = false;
@@ -119,11 +111,6 @@ state::state_ptr state::instancePtr(app &ctx) {
       ptr.reset(new state(ctx));
       ctx.data(statekey, ptr);
       fire_app_startup = true;
-      // Cache root of app::instance() for the legacy zero-arg path
-      // so existing callers continue to share the same object.
-      if (&ctx == &app::instance()) {
-        _instance = ptr;
-      }
     }
   }
 
@@ -163,15 +150,6 @@ state::state_ptr state::instancePtr(app &ctx) {
 // Purpose:
 //   Returns a reference to the root state object for the given app.
 state &state::instance(app &ctx) { return *instancePtr(ctx); }
-
-// ---------------
-// state::instance
-// ---------------
-// Purpose:
-//   Returns a reference to the singleton root object.
-// ---- Change History ----
-// 02/18/2012 -- Joe R. -- Creation.
-state &state::instance() { return *instancePtr(); }
 
 // --------------
 // state::lastMod


### PR DESCRIPTION
Capstone of the per-app state migration (PRs #30-#35). With every production and test caller now routing through `cvc::state::instance(cvc::app&)`, the legacy singleton API surface is unreachable and is removed:

- `cvcstate` macro (`inc/cvc/state.h`)
- `cvc::state::instance()` zero-arg overload (declaration + definition)
- `cvc::state::instancePtr()` zero-arg shim
- `state::_instance` static cache + the `&ctx == &app::instance()` cache-write block in `instancePtr(app&)`

State roots are now exclusively per-app, stored on the app's data map under `"__state"`.

Local: 590/590 with `-DCVC_USING_XMLRPC=ON` and OFF.