### PR TITLE
app: drop legacy app::instance() singleton API and cvcapp macro

### DIFF
--- a/inc/cvc/app.h
+++ b/inc/cvc/app.h
@@ -113,9 +113,6 @@ public:
 
   // ***** Main API
 
-  // Use instance() to grab a reference to the singleton application object.
-  static app &instance();
-
   // Regular data access
   data_map data();
   boost::any data(const std::string &key);
@@ -601,11 +598,6 @@ template <class T> data_type dataType();
 // Returns a human-readable name for the data_type enum, or empty string.
 std::string dataTypeName(data_type dt);
 } // namespace CVC_NAMESPACE
-
-// Shorthand to access the app object from anywhere.
-// DEPRECATED: retained only while migrating callers to explicit app& params.
-// TODO: remove once all cvcapp usage has been migrated.
-#define cvcapp CVC_NAMESPACE::app::instance()
 
 // Guarded PascalCase aliases for case-insensitive filesystems (macOS) where
 // consumer compat shims are bypassed.

--- a/src/cvc/app.cpp
+++ b/src/cvc/app.cpp
@@ -184,11 +184,6 @@ void app::wait_for_threads() {
   }
 }
 
-app &app::instance() {
-  app &app = *instancePtr();
-  return app;
-}
-
 app::app()
     : _maxPoolSize(boost::thread::hardware_concurrency() > 0 ? boost::thread::hardware_concurrency()
                                                              : 4),


### PR DESCRIPTION
Capstone of Phase C: with every production and test caller migrated to explicit `cvc::app&` parameters (see PRs #25-#36), the `app` singleton's public surface is no longer reachable and is removed:

- `cvcapp` macro (`inc/cvc/app.h`)
- `cvc::app::instance()` public method (declaration + definition)

Internal singleton machinery (`_instance`, `_instanceMutex`, `instancePtr()`, the `wait_for_threads` atexit registration) is left in place for this PR; nothing reaches it through the public API, so the process-wide `app` singleton is never constructed. Follow-ups can excise the dead internals.

Apps must now be created and passed explicitly.

Local: 590/590 with `-DCVC_USING_XMLRPC=ON` and OFF (pre-existing flaky `SceneGraphTest` that passes on retry).