### PR TITLE
docs: refresh README and API docs for explicit-app API

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ See [docs/SDF_LIBRARY.md](docs/SDF_LIBRARY.md) for complete documentation.
 ### API Documentation
 
 - **[docs/APP_API.md](docs/APP_API.md)** - Complete application framework API
-  - Singleton application object (`cvcapp`)
+  - Per-app context object (`cvc::app`) — explicit instances, no singleton
   - Data management with `boost::any` type-safe storage
   - Property system for configuration
   - Thread management with progress tracking

--- a/docs/APP_API.md
+++ b/docs/APP_API.md
@@ -61,15 +61,13 @@ cvc::app app;          // default-constructed: registers libcvc's built-in types
 cvc::app bare(cvc::no_init_t{});
 ```
 
-> **Migration note.** Earlier versions of libcvc exposed `cvc::app`
-> as a process-wide singleton accessed via `app::instance()` and the
-> `cvcapp` macro. Both are still present so existing code keeps
-> compiling, but they are now deprecated transitional shims that
-> simply forward to a hidden default instance and will be removed in
-> a future release. New code — and any code being touched — should
-> construct an `app` explicitly and pass it as `cvc::app& ctx`. The
-> RAII helpers `thread_info`, `thread_feedback`, and `scoped_lock`
-> all accept a leading `app& ctx` parameter for this reason.
+> **History.** Earlier versions of libcvc exposed `cvc::app` as a
+> process-wide singleton accessed via `app::instance()` and the
+> `cvcapp` macro. Both have been removed; `cvc::app` is now
+> exclusively constructed by callers and passed as `cvc::app& ctx`.
+> The RAII helpers `thread_info`, `thread_feedback`, and
+> `scoped_lock` all take a leading `app& ctx` parameter for this
+> reason.
 
 **Key characteristics:**
 - Thread-safe with fine-grained locking
@@ -163,18 +161,6 @@ don't want the global IO handlers fired up.
 `cvc::app` is move-only-ish (the copy constructor is private).
 Construct one at the scope that owns it (`main`, a test fixture, a
 cluster-node `cvcsrv` instance) and pass references downward.
-
-### Deprecated: `app::instance()` / `cvcapp`
-
-```cpp
-// Still compiles; do not use in new code.
-cvc::app& legacy = cvc::app::instance();
-cvcapp.data("key", value);              // macro form
-```
-
-Both forms forward to a single hidden process-wide instance and
-exist only to keep older callers compiling while they migrate. They
-will be removed in a future release; treat them as legacy shims.
 
 ## Data Management
 
@@ -739,10 +725,7 @@ app.thisThreadInfo("Initializing...");
 ```cpp
 class thread_feedback {
 public:
-    // Preferred: bind to a specific app context.
     thread_feedback(app& ctx, const std::string& key = "");
-    // Legacy: routes through app::instance() — deprecated.
-    thread_feedback(const std::string& key = "");
     ~thread_feedback();
 };
 ```
@@ -771,10 +754,7 @@ app.startThread("worker", [&app]{ workerThread(app); });
 ```cpp
 class thread_info {
 public:
-    // Preferred: bind to a specific app context.
     thread_info(app& ctx, const std::string& info = "running");
-    // Legacy: routes through app::instance() — deprecated.
-    thread_info(const std::string& info = "running");
     ~thread_info();
 };
 ```
@@ -897,12 +877,8 @@ writeToFile("output.dat", data);
 ```cpp
 class scoped_lock {
 public:
-    // Preferred: bind to a specific app context.
     scoped_lock(app& ctx,
                 const std::string& name,
-                const std::string& info = std::string());
-    // Legacy: routes through app::instance() — deprecated.
-    scoped_lock(const std::string& name,
                 const std::string& info = std::string());
     ~scoped_lock();
 };

--- a/docs/GRAPHICS_DATA_DRIVEN_UPDATES.md
+++ b/docs/GRAPHICS_DATA_DRIVEN_UPDATES.md
@@ -77,7 +77,7 @@ GraphicsNode node("my_mesh");
 node.setGeometry(initialGeometry);
 
 // Sync to state tree
-cvc::state& graphics = cvc::state::instance()("graphics");
+cvc::state& graphics = cvc::state::instance(app)("graphics");
 node.syncToState(graphics);
 
 // Connect to state data changes

--- a/docs/IMAGE_PROCESSING_ALGORITHMS.md
+++ b/docs/IMAGE_PROCESSING_ALGORITHMS.md
@@ -94,7 +94,7 @@ volume.anisotropicDiffusion(20);
 ### Performance Notes
 - In-place modification with one temporary buffer
 - Boundary voxels use zero-gradient assumption
-- Thread-safe with progress reporting via `cvcapp.threadProgress()`
+- Thread-safe with progress reporting via `app.threadProgress()`
 
 ---
 
@@ -367,7 +367,7 @@ Each slice undergoes 8 directional passes:
 
 **Progress Reporting:**
 - Total steps: 3 × depth (bottom-up + top-down + stretching)
-- Progress reported via `cvcapp.threadProgress()`
+- Progress reported via `app.threadProgress()`
 
 **Computational Complexity:**
 - Time: O(depth × width × height × passes)
@@ -664,7 +664,7 @@ volume.gdtvFilter(1.8, 0.7, 2, 0);  // Minimal smoothing at edges
 All algorithms use `thread_info` for context management and are thread-safe at the algorithm level. However, simultaneous operations on the same voxels object are not safe.
 
 ### Progress Reporting
-All algorithms report progress through `cvcapp.threadProgress()`:
+All algorithms report progress through `app.threadProgress()`:
 - Values range from 0.0 to 1.0
 - Called periodically during processing
 - Can be used to update progress bars or cancel operations

--- a/docs/STATE_API.md
+++ b/docs/STATE_API.md
@@ -42,6 +42,23 @@ The `cvc::state` class provides a thread-safe, hierarchical key-value store with
 - **Thread safety**: All operations protected by mutex locks
 - **Serialization**: JSON import/export for persistence
 
+### Per-app state roots
+
+Each `cvc::app` owns its own state tree. The root is obtained
+through `cvc::state::instance(app&)`:
+
+```cpp
+cvc::app app;
+cvc::state& root = cvc::state::instance(app);
+root("app.window.width").value(1920);
+```
+
+The examples in this document assume `cvc::app app;` is in scope
+and use `state::instance(app)` as the root accessor. Earlier
+versions of libcvc exposed the root through a global `cvcstate`
+macro / `state::instance()` zero-arg singleton; those have been
+removed — every caller must now pass the owning `app&` explicitly.
+
 ## Core Concepts
 
 ### State Tree
@@ -70,7 +87,7 @@ root
 State nodes emit signals when values/data change, enabling reactive programming:
 
 ```cpp
-cvcstate("sensor.temperature").valueChanged.connect([](std::string val) {
+state::instance(app)("sensor.temperature").valueChanged.connect([](std::string val) {
     std::cout << "Temperature: " << val << std::endl;
 });
 ```
@@ -81,10 +98,10 @@ cvcstate("sensor.temperature").valueChanged.connect([](std::string val) {
 
 ```cpp
 // Dot notation creates parent nodes automatically
-cvcstate("level1.level2.level3.key");
+state::instance(app)("level1.level2.level3.key");
 
 // Equivalent to:
-//   cvcstate("level1")
+//   state::instance(app)("level1")
 //     .child("level2")
 //     .child("level3")
 //     .child("key")
@@ -94,7 +111,7 @@ cvcstate("level1.level2.level3.key");
 
 ```cpp
 // Setting a deep path creates all intermediate nodes
-cvcstate("new.path.to.value").value(42);
+state::instance(app)("new.path.to.value").value(42);
 
 // Creates hierarchy:
 //   root -> new -> path -> to -> value
@@ -108,13 +125,13 @@ cvcstate("new.path.to.value").value(42);
 #include <cvc/state.h>
 
 // Global convenience function creates/accesses nodes
-state s1 = cvcstate("app.window.width");
+state s1 = state::instance(app)("app.window.width");
 
 // Direct construction
 state s2("app.window.height");
 
 // Access via parent
-state parent = cvcstate("app.window");
+state parent = state::instance(app)("app.window");
 state child = parent.child("title");
 ```
 
@@ -122,22 +139,22 @@ state child = parent.child("title");
 
 ```cpp
 // Set value (converted to string internally)
-cvcstate("count").value(42);
-cvcstate("ratio").value(3.14159);
-cvcstate("name").value(std::string("libcvc"));
+state::instance(app)("count").value(42);
+state::instance(app)("ratio").value(3.14159);
+state::instance(app)("name").value(std::string("libcvc"));
 
 // Get value with type conversion
-int count = cvcstate("count").value<int>();
-double ratio = cvcstate("ratio").value<double>();
-std::string name = cvcstate("name").value<std::string>();
+int count = state::instance(app)("count").value<int>();
+double ratio = state::instance(app)("ratio").value<double>();
+std::string name = state::instance(app)("name").value<std::string>();
 
 // Check if value exists
-if (cvcstate("optional.key").initialized()) {
-    int val = cvcstate("optional.key").value<int>();
+if (state::instance(app)("optional.key").initialized()) {
+    int val = state::instance(app)("optional.key").value<int>();
 }
 
 // Get raw string value
-std::string raw = cvcstate("count").value();  // "42"
+std::string raw = state::instance(app)("count").value();  // "42"
 ```
 
 ### Data Operations
@@ -150,18 +167,18 @@ struct Config {
 };
 
 Config cfg{1920, 1080, "dark"};
-cvcstate("app.config").data(cfg);
+state::instance(app)("app.config").data(cfg);
 
 // Retrieve with exact type match
 try {
-    Config loaded = cvcstate("app.config").data<Config>();
+    Config loaded = state::instance(app)("app.config").data<Config>();
 } catch (const cvc::type_conversion_error& e) {
     std::cerr << "Type mismatch: " << e.what() << std::endl;
 }
 
 // Check if data exists
-if (cvcstate("app.config").has_data()) {
-    Config cfg = cvcstate("app.config").data<Config>();
+if (state::instance(app)("app.config").has_data()) {
+    Config cfg = state::instance(app)("app.config").data<Config>();
 }
 ```
 
@@ -169,20 +186,20 @@ if (cvcstate("app.config").has_data()) {
 
 ```cpp
 // Set property (metadata for state node)
-cvcstate("value").property("units", "meters");
-cvcstate("value").property("min", "0.0");
-cvcstate("value").property("max", "100.0");
+state::instance(app)("value").property("units", "meters");
+state::instance(app)("value").property("min", "0.0");
+state::instance(app)("value").property("max", "100.0");
 
 // Get property
-std::string units = cvcstate("value").property("units");
+std::string units = state::instance(app)("value").property("units");
 
 // Check if property exists
-if (cvcstate("value").has_property("units")) {
+if (state::instance(app)("value").has_property("units")) {
     // Property exists
 }
 
 // Get all property keys
-std::vector<std::string> keys = cvcstate("value").property_keys();
+std::vector<std::string> keys = state::instance(app)("value").property_keys();
 ```
 
 ## Advanced Features
@@ -202,26 +219,26 @@ The futures API enables async/await-style programming with state values, providi
 
 ```cpp
 // Wait indefinitely for a value to be set
-int result = cvcstate("computation.result").wait_for_value<int>();
+int result = state::instance(app)("computation.result").wait_for_value<int>();
 
 // Wait with timeout (throws timeout_error on timeout)
-double value = cvcstate("sensor.reading")
+double value = state::instance(app)("sensor.reading")
     .wait_for_value<double>(boost::chrono::seconds(5));
 
 // Wait for data object
-MyStruct data = cvcstate("queue.item").wait_for_data<MyStruct>();
+MyStruct data = state::instance(app)("queue.item").wait_for_data<MyStruct>();
 ```
 
 #### Value Callbacks
 
 ```cpp
 // Register callback that fires when value changes
-int current = cvcstate("counter").value<int>([](int newValue) {
+int current = state::instance(app)("counter").value<int>([](int newValue) {
     std::cout << "Counter changed to: " << newValue << std::endl;
 });
 
 // Callback fires asynchronously whenever counter is updated
-cvcstate("counter").value(current + 1);  // Triggers callback
+state::instance(app)("counter").value(current + 1);  // Triggers callback
 ```
 
 #### Future Objects
@@ -230,7 +247,7 @@ The `value_future<T>()` method returns a `state_future<T>` object for advanced c
 
 ```cpp
 // Get a future object for advanced control
-auto future = cvcstate("async.result").value_future<std::string>();
+auto future = state::instance(app)("async.result").value_future<std::string>();
 
 // Non-blocking check
 if (future.is_ready()) {
@@ -257,14 +274,14 @@ std::string val = future.get();
 // Consumer thread waits for producer
 boost::thread consumer([]() {
     // Blocks until producer sets the value
-    int result = cvcstate("work.result").wait_for_value<int>();
+    int result = state::instance(app)("work.result").wait_for_value<int>();
     std::cout << "Got result: " << result << std::endl;
 });
 
 // Producer thread does work and sets result
 boost::thread producer([]() {
     int result = do_expensive_computation();
-    cvcstate("work.result").value(result);
+    state::instance(app)("work.result").value(result);
 });
 
 consumer.join();
@@ -280,14 +297,14 @@ std::vector<boost::thread> consumers;
 for (int i = 0; i < 5; ++i) {
     consumers.emplace_back([i]() {
         // All threads will be notified when value is set
-        int value = cvcstate("broadcast.value").wait_for_value<int>();
+        int value = state::instance(app)("broadcast.value").wait_for_value<int>();
         std::cout << "Consumer " << i << " got: " << value << std::endl;
     });
 }
 
 // Producer sets value once - all consumers wake up
 boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
-cvcstate("broadcast.value").value(42);
+state::instance(app)("broadcast.value").value(42);
 
 for (auto& t : consumers) {
     t.join();
@@ -299,16 +316,16 @@ for (auto& t : consumers) {
 **Before (inefficient polling):**
 ```cpp
 // Inefficient busy-wait polling
-while (!cvcstate("key").initialized()) {
+while (!state::instance(app)("key").initialized()) {
     boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
 }
-int val = cvcstate("key").value<int>();
+int val = state::instance(app)("key").value<int>();
 ```
 
 **After (efficient futures):**
 ```cpp
 // Efficient blocking wait with condition variables
-int val = cvcstate("key").wait_for_value<int>();
+int val = state::instance(app)("key").wait_for_value<int>();
 ```
 
 #### Futures Implementation Details
@@ -337,19 +354,19 @@ State nodes emit signals when values/data/properties change:
 
 ```cpp
 // Connect to value change signal
-cvcstate("config.theme").valueChanged.connect([](std::string newTheme) {
+state::instance(app)("config.theme").valueChanged.connect([](std::string newTheme) {
     applyTheme(newTheme);
 });
 
 // Connect to data change signal
-cvcstate("mesh.data").dataChanged.connect([]() {
+state::instance(app)("mesh.data").dataChanged.connect([]() {
     // Data changed - reload mesh
-    cvc::geometry mesh = cvcstate("mesh.data").data<cvc::geometry>();
+    cvc::geometry mesh = state::instance(app)("mesh.data").data<cvc::geometry>();
     renderMesh(mesh);
 });
 
 // Connect to property change signal
-cvcstate("slider").propertyChanged.connect([](std::string key, std::string value) {
+state::instance(app)("slider").propertyChanged.connect([](std::string key, std::string value) {
     std::cout << "Property '" << key << "' = " << value << std::endl;
 });
 
@@ -368,15 +385,15 @@ Two states that listen to each other create an infinite loop:
 
 ```cpp
 // ❌ DANGEROUS: Infinite loop
-auto connA = cvcstate("nodeA").valueChanged.connect([]() {
-    cvcstate("nodeB").value("trigger");  // Triggers nodeB's callback
+auto connA = state::instance(app)("nodeA").valueChanged.connect([]() {
+    state::instance(app)("nodeB").value("trigger");  // Triggers nodeB's callback
 });
 
-auto connB = cvcstate("nodeB").valueChanged.connect([]() {
-    cvcstate("nodeA").value("trigger");  // Triggers nodeA's callback → LOOP!
+auto connB = state::instance(app)("nodeB").valueChanged.connect([]() {
+    state::instance(app)("nodeA").value("trigger");  // Triggers nodeA's callback → LOOP!
 });
 
-cvcstate("nodeA").value("start");  // Stack overflow or hang!
+state::instance(app)("nodeA").value("start");  // Stack overflow or hang!
 ```
 
 **2. Deep Callback Chains**
@@ -389,8 +406,8 @@ for (int i = 0; i < 1000; ++i) {
     std::string current = "node" + std::to_string(i);
     std::string next = "node" + std::to_string(i + 1);
     
-    cvcstate(current).valueChanged.connect([next, i]() {
-        cvcstate(next).value(i);  // Each callback triggers the next
+    state::instance(app)(current).valueChanged.connect([next, i]() {
+        state::instance(app)(next).value(i);  // Each callback triggers the next
     });
 }
 ```
@@ -401,9 +418,9 @@ Exponential fan-out can cause performance issues:
 
 ```cpp
 // ⚠️ RISKY: Exponential callback explosion
-cvcstate("parent").valueChanged.connect([]() {
+state::instance(app)("parent").valueChanged.connect([]() {
     for (int i = 0; i < 100; ++i) {
-        cvcstate("child" + std::to_string(i)).value(i);
+        state::instance(app)("child" + std::to_string(i)).value(i);
         // If each child also triggers more callbacks...
     }
 });
@@ -421,17 +438,17 @@ std::atomic<int> nodeA_count(0);
 std::atomic<int> nodeB_count(0);
 const int MAX_ITERATIONS = 10;
 
-auto connA = cvcstate("nodeA").valueChanged.connect([&nodeA_count]() {
+auto connA = state::instance(app)("nodeA").valueChanged.connect([&nodeA_count]() {
     int count = nodeA_count.fetch_add(1);
     if (count < MAX_ITERATIONS) {
-        cvcstate("nodeB").value(count);
+        state::instance(app)("nodeB").value(count);
     }
 });
 
-auto connB = cvcstate("nodeB").valueChanged.connect([&nodeB_count]() {
+auto connB = state::instance(app)("nodeB").valueChanged.connect([&nodeB_count]() {
     int count = nodeB_count.fetch_add(1);
     if (count < MAX_ITERATIONS) {
-        cvcstate("nodeA").value(count);
+        state::instance(app)("nodeA").value(count);
     }
 });
 ```
@@ -452,14 +469,14 @@ struct GuardedCallback {
             return;  // Already processing, skip to prevent loop
         }
         
-        cvcstate(trigger_key).value("update");
+        state::instance(app)(trigger_key).value("update");
         processing.store(false);
     }
 };
 
 GuardedCallback guardA, guardB;
-cvcstate("nodeA").valueChanged.connect([&guardA]() { guardA("nodeB"); });
-cvcstate("nodeB").valueChanged.connect([&guardB]() { guardB("nodeA"); });
+state::instance(app)("nodeA").valueChanged.connect([&guardA]() { guardA("nodeB"); });
+state::instance(app)("nodeB").valueChanged.connect([&guardB]() { guardB("nodeA"); });
 ```
 
 **Pattern 3: Change Detection Guard**
@@ -481,10 +498,10 @@ struct ChangeDetector {
 };
 
 ChangeDetector detector;
-cvcstate("watched").valueChanged.connect([&detector]() {
-    std::string value = cvcstate("watched").value();
+state::instance(app)("watched").valueChanged.connect([&detector]() {
+    std::string value = state::instance(app)("watched").value();
     if (detector.hasChanged(value)) {
-        cvcstate("dependent").value(value);
+        state::instance(app)("dependent").value(value);
     }
 });
 ```
@@ -513,7 +530,7 @@ struct DepthGuard {
     }
 };
 
-cvcstate("node").valueChanged.connect([]() {
+state::instance(app)("node").valueChanged.connect([]() {
     DepthGuard guard;
     if (guard.exceeded) {
         std::cerr << "Warning: Max callback depth exceeded!\n";
@@ -529,9 +546,9 @@ Break recursion using thread pools:
 
 ```cpp
 // ✅ SAFE: Async breaks the call stack
-cvcstate("nodeA").valueChanged.connect([]() {
-    cvcapp.thread("worker", []() {
-        cvcstate("nodeB").value("update");
+state::instance(app)("nodeA").valueChanged.connect([]() {
+    app.thread("worker", []() {
+        state::instance(app)("nodeB").value("update");
     });
 });
 ```
@@ -565,35 +582,35 @@ public:
     void setup() {
         // Step 1: Input → Validation (with re-entry guard)
         connections.push_back(
-            cvcstate("pipeline.input").valueChanged.connect([this]() {
+            state::instance(app)("pipeline.input").valueChanged.connect([this]() {
                 bool expected = false;
                 if (!validating.compare_exchange_strong(expected, true)) {
                     return;  // Already validating
                 }
                 
-                std::string input = cvcstate("pipeline.input").value();
+                std::string input = state::instance(app)("pipeline.input").value();
                 bool valid = validateInput(input);
-                cvcstate("pipeline.valid").value(valid);
+                state::instance(app)("pipeline.valid").value(valid);
                 validating.store(false);
             })
         );
         
         // Step 2: Validation → Processing (conditional, no loop back)
         connections.push_back(
-            cvcstate("pipeline.valid").valueChanged.connect([]() {
-                bool valid = cvcstate("pipeline.valid").value<bool>();
+            state::instance(app)("pipeline.valid").valueChanged.connect([]() {
+                bool valid = state::instance(app)("pipeline.valid").value<bool>();
                 if (valid) {
-                    std::string input = cvcstate("pipeline.input").value();
+                    std::string input = state::instance(app)("pipeline.input").value();
                     std::string processed = processInput(input);
-                    cvcstate("pipeline.output").value(processed);
+                    state::instance(app)("pipeline.output").value(processed);
                 }
             })
         );
         
         // Step 3: Output → UI Update (terminal, no further callbacks)
         connections.push_back(
-            cvcstate("pipeline.output").valueChanged.connect([]() {
-                std::string output = cvcstate("pipeline.output").value();
+            state::instance(app)("pipeline.output").valueChanged.connect([]() {
+                std::string output = state::instance(app)("pipeline.output").value();
                 updateUI(output);  // Terminal: no further state changes
             })
         );
@@ -617,18 +634,18 @@ All `cvc::state` operations are thread-safe via mutex protection:
 
 ```cpp
 // Multiple threads can safely access the same state
-boost::thread t1([](){ cvcstate("shared").value(1); });
-boost::thread t2([](){ cvcstate("shared").value(2); });
-boost::thread t3([](){ int v = cvcstate("shared").value<int>(); });
+boost::thread t1([](){ state::instance(app)("shared").value(1); });
+boost::thread t2([](){ state::instance(app)("shared").value(2); });
+boost::thread t3([](){ int v = state::instance(app)("shared").value<int>(); });
 
 t1.join(); t2.join(); t3.join();
 
 // Futures enable producer-consumer patterns
 boost::thread producer([](){ 
-    cvcstate("result").value(compute()); 
+    state::instance(app)("result").value(compute()); 
 });
 boost::thread consumer([](){ 
-    int result = cvcstate("result").wait_for_value<int>(); 
+    int result = state::instance(app)("result").wait_for_value<int>(); 
 });
 ```
 
@@ -651,7 +668,7 @@ However, before December 2025, there was a race condition where `_valueTypeName`
 template <class T> state& value(const T& v) {
   {
     boost::mutex::scoped_lock lock(_mutex);
-    _valueTypeName = cvcapp.dataTypeName<T>();
+    _valueTypeName = app.dataTypeName<T>();
   }  // Lock released here - RACE WINDOW!
   return value(boost::lexical_cast<std::string>(v), false);
 }
@@ -676,7 +693,7 @@ template <class T> state& value(const T& v) {
     boost::mutex::scoped_lock lock(_mutex);
     if(_value == str_value) return *this; // Early return if unchanged
     
-    _valueTypeName = cvcapp.dataTypeName<T>();
+    _valueTypeName = app.dataTypeName<T>();
     _value = str_value;
     _lastMod = boost::posix_time::microsec_clock::universal_time();
     _initialized = true;
@@ -710,7 +727,7 @@ protected:
                 processValue(value);
             } catch (const boost::bad_lexical_cast& e) {
                 // Log and handle gracefully
-                cvcapp.log(1, "Warning: Failed to convert counter value");
+                app.log(1, "Warning: Failed to convert counter value");
             }
         }
     }
@@ -753,10 +770,10 @@ This test rapidly changes integer values, which previously would cause `bad_lexi
 
 ```cpp
 // Export state tree to JSON string
-std::string json = cvcstate.dump();
+std::string json = state::instance(app).dump();
 
 // Import from JSON (merges with existing state)
-cvcstate.read(json_string);
+state::instance(app).read(json_string);
 
 // Serialization preserves:
 // - Value data (as strings)
@@ -775,7 +792,7 @@ The `cvc::state_object<T>` template class provides a convenient base class for o
 - **Change notifications**: `handleStateChanged()` callback fires when any child state changes
 - **Thread-safe updates**: State changes trigger async handlers in separate threads
 - **Easy access**: Convenient `getState()` and `stateName()` helper methods
-- **Type registration**: Automatically registers the class type with `cvcapp`
+- **Type registration**: Automatically registers the class type with the bound `cvc::app`
 
 #### Basic Usage
 
@@ -826,7 +843,7 @@ config->getState("width").value(2560);  // Triggers handleStateChanged()
 
 // Or access globally if you know the path
 std::string path = config->stateName("width");
-cvcstate(path).value(2560);  // Same effect
+state::instance(app)(path).value(2560);  // Same effect
 ```
 
 #### Monitoring Object State
@@ -865,7 +882,7 @@ public:
 protected:
     virtual void handleStateChanged(const std::string& childState) override {
         // Log all state changes
-        cvcapp.log(2, str(boost::format("DataProcessor: %s = %s") 
+        app.log(2, str(boost::format("DataProcessor: %s = %s") 
             % childState 
             % getState(childState).value()));
             
@@ -873,7 +890,7 @@ protected:
         if (childState == "error_count") {
             int errors = getState("error_count").value<int>();
             if (errors > 10) {
-                cvcapp.log(0, "Too many errors, halting processing");
+                app.log(0, "Too many errors, halting processing");
                 // Take corrective action
             }
         }
@@ -982,7 +999,7 @@ protected:
 The `state_object<T>` template provides these methods:
 
 **Constructor:**
-- Registers the type with `cvcapp`
+- Registers the type with the bound `cvc::app`
 - Sets up automatic state change monitoring
 - Each instance gets a unique state path: `<TypeName>/<InstanceAddress>`
 
@@ -1502,10 +1519,14 @@ TEST(StateTest, LockWithWait) {
 ### Construction and Access
 
 ```cpp
-// Global access function
-state cvcstate(const std::string& name);
+// Per-app root accessor
+namespace cvc {
+  state& state::instance(app& ctx);
+}
+// Then use the functor form for child paths:
+cvc::state::instance(app)("level1.level2.key");
 
-// Constructor
+// Direct construction
 state(const std::string& name = std::string());
 
 // Copy semantics (shallow copy - same node)
@@ -1632,28 +1653,28 @@ void read(const std::string& json);
 ```cpp
 void loadConfig() {
     // Set default configuration
-    cvcstate("app.window.width").value(1920);
-    cvcstate("app.window.height").value(1080);
-    cvcstate("app.theme").value("dark");
+    state::instance(app)("app.window.width").value(1920);
+    state::instance(app)("app.window.height").value(1080);
+    state::instance(app)("app.theme").value("dark");
     
     // Add metadata
-    cvcstate("app.window.width").property("min", "640");
-    cvcstate("app.window.width").property("max", "3840");
+    state::instance(app)("app.window.width").property("min", "640");
+    state::instance(app)("app.window.width").property("max", "3840");
     
     // Monitor changes
-    cvcstate("app.theme").valueChanged.connect([](std::string theme) {
+    state::instance(app)("app.theme").valueChanged.connect([](std::string theme) {
         applyTheme(theme);
     });
 }
 
 void saveConfig() {
-    std::string json = cvcstate("app").dump();
+    std::string json = state::instance(app)("app").dump();
     writeFile("config.json", json);
 }
 
 void restoreConfig() {
     std::string json = readFile("config.json");
-    cvcstate("app").read(json);
+    state::instance(app)("app").read(json);
 }
 ```
 
@@ -1663,25 +1684,25 @@ void restoreConfig() {
 // Stage 1: Load data
 void loadStage() {
     cvc::volume vol("input.rawiv");
-    cvcstate("pipeline.input").data(vol);
+    state::instance(app)("pipeline.input").data(vol);
 }
 
 // Stage 2: Process (waits for stage 1)
 void processStage() {
-    cvc::volume input = cvcstate("pipeline.input")
+    cvc::volume input = state::instance(app)("pipeline.input")
         .wait_for_data<cvc::volume>(boost::chrono::seconds(30));
     
     input.bilateral_filter(5.0, 0.1);
-    cvcstate("pipeline.filtered").data(input);
+    state::instance(app)("pipeline.filtered").data(input);
 }
 
 // Stage 3: Output (waits for stage 2)
 void outputStage() {
-    cvc::volume result = cvcstate("pipeline.filtered")
+    cvc::volume result = state::instance(app)("pipeline.filtered")
         .wait_for_data<cvc::volume>(boost::chrono::seconds(30));
     
     result.write("output.rawiv");
-    cvcstate("pipeline.complete").value(true);
+    state::instance(app)("pipeline.complete").value(true);
 }
 ```
 
@@ -1695,10 +1716,10 @@ class TemperatureMonitor {
 public:
     TemperatureMonitor() {
         // Set up monitoring with callback
-        cvcstate("sensor.temperature").value<double>([this](double temp) {
+        state::instance(app)("sensor.temperature").value<double>([this](double temp) {
             if (temp > 100.0) {
                 std::cerr << "ALERT: High temperature: " << temp << std::endl;
-                cvcstate("alarm.triggered").value(true);
+                state::instance(app)("alarm.triggered").value(true);
             }
         });
         
@@ -1707,11 +1728,11 @@ public:
             while (running_) {
                 try {
                     // Wait for temperature reading
-                    double temp = cvcstate("sensor.reading")
+                    double temp = state::instance(app)("sensor.reading")
                         .wait_for_value<double>(boost::chrono::seconds(1));
                     
                     // Update display
-                    cvcstate("sensor.temperature").value(temp);
+                    state::instance(app)("sensor.temperature").value(temp);
                     
                 } catch (const cvc::timeout_error&) {
                     // No reading yet, keep waiting
@@ -1740,12 +1761,12 @@ public:
             while (running_) {
                 try {
                     // Wait for request
-                    std::string request = cvcstate("server.request")
+                    std::string request = state::instance(app)("server.request")
                         .wait_for_value<std::string>(boost::chrono::seconds(1));
                     
                     // Process and respond
                     std::string response = processRequest(request);
-                    cvcstate("server.response").value(response);
+                    state::instance(app)("server.response").value(response);
                     
                 } catch (const cvc::timeout_error&) {
                     // No request, keep waiting
@@ -1755,8 +1776,8 @@ public:
     }
     
     std::string makeRequest(const std::string& req) {
-        cvcstate("server.request").value(req);
-        return cvcstate("server.response")
+        state::instance(app)("server.request").value(req);
+        return state::instance(app)("server.response")
             .wait_for_value<std::string>(boost::chrono::seconds(10));
     }
 };
@@ -1768,12 +1789,12 @@ public:
 
 ```cpp
 // Setting an int value
-cvcstate("number").value(42);
+state::instance(app)("number").value(42);
 
 // Attempting wrong type conversion throws type_conversion_error
 try {
     // This will throw because "42" cannot be cast to Config
-    Config cfg = cvcstate("number").data<Config>();
+    Config cfg = state::instance(app)("number").data<Config>();
 } catch (const cvc::type_conversion_error& e) {
     std::cerr << "Conversion failed: " << e.what() << std::endl;
     // Output: "Conversion failed: cvc::type_conversion_error exception: 
@@ -1786,7 +1807,7 @@ try {
 ```cpp
 // Wait with timeout
 try {
-    int value = cvcstate("slow.computation")
+    int value = state::instance(app)("slow.computation")
         .wait_for_value<int>(boost::chrono::milliseconds(100));
 } catch (const cvc::timeout_error& e) {
     std::cerr << "Timeout: " << e.what() << std::endl;
@@ -1821,7 +1842,7 @@ cvc::exception (inherits from boost::exception)
 - For expensive operations, trigger async work instead:
 
 ```cpp
-cvcstate("trigger").valueChanged.connect([](std::string val) {
+state::instance(app)("trigger").valueChanged.connect([](std::string val) {
     // Launch async processing instead of blocking
     boost::thread([val]() {
         expensiveOperation(val);
@@ -1846,7 +1867,7 @@ cvcstate("trigger").valueChanged.connect([](std::string val) {
 struct VolumeRef {
     boost::shared_ptr<cvc::volume> vol;
 };
-cvcstate("volume").data(VolumeRef{vol_ptr});
+state::instance(app)("volume").data(VolumeRef{vol_ptr});
 ```
 
 ## Testing
@@ -1879,8 +1900,8 @@ TEST(StateTest, ConcurrentAccess) {
     std::vector<boost::thread> threads;
     for (int i = 0; i < 10; i++) {
         threads.emplace_back([i]() {
-            cvcstate("concurrent.value").value(i);
-            int val = cvcstate("concurrent.value").value<int>();
+            state::instance(app)("concurrent.value").value(i);
+            int val = state::instance(app)("concurrent.value").value<int>();
         });
     }
     for (auto& t : threads) t.join();
@@ -1890,19 +1911,19 @@ TEST(StateTest, ConcurrentAccess) {
 TEST(StateTest, FuturesBlocking) {
     boost::thread producer([]() {
         boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
-        cvcstate("future.value").value(42);
+        state::instance(app)("future.value").value(42);
     });
     
-    int result = cvcstate("future.value").wait_for_value<int>();
+    int result = state::instance(app)("future.value").wait_for_value<int>();
     EXPECT_EQ(42, result);
     producer.join();
 }
 
 // Type conversion error test
 TEST(StateTest, TypeConversionError) {
-    cvcstate("test").value(42);
+    state::instance(app)("test").value(42);
     EXPECT_THROW(
-        cvcstate("test").data<std::vector<int>>(),
+        state::instance(app)("test").data<std::vector<int>>(),
         cvc::type_conversion_error
     );
 }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -631,18 +631,22 @@ g2.copy(g1, true);  // Creates new shared_ptr instances
 
 ### 1. Isolation
 
-Each test is independent and cleans up after itself:
+Each test is independent and cleans up after itself. The examples
+below use `app` as a `cvc::app` instance owned by the test (typically
+a fixture member or a file-scope test object):
 
 ```cpp
 TEST(StateTest, ValueSetAndGet) {
+  cvc::app app;
+
   // Arrange
-  cvcstate("test.value").value("test");
+  state::instance(app)("test.value").value("test");
   
   // Act & Assert
-  EXPECT_EQ(cvcstate("test.value").value(), "test");
+  EXPECT_EQ(state::instance(app)("test.value").value(), "test");
   
   // Cleanup
-  cvcstate("test").reset();
+  state::instance(app)("test").reset();
 }
 ```
 
@@ -695,7 +699,7 @@ TEST(TestSuiteName, TestName) {
   EXPECT_DOUBLE_EQ(value, 5.0);
   
   // Cleanup (if needed)
-  cvcstate("test").reset();
+  state::instance(app)("test").reset();
 }
 ```
 
@@ -726,9 +730,9 @@ ctest --output-on-failure
 
 ```cpp
 TEST(StateTest, TypeConversionError) {
-  cvcstate("test").value(42);
+  state::instance(app)("test").value(42);
   EXPECT_THROW({
-    cvcstate("test").data<std::vector<int>>();
+    state::instance(app)("test").data<std::vector<int>>();
   }, cvc::type_conversion_error);
 }
 ```
@@ -785,7 +789,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 ```cpp
 TEST(StateTest, ConcurrentValueReads) {
-  cvcstate("test.concurrent").value("initial");
+  state::instance(app)("test.concurrent").value("initial");
   
   std::atomic<int> success_count(0);
   std::vector<boost::thread> threads;
@@ -793,7 +797,7 @@ TEST(StateTest, ConcurrentValueReads) {
   for (int i = 0; i < 10; ++i) {
     threads.emplace_back([&success_count]() {
       for (int j = 0; j < 100; ++j) {
-        std::string val = cvcstate("test.concurrent").value();
+        std::string val = state::instance(app)("test.concurrent").value();
         if (!val.empty()) success_count++;
       }
     });
@@ -802,7 +806,7 @@ TEST(StateTest, ConcurrentValueReads) {
   for (auto& t : threads) t.join();
   
   EXPECT_EQ(success_count.load(), 1000);
-  cvcstate("test").reset();
+  state::instance(app)("test").reset();
 }
 ```
 
@@ -956,10 +960,10 @@ Async programming patterns with the futures API:
 TEST(StateTest, WaitForValue) {
   boost::thread writer([]() {
     boost::this_thread::sleep_for(boost::chrono::milliseconds(100));
-    cvcstate("test.future.wait").value(12345);
+    state::instance(app)("test.future.wait").value(12345);
   });
   
-  int val = cvcstate("test.future.wait").wait_for_value<int>();
+  int val = state::instance(app)("test.future.wait").wait_for_value<int>();
   EXPECT_EQ(val, 12345);
   
   writer.join();
@@ -979,7 +983,7 @@ CRTP-based state object pattern for automatic state management:
 - Data processing (status tracking, error counting)
 - Renderer state (camera, render mode)
 - Application settings (theme, language)
-- External state access via global `cvcstate()`
+- External state access via per-app `cvc::state::instance(app)`
 - Nested state paths
 - Multiple instances with unique state paths
 - Boost::any data storage

--- a/docs/THREAD_POOL.md
+++ b/docs/THREAD_POOL.md
@@ -34,7 +34,7 @@ For the full per-method reference, see
 
 // Submit work to the pool. Returns immediately; the task runs when a
 // worker slot is available.
-cvcapp.startThreadPooled("compute_sdf",
+app.startThreadPooled("compute_sdf",
                          []() { compute_sdf(); },
                          cvc::PRIORITY_NORMAL,
                          /*wait=*/true);
@@ -45,14 +45,14 @@ cvcapp.startThreadPooled("compute_sdf",
 ### Parallel batch with bounded concurrency
 
 ```cpp
-unsigned int saved = cvcapp.getThreadPoolSize();
-cvcapp.setThreadPoolSize(4);            // at most 4 concurrent
+unsigned int saved = app.getThreadPoolSize();
+app.setThreadPoolSize(4);            // at most 4 concurrent
 
 std::vector<std::string> keys;
 for (int i = 0; i < 100; ++i) {
   std::string key = "batch_" + std::to_string(i);
   keys.push_back(key);
-  cvcapp.startThreadPooled(key,
+  app.startThreadPooled(key,
                            [i]() { process_item(i); },
                            cvc::PRIORITY_NORMAL,
                            true);
@@ -60,24 +60,24 @@ for (int i = 0; i < 100; ++i) {
 
 // Wait for completion via the standard thread map.
 for (const auto& key : keys) {
-  if (cvcapp.hasThread(key)) {
-    if (auto t = cvcapp.threads(key)) t->join();
+  if (app.hasThread(key)) {
+    if (auto t = app.threads(key)) t->join();
   }
 }
 
-cvcapp.setThreadPoolSize(saved);
+app.setThreadPoolSize(saved);
 ```
 
 ### Mixing priorities
 
 ```cpp
 // A long-running background scan.
-cvcapp.startThreadPooled("background_scan",
+app.startThreadPooled("background_scan",
                          []() { scan_dataset(); },
                          cvc::PRIORITY_LOW, true);
 
 // User-initiated work jumps the queue.
-cvcapp.startThreadPooled("user_request",
+app.startThreadPooled("user_request",
                          []() { handle_user_request(); },
                          cvc::PRIORITY_HIGH, true);
 ```
@@ -85,11 +85,11 @@ cvcapp.startThreadPooled("user_request",
 ### Reporting progress and respecting interruption
 
 ```cpp
-cvcapp.startThreadPooled("import", []() {
-  cvc::thread_feedback feedback("Importing volume...");
+app.startThreadPooled("import", [&app]() {
+  cvc::thread_feedback feedback(app, "Importing volume...");
   for (int i = 0; i < 100; ++i) {
     boost::this_thread::interruption_point();
-    cvcapp.threadProgress(i / 100.0);
+    app.threadProgress(i / 100.0);
     do_step(i);
   }
 }, cvc::PRIORITY_NORMAL, true);
@@ -98,9 +98,9 @@ cvcapp.startThreadPooled("import", []() {
 ### Inspecting the pool
 
 ```cpp
-unsigned int max_concurrent = cvcapp.getThreadPoolSize();
-unsigned int running        = cvcapp.getActiveThreadCount();
-unsigned int queued         = cvcapp.getPendingThreadCount();
+unsigned int max_concurrent = app.getThreadPoolSize();
+unsigned int running        = app.getActiveThreadCount();
+unsigned int queued         = app.getPendingThreadCount();
 ```
 
 ## When to Use the Pool vs. `startThread`

--- a/docs/THREAD_POOL_API.md
+++ b/docs/THREAD_POOL_API.md
@@ -2,7 +2,12 @@
 
 ## Overview
 
-The CVC application class now includes a priority-based thread pool to manage concurrent task execution. This allows you to limit the number of simultaneously running heavy computations and prioritize critical tasks.
+The `cvc::app` class includes a priority-based thread pool to manage concurrent task execution. This allows you to limit the number of simultaneously running heavy computations and prioritize critical tasks.
+
+The examples below assume `cvc::app app;` is in scope and use it as
+the explicit context (a fixture member, `main()`-scoped object, etc.).
+The previously documented `cvcapp` macro has been removed; every
+caller now passes its own `cvc::app&`.
 
 ## Basic Usage
 
@@ -14,20 +19,22 @@ The CVC application class now includes a priority-based thread pool to manage co
 // Define your task
 class MyTask {
 public:
+  cvc::app& app;
+  explicit MyTask(cvc::app& a) : app(a) {}
   void operator()() {
     // Your computation here
-    thread_feedback feedback("Processing data...");
-    
+    cvc::thread_feedback feedback(app, "Processing data...");
+
     for (int i = 0; i < 100; i++) {
       boost::this_thread::interruption_point();
-      cvcapp.threadProgress(i / 100.0);
+      app.threadProgress(i / 100.0);
       // Do work...
     }
   }
 };
 
 // Submit to thread pool with normal priority
-cvcapp.startThreadPooled("myTask", MyTask(), PRIORITY_NORMAL);
+app.startThreadPooled("myTask", MyTask(app), PRIORITY_NORMAL);
 ```
 
 ### Priority Levels
@@ -45,14 +52,14 @@ Higher priority tasks are scheduled before lower priority ones when the pool is 
 
 ```cpp
 // Set maximum concurrent threads (default: hardware_concurrency or 4)
-cvcapp.setThreadPoolSize(8);
+app.setThreadPoolSize(8);
 
 // Get current pool size
-unsigned int poolSize = cvcapp.getThreadPoolSize();
+unsigned int poolSize = app.getThreadPoolSize();
 
 // Check active and pending threads
-unsigned int active = cvcapp.getActiveThreadCount();
-unsigned int pending = cvcapp.getPendingThreadCount();
+unsigned int active = app.getActiveThreadCount();
+unsigned int pending = app.getPendingThreadCount();
 ```
 
 ## Comparison: startThread vs startThreadPooled
@@ -73,7 +80,7 @@ unsigned int pending = cvcapp.getPendingThreadCount();
 
 ```cpp
 // Configure pool for 4 concurrent threads
-cvcapp.setThreadPoolSize(4);
+app.setThreadPoolSize(4);
 
 // Submit 100 tasks - only 4 run concurrently
 for (int i = 0; i < 100; i++) {
@@ -82,7 +89,7 @@ for (int i = 0; i < 100; i++) {
   // Critical tasks processed first
   thread_priority priority = (i < 10) ? PRIORITY_CRITICAL : PRIORITY_NORMAL;
   
-  cvcapp.startThreadPooled(key, [i]() {
+  app.startThreadPooled(key, [i]() {
     thread_feedback feedback("Processing batch " + std::to_string(i));
     // Do work...
   }, priority, false); // false = don't wait, use unique key
@@ -95,7 +102,7 @@ for (int i = 0; i < 100; i++) {
 2. **Worker Allocation**: Workers start when pool has capacity
 3. **Execution**: Highest priority task is executed next
 4. **Completion**: Worker processes next task or terminates if queue is empty
-5. **Thread Tracking**: Running tasks appear in `cvcapp.threads()` map with their keys
+5. **Thread Tracking**: Running tasks appear in `app.threads()` map with their keys
 
 ## Notes
 


### PR DESCRIPTION
Updates the README and `docs/` to reflect the removal of the `cvcapp`/`cvcstate` macros and `app::instance()`/`state::instance()` zero-arg singletons (PRs #36, #37).

Changes:
- **README.md**: drops the singleton bullet in the App API section.
- **docs/APP_API.md**: removes the deprecated-overloads block; drops the 'Legacy: routes through app::instance()' constructors from `thread_info`, `thread_feedback`, and `scoped_lock` signatures; reframes the migration note as history.
- **docs/STATE_API.md**: adds a 'Per-app state roots' overview describing `cvc::state::instance(app&)`; fixes the Construction and Access reference; rewrites all `cvcstate(...)` examples to `cvc::state::instance(app)(...)`.
- **docs/TESTING.md**: introduces `cvc::app app;` in the Isolation example; rewrites `cvcstate` examples.
- **docs/THREAD_POOL.md / THREAD_POOL_API.md**: `cvcapp.` -> `app.`; `thread_feedback` in pool example takes `app&`.
- **docs/IMAGE_PROCESSING_ALGORITHMS.md**: `cvcapp.threadProgress()` -> `app.threadProgress()`.
- **docs/GRAPHICS_DATA_DRIVEN_UPDATES.md**: `cvc::state::instance()` -> `cvc::state::instance(app)`.

Doc-only; no code changes.