### PR TITLE
app: add app::root() shorthand for per-app state root

### DIFF
--- a/docs/GRAPHICS_DATA_DRIVEN_UPDATES.md
+++ b/docs/GRAPHICS_DATA_DRIVEN_UPDATES.md
@@ -77,7 +77,7 @@ GraphicsNode node("my_mesh");
 node.setGeometry(initialGeometry);
 
 // Sync to state tree
-cvc::state& graphics = cvc::state::instance(app)("graphics");
+cvc::state& graphics = app.root()("graphics");
 node.syncToState(graphics);
 
 // Connect to state data changes

--- a/docs/STATE_API.md
+++ b/docs/STATE_API.md
@@ -44,20 +44,25 @@ The `cvc::state` class provides a thread-safe, hierarchical key-value store with
 
 ### Per-app state roots
 
-Each `cvc::app` owns its own state tree. The root is obtained
-through `cvc::state::instance(app&)`:
+Each `cvc::app` owns its own state tree. Get the root with the
+`app::root()` shorthand:
 
 ```cpp
 cvc::app app;
-cvc::state& root = cvc::state::instance(app);
+cvc::state& root = app.root();
 root("app.window.width").value(1920);
 ```
 
+`app.root()` is exactly equivalent to `cvc::state::instance(app)` —
+the second spelling is also fine if it reads better in your
+context, e.g. inside templates that already accept an `app&`.
+
 The examples in this document assume `cvc::app app;` is in scope
-and use `state::instance(app)` as the root accessor. Earlier
-versions of libcvc exposed the root through a global `cvcstate`
-macro / `state::instance()` zero-arg singleton; those have been
-removed — every caller must now pass the owning `app&` explicitly.
+and use either `app.root()` or `cvc::state::instance(app)` as the
+root accessor. Earlier versions of libcvc exposed the root through
+a global `cvcstate` macro / `state::instance()` zero-arg singleton;
+those have been removed — every caller must now reach the root
+through its owning `app`.
 
 ## Core Concepts
 
@@ -1519,11 +1524,13 @@ TEST(StateTest, LockWithWait) {
 ### Construction and Access
 
 ```cpp
-// Per-app root accessor
+// Per-app root accessor (preferred call-site spelling)
 namespace cvc {
-  state& state::instance(app& ctx);
+  state& app::root();                     // member shorthand
+  state& state::instance(app& ctx);       // free-form equivalent
 }
 // Then use the functor form for child paths:
+app.root()("level1.level2.key");
 cvc::state::instance(app)("level1.level2.key");
 
 // Direct construction

--- a/inc/cvc/app.h
+++ b/inc/cvc/app.h
@@ -98,6 +98,10 @@ namespace CVC_NAMESPACE {
 // Useful for test contexts or lightweight usage.
 struct no_init_t {};
 
+// Forward declaration so that app::root() can return a state reference
+// without pulling in <cvc/state.h> (which itself includes <cvc/app.h>).
+class state;
+
 class app {
 public:
   typedef boost::shared_ptr<app> app_ptr;
@@ -496,6 +500,12 @@ public:
   map_change_signal mutexesChanged;
 
   void wait() { wait_for_threads(); } // non-static for convenience
+
+  // Returns this app's root state node. Lazily creates the root on
+  // first access. Equivalent to (and implemented in terms of)
+  // cvc::state::instance(*this); use whichever reads better at the
+  // call site.
+  state &root();
 
   void sleep(double ms);
 

--- a/src/cvc/state.cpp
+++ b/src/cvc/state.cpp
@@ -151,6 +151,15 @@ state::state_ptr state::instancePtr(app &ctx) {
 //   Returns a reference to the root state object for the given app.
 state &state::instance(app &ctx) { return *instancePtr(ctx); }
 
+// ----------
+// app::root
+// ----------
+// Purpose:
+//   Defined here (not in app.cpp) because returning a state& requires
+//   the full state definition. Routes through state::instance(app&)
+//   so both spellings produce the same per-app root.
+state &app::root() { return state::instance(*this); }
+
 // --------------
 // state::lastMod
 // --------------

--- a/src/cvc/tests/state_test.cpp
+++ b/src/cvc/tests/state_test.cpp
@@ -69,6 +69,21 @@ TEST(StateTest, SingletonInstance) {
   EXPECT_EQ(&state1, &state2);
 }
 
+TEST(StateTest, AppRootShorthand) {
+  // app::root() must return the same per-app root as
+  // cvc::state::instance(app); both spellings are interchangeable.
+  EXPECT_EQ(&test_ctx.root(), &cvc::state::instance(test_ctx));
+
+  // Independent apps must have independent roots.
+  cvc::app other;
+  EXPECT_NE(&test_ctx.root(), &other.root());
+
+  // Round-trip a value through the shorthand.
+  test_ctx.root()("test.app_root_shorthand").value(7);
+  EXPECT_EQ(cvc::state::instance(test_ctx)("test.app_root_shorthand").value<int>(), 7);
+  test_ctx.root()("test.app_root_shorthand").reset();
+}
+
 // ===========================
 // Value Management Tests
 // ===========================


### PR DESCRIPTION
Returning the per-app state root through `cvc::state::instance(*this)` is awkward at call sites. Add a member shorthand:

```cpp
cvc::state& root = app.root();
```

Exactly equivalent to `cvc::state::instance(app)` — both spellings remain so callers pick whichever reads better. `state.h` keeps driving the per-app caching machinery; `app.h` gains only a forward declaration of `cvc::state` and a member declaration, with the definition in `state.cpp` where the full `state` class is in scope.

New `StateTest.AppRootShorthand` confirms:
- identity with `state::instance(app)` for the same app,
- independent roots across distinct apps,
- value round-trip through the shorthand.

Docs touched: `STATE_API.md` (overview + Construction and Access reference now show `app.root()` first), `GRAPHICS_DATA_DRIVEN_UPDATES.md` (example uses shorthand).

Local: 591/591 with `-DCVC_USING_XMLRPC=ON` and OFF.