### PR TITLE
release: bump libcvc to 3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 # First declare project with C and CXX to initialize CMake properly
 project(libcvc
-  VERSION 3.0.0
+  VERSION 3.1.0
   DESCRIPTION "Computational Visualization Center library from VolumeRover package"
   LANGUAGES C CXX
 )

--- a/README.md
+++ b/README.md
@@ -493,6 +493,18 @@ libcvc/
 
 ## Version History
 
+- **3.1.0** (2026) - **Singleton-less API release**
+  - Removed the global `cvcapp` / `cvcstate` macros and the
+    `cvc::app::instance()` / `cvc::state::instance()` zero-arg
+    singletons; every caller now reaches the application context
+    and state tree through an explicit `cvc::app&`.
+  - Added `cvc::app::root()` member shorthand, equivalent to
+    `cvc::state::instance(app)`, for ergonomic per-app state access.
+  - Per-app state caching keyed on the owning `cvc::app` instance.
+  - Documentation refresh across `README.md`, `docs/APP_API.md`,
+    `docs/STATE_API.md`, `docs/TESTING.md`, `docs/THREAD_POOL*.md`,
+    `docs/IMAGE_PROCESSING_ALGORITHMS.md`, and
+    `docs/GRAPHICS_DATA_DRIVEN_UPDATES.md`.
 - **3.0.0** (2026) - **Production-grade packaging & CI/CD release**
   - Cross-platform release artifacts: Linux (.tar.gz, .deb, AppImage),
     macOS (.zip, .dmg with VolumeRover3.app bundle), Windows (.zip,

--- a/USAGE.md
+++ b/USAGE.md
@@ -8,18 +8,18 @@ directory. No system installation, no `LD_LIBRARY_PATH` games.
 
 ```bash
 # Linux / macOS
-tar xf libcvc-3.0.0-linux-x86_64-release.tar.gz   # → ./libcvc-3.0.0/
+tar xf libcvc-3.1.0-linux-x86_64-release.tar.gz   # → ./libcvc-3.1.0/
 # or
-unzip libcvc-3.0.0-macos-arm64-release.zip        # → ./libcvc-3.0.0/
+unzip libcvc-3.1.0-macos-arm64-release.zip        # → ./libcvc-3.1.0/
 
 # Windows (PowerShell)
-Expand-Archive libcvc-3.0.0-windows-x86_64-release.zip
+Expand-Archive libcvc-3.1.0-windows-x86_64-release.zip
 ```
 
 The archive lays out the standard GNU install tree:
 
 ```
-libcvc-3.0.0/
+libcvc-3.1.0/
 ├── bin/                   # libcvc.dll (Windows only)
 ├── include/cvc/           # Public headers
 ├── lib/
@@ -38,13 +38,13 @@ libcvc-3.0.0/
 The most portable way is `CMAKE_PREFIX_PATH`:
 
 ```bash
-cmake -B build -DCMAKE_PREFIX_PATH=/path/to/libcvc-3.0.0
+cmake -B build -DCMAKE_PREFIX_PATH=/path/to/libcvc-3.1.0
 ```
 
 You can also set `cvc_DIR` directly:
 
 ```bash
-cmake -B build -Dcvc_DIR=/path/to/libcvc-3.0.0/lib/cmake/cvc
+cmake -B build -Dcvc_DIR=/path/to/libcvc-3.1.0/lib/cmake/cvc
 ```
 
 ## 3. Use it from your `CMakeLists.txt`
@@ -85,7 +85,7 @@ int main() {
 ```
 
 ```bash
-cmake -B build -DCMAKE_PREFIX_PATH=/path/to/libcvc-3.0.0
+cmake -B build -DCMAKE_PREFIX_PATH=/path/to/libcvc-3.1.0
 cmake --build build
 ./build/my_app
 ```


### PR DESCRIPTION
Bumps the project to **libcvc 3.1.0** — the singleton-less API release.

### Highlights
- Removed `cvcapp` / `cvcstate` macros and the zero-arg `cvc::app::instance()` / `cvc::state::instance()` singletons (PRs #36, #37).
- All callers now reach the application context and state tree through an explicit `cvc::app&` argument.
- Added `cvc::app::root()` member shorthand equivalent to `cvc::state::instance(app)` (PR #39).
- Per-app state caching keyed on the owning `cvc::app` instance.
- Documentation refresh across README, APP_API, STATE_API, TESTING, THREAD_POOL{,_API}, IMAGE_PROCESSING_ALGORITHMS, GRAPHICS_DATA_DRIVEN_UPDATES (PR #38).

### Files
- `CMakeLists.txt`: `project(libcvc VERSION 3.0.0)` → `3.1.0`.
- `README.md`: new `3.1.0` entry in Version History.
- `USAGE.md`: tarball and prefix-path examples updated to `libcvc-3.1.0`.

After merge, master will be tagged `v3.1.0` and a release published.