### PR TITLE
ci(release): skip AppImage rename when filename already matches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,9 +220,15 @@ jobs:
                         --desktop-file AppDir/volrover3.desktop \
                         --icon-file    AppDir/volrover_logo.png
           # linuxdeploy emits "VolumeRover3-x86_64.AppImage" by default if
-          # Name= matches; rename to our STEM for consistency.
+          # Name= matches; rename to our STEM for consistency. Skip files
+          # that are already named correctly (otherwise `mv` fails with
+          # "are the same file" because OUTPUT was set to ${STEM}.AppImage).
           for f in *.AppImage; do
-            case "$f" in linuxdeploy*) ;; *) mv "$f" "${STEM}.AppImage" ;; esac
+            case "$f" in
+              linuxdeploy*) ;;
+              "${STEM}.AppImage") ;;
+              *) mv "$f" "${STEM}.AppImage" ;;
+            esac
           done
           ls -la *.AppImage
 


### PR DESCRIPTION
Fix v3.1.0 release artifact pipeline: the Build AppImage step set `OUTPUT=${STEM}.AppImage` so linuxdeploy already produces the correctly-named file, and the follow-up rename loop then tried to `mv` the file onto itself:

```
mv: 'VolumeRover3-3.1.0-x86_64.AppImage' and
    'VolumeRover3-3.1.0-x86_64.AppImage' are the same file
```

Linux/volrover3 failed → gated `release` job skipped → v3.1.0 published with **0 assets**.

Loop now skips files already named `${STEM}.AppImage`, making it idempotent.

Once merged, the v3.1.0 tag will be moved to master HEAD to retrigger the Release workflow with the fix in place.