### PR TITLE
ci(release): preserve curated release body across re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -614,7 +614,14 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          # Preserve the curated release body (set manually before tagging
+          # or via `gh release edit`). With generate_release_notes: false
+          # and no `body`/`body_path` input, softprops does not touch the
+          # body field when updating an existing release — only assets are
+          # uploaded. Re-running the workflow on the same tag (e.g. after
+          # an artifact-only fix) will not clobber hand-written release
+          # notes.
+          generate_release_notes: false
           files: |
             artifacts/*.tar.gz
             artifacts/*.zip


### PR DESCRIPTION
softprops/action-gh-release@v2 with `generate_release_notes: true` and no explicit body **overwrites the curated body** when re-running the workflow on a tag whose release already exists. That's how a hand-written body with migration guide and validation summary can disappear after a routine artifact rebuild.

Set `generate_release_notes: false`. With no `body`/`body_path` input, softprops omits the body field from the update payload, so the existing release body is preserved — only assets get updated.

For first-time tag pushes, the release body should be filled in via `gh release edit --notes-file` after the first run (or before the tag push).