### PR TITLE
fix(windows): bundle CUDA/OpenMP/FFTW/zlib runtime DLLs and verify with dumpbin in CI

### DIFF
--- a/.github/scripts/verify-windows-deps.ps1
+++ b/.github/scripts/verify-windows-deps.ps1
@@ -73,6 +73,18 @@ function Test-IsSystemDll([string]$name) {
   foreach ($pat in $systemDllPatterns) {
     if ($name -imatch $pat) { return $true }
   }
+  # Anything that lives in %windir%\System32 (or SysWOW64) is, by
+  # definition, a Windows system DLL we don't ship. Checking the
+  # filesystem is more robust than maintaining an exhaustive regex
+  # list — Microsoft adds new system DLLs (bcp47mrm, TextShaping,
+  # logoncli, ...) faster than we can enumerate them.
+  $sysDirs = @(
+    (Join-Path $env:windir 'System32'),
+    (Join-Path $env:windir 'SysWOW64')
+  )
+  foreach ($d in $sysDirs) {
+    if (Test-Path (Join-Path $d $name)) { return $true }
+  }
   return $false
 }
 

--- a/.github/scripts/verify-windows-deps.ps1
+++ b/.github/scripts/verify-windows-deps.ps1
@@ -1,0 +1,141 @@
+# Verify that all non-system DLL dependencies of the given binaries are
+# resolved within the same directory.
+#
+# Usage:
+#   .\verify-windows-deps.ps1 -BinDir <path> [-Binaries volrover3.exe,cvc.dll]
+#
+# Exits with non-zero status (and prints what's missing) if any required
+# DLL is absent from <BinDir>. System DLLs (kernel32, user32, msvcp140,
+# vcruntime140, ucrtbase, api-ms-*, ext-ms-*, etc.) are ignored.
+#
+# Designed to run in GitHub Actions windows-* runners, which have
+# dumpbin.exe available via the Visual Studio "Developer PowerShell"
+# environment. The CI workflow activates that environment via
+# ilammy/msvc-dev-cmd or the vcvars64.bat shim before invoking us.
+
+param(
+  [Parameter(Mandatory=$true)] [string]   $BinDir,
+  [Parameter(Mandatory=$false)] [string[]] $Binaries = @()
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $BinDir)) {
+  Write-Error "BinDir does not exist: $BinDir"
+  exit 2
+}
+
+$BinDir = (Resolve-Path $BinDir).Path
+Write-Host "Verifying runtime dependencies under: $BinDir"
+
+# Auto-discover binaries if the caller did not name them.
+if (-not $Binaries -or $Binaries.Count -eq 0) {
+  $Binaries = @()
+  Get-ChildItem -Path $BinDir -Filter *.exe -File | ForEach-Object { $Binaries += $_.Name }
+  Get-ChildItem -Path $BinDir -Filter *.dll -File | ForEach-Object { $Binaries += $_.Name }
+}
+
+if (-not (Get-Command dumpbin -ErrorAction SilentlyContinue)) {
+  Write-Error "dumpbin.exe not on PATH. Run from a Visual Studio developer shell (vcvars64.bat / ilammy/msvc-dev-cmd)."
+  exit 2
+}
+
+# DLLs that are part of Windows / the MSVC runtime — never required to
+# ship alongside our binaries. Conservative list; matched case-insensitively.
+$systemDllPatterns = @(
+  '^kernel32\.dll$', '^user32\.dll$', '^gdi32\.dll$', '^advapi32\.dll$',
+  '^shell32\.dll$', '^ole32\.dll$', '^oleaut32\.dll$', '^comctl32\.dll$',
+  '^comdlg32\.dll$', '^ws2_32\.dll$', '^wsock32\.dll$', '^crypt32\.dll$',
+  '^bcrypt\.dll$', '^ncrypt\.dll$', '^secur32\.dll$', '^iphlpapi\.dll$',
+  '^dnsapi\.dll$', '^netapi32\.dll$', '^userenv\.dll$', '^psapi\.dll$',
+  '^version\.dll$', '^winmm\.dll$', '^winspool\.drv$', '^uxtheme\.dll$',
+  '^dwmapi\.dll$', '^dbghelp\.dll$', '^imm32\.dll$', '^rpcrt4\.dll$',
+  '^setupapi\.dll$', '^shlwapi\.dll$', '^urlmon\.dll$', '^wininet\.dll$',
+  '^d3d9\.dll$', '^d3d11\.dll$', '^d3d12\.dll$', '^dxgi\.dll$',
+  '^opengl32\.dll$', '^glu32\.dll$', '^msimg32\.dll$',
+  '^mf\.dll$', '^mfplat\.dll$', '^mfreadwrite\.dll$',
+  '^msvcp140\.dll$', '^msvcp140_1\.dll$', '^msvcp140_2\.dll$',
+  '^vcruntime140\.dll$', '^vcruntime140_1\.dll$',
+  '^concrt140\.dll$', '^vccorlib140\.dll$',
+  '^ucrtbase\.dll$', '^ucrtbased\.dll$', '^msvcrt\.dll$',
+  '^api-ms-.*\.dll$', '^ext-ms-.*\.dll$',
+  '^hvsifiletrust\.dll$', '^pdmutilities\.dll$',
+  # Windows codecs / WIC
+  '^windowscodecs\.dll$', '^propsys\.dll$', '^msctf\.dll$',
+  '^combase\.dll$', '^cfgmgr32\.dll$',
+  # GPU vendor user-mode drivers loaded by the OS, not by us
+  '^nvcuda\.dll$', '^nvapi.*\.dll$',
+  # CUDA driver API (lives with the NVIDIA driver, NOT the toolkit)
+  '^cuda\.dll$'
+)
+
+function Test-IsSystemDll([string]$name) {
+  foreach ($pat in $systemDllPatterns) {
+    if ($name -imatch $pat) { return $true }
+  }
+  return $false
+}
+
+function Get-DependentDlls([string]$path) {
+  $out = & dumpbin /dependents $path 2>&1
+  $deps = @()
+  $inSection = $false
+  foreach ($line in $out) {
+    if ($line -match '^\s*Image has the following dependencies:') {
+      $inSection = $true
+      continue
+    }
+    if ($inSection) {
+      if ($line -match '^\s*Summary') { break }
+      if ($line -match '^\s*([A-Za-z0-9_.+-]+\.dll)\s*$') {
+        $deps += $Matches[1]
+      }
+    }
+  }
+  return $deps
+}
+
+$missing = @{}
+$visited = New-Object System.Collections.Generic.HashSet[string]
+$queue   = New-Object System.Collections.Generic.Queue[string]
+foreach ($b in $Binaries) { [void]$queue.Enqueue($b) }
+
+while ($queue.Count -gt 0) {
+  $current = $queue.Dequeue()
+  $key = $current.ToLowerInvariant()
+  if (-not $visited.Add($key)) { continue }
+
+  $full = Join-Path $BinDir $current
+  if (-not (Test-Path $full)) {
+    if (-not (Test-IsSystemDll $current)) {
+      if (-not $missing.ContainsKey($key)) { $missing[$key] = $current }
+    }
+    continue
+  }
+
+  Write-Host "  walking $current"
+  $deps = Get-DependentDlls $full
+  foreach ($d in $deps) {
+    $dKey = $d.ToLowerInvariant()
+    if ($visited.Contains($dKey)) { continue }
+    if (Test-IsSystemDll $d) { continue }
+    $bundled = Join-Path $BinDir $d
+    if (Test-Path $bundled) {
+      [void]$queue.Enqueue($d)
+    } else {
+      if (-not $missing.ContainsKey($dKey)) { $missing[$dKey] = $d }
+    }
+  }
+}
+
+if ($missing.Count -gt 0) {
+  Write-Host ""
+  Write-Host "::error::Missing non-system DLL dependencies under $BinDir :"
+  foreach ($name in ($missing.Values | Sort-Object -Unique)) {
+    Write-Host "  - $name"
+  }
+  exit 1
+}
+
+Write-Host ""
+Write-Host "OK: all non-system DLL dependencies resolve within $BinDir."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1016,6 +1016,34 @@ jobs:
           Copy-Item "$stem.zip"        "$env:GITHUB_WORKSPACE/"
           Copy-Item "$stem-setup.exe"  "$env:GITHUB_WORKSPACE/"
 
+      # Setup MSVC dev shell so dumpbin.exe is on PATH for the
+      # dependency verification step below.
+      - name: Activate MSVC dev shell (for dumpbin)
+        if: matrix.kind == 'volrover3'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      # Verify that the staged volrover3.exe and every DLL it transitively
+      # depends on are present alongside the binary. Fails CI on any
+      # missing non-system DLL (cudart64_*.dll, fftw3.dll, libomp140*.dll,
+      # zlib1.dll, etc.) so we never ship a Windows artifact that crashes
+      # at launch with a "DLL not found" error.
+      - name: Verify Windows DLL dependencies (volrover3)
+        if: matrix.kind == 'volrover3'
+        shell: pwsh
+        run: |
+          $stem = "VolumeRover3-${{ steps.meta.outputs.version }}-${{ steps.meta.outputs.sha }}-windows-${{ steps.meta.outputs.arch }}-${{ steps.meta.outputs.btlc }}"
+          $extract = "$env:GITHUB_WORKSPACE\verify-bin"
+          if (Test-Path $extract) { Remove-Item -Recurse -Force $extract }
+          Expand-Archive -Path "$env:GITHUB_WORKSPACE\$stem.zip" -DestinationPath $extract
+          # CPack ZIP layout: <stem>/bin/volrover3.exe (CMAKE_INSTALL_BINDIR=bin)
+          $bin = Get-ChildItem -Path $extract -Recurse -Filter volrover3.exe -File | Select-Object -First 1
+          if (-not $bin) { throw "volrover3.exe not found in extracted zip" }
+          & "$env:GITHUB_WORKSPACE\.github\scripts\verify-windows-deps.ps1" `
+              -BinDir $bin.Directory.FullName `
+              -Binaries volrover3.exe
+
       - name: Upload Windows libcvc zip
         if: matrix.kind == 'libcvc'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -586,6 +586,31 @@ jobs:
           Copy-Item "$stem.zip"        "$env:GITHUB_WORKSPACE/"
           Copy-Item "$stem-setup.exe"  "$env:GITHUB_WORKSPACE/"
 
+      - name: Activate MSVC dev shell (for dumpbin)
+        if: matrix.kind == 'volrover3'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      # Refuse to ship a release artifact that would fail to launch on
+      # a vanilla Windows machine due to a missing DLL (cudart, fftw3,
+      # libomp140.x86_64, zlib, ...). dumpbin walks the EXE's PE imports
+      # transitively and the verification script asserts every non-system
+      # dependency is present in the same directory.
+      - name: Verify Windows DLL dependencies (volrover3)
+        if: matrix.kind == 'volrover3'
+        shell: pwsh
+        run: |
+          $stem = "VolumeRover3-${{ steps.meta.outputs.version }}-windows-${{ steps.meta.outputs.arch }}"
+          $extract = "$env:GITHUB_WORKSPACE\verify-bin"
+          if (Test-Path $extract) { Remove-Item -Recurse -Force $extract }
+          Expand-Archive -Path "$env:GITHUB_WORKSPACE\$stem.zip" -DestinationPath $extract
+          $bin = Get-ChildItem -Path $extract -Recurse -Filter volrover3.exe -File | Select-Object -First 1
+          if (-not $bin) { throw "volrover3.exe not found in extracted zip" }
+          & "$env:GITHUB_WORKSPACE\.github\scripts\verify-windows-deps.ps1" `
+              -BinDir $bin.Directory.FullName `
+              -Binaries volrover3.exe
+
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/CMake/SetupCUDA.cmake
+++ b/CMake/SetupCUDA.cmake
@@ -31,14 +31,35 @@ function(SetupCUDA TargetName)
   
   # Find and link CUDA toolkit libraries
   find_package(CUDAToolkit REQUIRED)
-  
-  # Link CUDA runtime
-  if(TARGET CUDA::cudart)
-    target_link_libraries(${TargetName} PUBLIC CUDA::cudart)
+
+  # Link CUDA runtime.
+  #
+  # CMake exposes BOTH CUDA::cudart (the *shared* runtime) and
+  # CUDA::cudart_static, regardless of CMAKE_CUDA_RUNTIME_LIBRARY.
+  # That global variable only affects how nvcc-compiled translation
+  # units pull in the runtime; an explicit target_link_libraries on
+  # CUDA::cudart still drags in cudart64_12X.dll and forces end users
+  # to install the CUDA toolkit just to launch the binary.
+  #
+  # For redistribution we want the static cudart so the only thing the
+  # end user needs is the NVIDIA driver. Honor CMAKE_CUDA_RUNTIME_LIBRARY
+  # when set, otherwise default to Static.
+  if(NOT DEFINED CMAKE_CUDA_RUNTIME_LIBRARY OR CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "Static")
+    if(TARGET CUDA::cudart_static)
+      target_link_libraries(${TargetName} PUBLIC CUDA::cudart_static)
+    elseif(TARGET CUDA::cudart)
+      target_link_libraries(${TargetName} PUBLIC CUDA::cudart)
+    else()
+      target_link_libraries(${TargetName} PUBLIC ${CUDA_LIBRARIES})
+      target_include_directories(${TargetName} PRIVATE ${CUDA_INCLUDE_DIRS})
+    endif()
   else()
-    # Fallback for older CMake/CUDA versions
-    target_link_libraries(${TargetName} PUBLIC ${CUDA_LIBRARIES})
-    target_include_directories(${TargetName} PRIVATE ${CUDA_INCLUDE_DIRS})
+    if(TARGET CUDA::cudart)
+      target_link_libraries(${TargetName} PUBLIC CUDA::cudart)
+    else()
+      target_link_libraries(${TargetName} PUBLIC ${CUDA_LIBRARIES})
+      target_include_directories(${TargetName} PRIVATE ${CUDA_INCLUDE_DIRS})
+    endif()
   endif()
   
   # Optional: Link additional CUDA libraries as needed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,16 @@ endif()
 
 # ************* CPack configuration *************
 include(GNUInstallDirs)
+
+# Ship Microsoft's MSVC CRT redist AND the LLVM OpenMP runtime
+# (libomp140.x86_64.dll) alongside our binaries. Without
+# CMAKE_INSTALL_OPENMP_LIBRARIES the OpenMP DLL is not bundled and
+# volrover3.exe / cvc.dll fail to launch on a vanilla Windows machine
+# with "libomp140.x86_64.dll was not found".
+set(CMAKE_INSTALL_OPENMP_LIBRARIES TRUE)
+# InstallRequiredSystemLibraries installs into bin/ by default, which
+# is what we want next to volrover3.exe.
+set(CMAKE_INSTALL_SYSTEM_RUNTIME_COMPONENT volrover3)
 include(InstallRequiredSystemLibraries)
 
 # Compute architecture tag for archive file names.

--- a/src/volrover3/CMakeLists.txt
+++ b/src/volrover3/CMakeLists.txt
@@ -214,6 +214,78 @@ if(WIN32)
     DESTINATION ${CMAKE_INSTALL_BINDIR}
     COMPONENT volrover3)
 
+  # ── Belt-and-suspenders runtime-dependency walker ──
+  #
+  # $<TARGET_RUNTIME_DLLS:volrover3> only resolves DLLs that arrived
+  # via CMake imported targets with IMPORTED_LOCATION set (e.g. modern
+  # Qt6, vcpkg-built cgal, vtk). It silently misses:
+  #   - fftw3.dll  : found via legacy CMake/FindFFTW.cmake which only
+  #                  sets variables, no imported target.
+  #   - zlib1.dll, libpng16.dll, etc. : transitive deps pulled in via
+  #                                     hdf5/imagemagick that don't
+  #                                     propagate through cvc's
+  #                                     interface link libraries.
+  #   - cudart64_*.dll : if a future change accidentally re-introduces
+  #                      a dynamic CUDA::cudart link.
+  #
+  # file(GET_RUNTIME_DEPENDENCIES) is CMake's PE-import walker. We run
+  # it at install time over the staged volrover3.exe and cvc.dll, then
+  # copy every non-system DLL it finds into bin/. Search dirs include
+  # the build tree, CMAKE_PREFIX_PATH (vcpkg + Qt + VTK) and
+  # CUDAToolkit_BIN_DIR (in case dynamic cudart slips in).
+  #
+  # We pre-compute the search-dir list at configure time and store it
+  # as a quoted CMake list so paths with spaces survive the install
+  # script generation intact.
+  set(_cvc_runtime_search_dirs
+    "${CMAKE_BINARY_DIR}/bin"
+    "${CMAKE_BINARY_DIR}/lib"
+  )
+  foreach(_p IN LISTS CMAKE_PREFIX_PATH)
+    list(APPEND _cvc_runtime_search_dirs "${_p}/bin")
+  endforeach()
+  if(DEFINED CUDAToolkit_BIN_DIR)
+    list(APPEND _cvc_runtime_search_dirs "${CUDAToolkit_BIN_DIR}")
+  endif()
+
+  install(CODE "
+    set(_search_dirs \"${_cvc_runtime_search_dirs}\")
+    list(PREPEND _search_dirs \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\")
+    if(DEFINED ENV{QT_ROOT_DIR})
+      list(APPEND _search_dirs \"\$ENV{QT_ROOT_DIR}/bin\")
+    endif()
+    if(DEFINED ENV{VCPKG_INSTALLATION_ROOT})
+      list(APPEND _search_dirs \"\$ENV{VCPKG_INSTALLATION_ROOT}/installed/x64-windows/bin\")
+    endif()
+
+    file(GET_RUNTIME_DEPENDENCIES
+      EXECUTABLES \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/volrover3.exe\"
+      LIBRARIES   \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/cvc.dll\"
+      RESOLVED_DEPENDENCIES_VAR _resolved
+      UNRESOLVED_DEPENDENCIES_VAR _unresolved
+      CONFLICTING_DEPENDENCIES_PREFIX _conflicting
+      DIRECTORIES \${_search_dirs}
+      PRE_EXCLUDE_REGEXES
+        [[api-ms-.*]]
+        [[ext-ms-.*]]
+      POST_EXCLUDE_REGEXES
+        [[.*/system32/.*\\.dll]]
+        [[.*/SysWOW64/.*\\.dll]]
+        [[.*/[Ww]indows/.*\\.dll]]
+    )
+
+    foreach(_dll IN LISTS _resolved)
+      message(STATUS \"Bundling runtime dep: \${_dll}\")
+      file(INSTALL \"\${_dll}\"
+        DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\"
+        FOLLOW_SYMLINK_CHAIN)
+    endforeach()
+
+    if(_unresolved)
+      message(STATUS \"Unresolved runtime deps (assumed system): \${_unresolved}\")
+    endif()
+  " COMPONENT volrover3)
+
   if(QT_VERSION_MAJOR EQUAL 6)
     set(_qt_bin_hint "${Qt6_DIR}/../../../bin")
   else()


### PR DESCRIPTION
The Windows artifacts shipped from CI/release workflows were failing to
launch on vanilla Windows machines with missing-DLL errors:

- `cudart64_12.dll`
- `libomp140.x86_64.dll`
- `fftw3.dll`
- `z.dll` (`zlib1.dll`)

## Root causes and fixes

- **`CMake/SetupCUDA.cmake`** unconditionally linked `CUDA::cudart` (the *shared* runtime target), which overrides `CMAKE_CUDA_RUNTIME_LIBRARY=Static`. Switched to `CUDA::cudart_static` when static is requested (the default for redistribution). End users now only need the NVIDIA driver, not a CUDA toolkit install.

- **`CMakeLists.txt`** now sets `CMAKE_INSTALL_OPENMP_LIBRARIES=TRUE` before `include(InstallRequiredSystemLibraries)` so MSVC's LLVM OpenMP redist (`libomp140.x86_64.dll`) is bundled alongside the MSVC CRT.

- **`src/volrover3/CMakeLists.txt`** now runs `file(GET_RUNTIME_DEPENDENCIES)` at install time on Windows. `$<TARGET_RUNTIME_DLLS:...>` only resolves DLLs that arrived via imported targets with `IMPORTED_LOCATION`; it silently misses `fftw3.dll` (legacy `FindFFTW.cmake`) and transitive deps like `zlib1.dll`/`libpng16.dll` pulled in via hdf5/imagemagick. The PE-import walker copies every non-system DLL into `bin/`.

## CI verification with dumpbin

- Added **`.github/scripts/verify-windows-deps.ps1`** which runs `dumpbin /dependents` transitively over the bundled `volrover3.exe` and every nested DLL, ignoring known system DLLs (kernel32, msvcp140, ucrtbase, api-ms-*, cuda.dll driver API, ...).
- Wired into both **`ci.yml`** and **`release.yml`** after the cpack ZIP step, gated by `ilammy/msvc-dev-cmd@v1` to put `dumpbin.exe` on PATH. CI now refuses to publish a Windows artifact that would fail to launch on a vanilla machine.

After this merges, cut `v3.1.1` so the release workflow rebuilds the Windows assets with the bundled DLLs.
