### PR TITLE
chore(release): bump project VERSION to 3.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 # First declare project with C and CXX to initialize CMake properly
 project(libcvc
-  VERSION 3.1.0
+  VERSION 3.1.1
   DESCRIPTION "Computational Visualization Center library from VolumeRover package"
   LANGUAGES C CXX
 )


### PR DESCRIPTION
Bump CMakeLists.txt project VERSION to 3.1.1 so the release workflow produces correctly-named artifacts (libcvc-3.1.1-..., VolumeRover3-3.1.1-...) for the upcoming v3.1.1 tag.

The v3.1.1 tag will be cut after this merges.