### PR TITLE
ci: bundle all deps (shared + static) into libcvc release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,13 @@ permissions:
 # the extracted archive without needing apt / Homebrew / vcpkg on the
 # host. Shared archives ship .so/.dylib/.dll (with rpath fixups on
 # Linux+macOS) plus their import .lib on Windows; static archives ship
-# .a/.lib only. Both flavors include cvc::xmlrpc plus a Qt-free build
-# of VTK 9.5 (libvtk*.so/.dylib/.dll/.a/.lib + headers + CMake config)
-# so consumers don't have to rebuild VTK separately.
+# .a/.lib only. Both flavors include cvc::xmlrpc. VTK is intentionally
+# NOT bundled — downstream consumers (F2Dock, MolSurf, volrover) bring
+# their own VTK with the configuration they need (e.g. Qt-enabled for
+# volrover).
 #
 # Debug archives on Windows also include MSVC .pdb files for libcvc
-# itself, every vcpkg-built dependency, and VTK, so symbolicated stack
+# itself and every vcpkg-built dependency, so symbolicated stack
 # traces work out of the box.
 #
 # System libraries (glibc, libstdc++, libm, Windows UCRT) are
@@ -160,45 +161,6 @@ jobs:
             libxrender-dev libxcursor-dev libxinerama-dev libxi-dev \
             libcgal-dev \
             libfuse2 file desktop-file-utils
-
-      # ── VTK 9.5 (Qt-free) for libcvc archives ──
-      # Built per (build_type, link) so debug-shared, release-shared,
-      # debug-static, release-static each get a matching VTK install
-      # tree to bundle. Qt is intentionally disabled: libcvc itself
-      # has no Qt dependency, and bundling Qt6 would balloon the
-      # libcvc archive by hundreds of MB. The volrover3 row keeps its
-      # own ~/vtk-qt6 build (with Qt) cached separately below.
-      - name: Cache VTK (no Qt) install tree
-        if: matrix.kind == 'libcvc'
-        id: vtk-nq-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/vtk-nq
-          key: vtk-nq-9.5.0-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.link }}-v1
-
-      - name: Build VTK 9.5 (no Qt) from source
-        if: matrix.kind == 'libcvc' && steps.vtk-nq-cache.outputs.cache-hit != 'true'
-        run: |
-          set -euo pipefail
-          if [ "${{ matrix.link }}" = "static" ]; then
-            vtk_shared=OFF
-          else
-            vtk_shared=ON
-          fi
-          curl -L -o vtk.tar.gz https://github.com/Kitware/VTK/archive/refs/tags/v9.5.0.tar.gz
-          tar xzf vtk.tar.gz
-          cmake -S VTK-9.5.0 -B vtk-build -G Ninja \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_INSTALL_PREFIX=$HOME/vtk-nq \
-            -DBUILD_SHARED_LIBS=$vtk_shared \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-            -DVTK_GROUP_ENABLE_Qt=NO \
-            -DVTK_BUILD_TESTING=OFF \
-            -DVTK_BUILD_EXAMPLES=OFF \
-            -DVTK_BUILD_DOCUMENTATION=OFF \
-            -DVTK_LEGACY_REMOVE=ON
-          cmake --build vtk-build --parallel --target install
-          rm -rf vtk-build VTK-9.5.0 vtk.tar.gz
 
       # ── VTK 9.5 built against Qt6, cached ──
       # Cache key matches ci.yml so the build is shared across both
@@ -344,34 +306,9 @@ jobs:
           fi
 
           # ── Bundle VTK (no Qt) ──────────────────────────────────
-          if [ -d "$HOME/vtk-nq" ]; then
-            mkdir -p "$DIST/lib/cmake" "$DIST/include"
-            # Copy VTK install tree alongside libcvc's own files.
-            # Include trees may not overlap; if they do, VTK headers
-            # land under include/vtk-9.5/ which doesn't collide.
-            for src in "$HOME/vtk-nq/include"/*; do
-              [ -e "$src" ] && cp -R "$src" "$DIST/include/" 2>/dev/null || true
-            done
-            if [ -d "$HOME/vtk-nq/lib" ]; then
-              # Preserve symlinks for shared lib SONAMEs.
-              find "$HOME/vtk-nq/lib" -maxdepth 1 \( -name '*.so*' -o -name '*.a' \) -print0 \
-                | xargs -0 -r cp -P -t "$DIST/lib/" 2>/dev/null || true
-              # CMake config bundle.
-              if [ -d "$HOME/vtk-nq/lib/cmake" ]; then
-                cp -R "$HOME/vtk-nq/lib/cmake/." "$DIST/lib/cmake/" 2>/dev/null || true
-              fi
-            fi
-            # Re-stamp RUNPATH on any VTK .so we just dropped in so it
-            # finds its peers via $ORIGIN as well.
-            if [ "${{ matrix.link }}" = "shared" ]; then
-              for so in "$DIST"/lib/libvtk*.so*; do
-                [ -e "$so" ] || continue
-                [ -L "$so" ] && continue
-                patchelf --remove-rpath "$so" 2>/dev/null || true
-                patchelf --set-rpath '$ORIGIN' "$so" 2>/dev/null || true
-              done
-            fi
-          fi
+          # Intentionally not bundled: libcvc's CMake config does not
+          # require VTK at consumer time. Each downstream project
+          # (F2Dock, MolSurf, volrover) brings its own VTK if needed.
 
           tar czf "$STEM.tar.gz" "$STEM"
           cp "$STEM.tar.gz" "$GITHUB_WORKSPACE/"
@@ -511,38 +448,6 @@ jobs:
           echo "BOOST_ROOT=$(brew --prefix boost)" >> $GITHUB_ENV
           echo "CMAKE_PREFIX_PATH=$(brew --prefix boost):$(brew --prefix hdf5)" >> $GITHUB_ENV
 
-      - name: Cache VTK (no Qt) install tree
-        if: matrix.kind == 'libcvc'
-        id: vtk-nq-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/vtk-nq
-          key: vtk-nq-9.5.0-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.link }}-v1
-
-      - name: Build VTK 9.5 (no Qt) from source
-        if: matrix.kind == 'libcvc' && steps.vtk-nq-cache.outputs.cache-hit != 'true'
-        run: |
-          set -euo pipefail
-          if [ "${{ matrix.link }}" = "static" ]; then
-            vtk_shared=OFF
-          else
-            vtk_shared=ON
-          fi
-          curl -L -o vtk.tar.gz https://github.com/Kitware/VTK/archive/refs/tags/v9.5.0.tar.gz
-          tar xzf vtk.tar.gz
-          cmake -S VTK-9.5.0 -B vtk-build -G Ninja \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_INSTALL_PREFIX=$HOME/vtk-nq \
-            -DBUILD_SHARED_LIBS=$vtk_shared \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-            -DVTK_GROUP_ENABLE_Qt=NO \
-            -DVTK_BUILD_TESTING=OFF \
-            -DVTK_BUILD_EXAMPLES=OFF \
-            -DVTK_BUILD_DOCUMENTATION=OFF \
-            -DVTK_LEGACY_REMOVE=ON
-          cmake --build vtk-build --parallel --target install
-          rm -rf vtk-build VTK-9.5.0 vtk.tar.gz
-
       - name: Install dependencies (volrover3)
         if: matrix.kind == 'volrover3'
         run: |
@@ -622,44 +527,7 @@ jobs:
           fi
 
           # ── Bundle VTK (no Qt) ──────────────────────────────────
-          if [ -d "$HOME/vtk-nq" ]; then
-            mkdir -p "$DIST/lib/cmake" "$DIST/include"
-            for src in "$HOME/vtk-nq/include"/*; do
-              [ -e "$src" ] && cp -R "$src" "$DIST/include/" 2>/dev/null || true
-            done
-            if [ -d "$HOME/vtk-nq/lib" ]; then
-              find "$HOME/vtk-nq/lib" -maxdepth 1 \( -name '*.dylib' -o -name '*.a' \) -print0 \
-                | xargs -0 -I {} cp -RP {} "$DIST/lib/" 2>/dev/null || true
-              if [ -d "$HOME/vtk-nq/lib/cmake" ]; then
-                cp -R "$HOME/vtk-nq/lib/cmake/." "$DIST/lib/cmake/" 2>/dev/null || true
-              fi
-            fi
-            # Rewrite install_names on bundled VTK dylibs so they
-            # resolve siblings via @loader_path/ (i.e. find each
-            # other inside the archive's lib/ directory).
-            if [ "${{ matrix.link }}" = "shared" ]; then
-              for dy in "$DIST"/lib/libvtk*.dylib; do
-                [ -e "$dy" ] || continue
-                [ -L "$dy" ] && continue
-                # Set the dylib's own LC_ID_DYLIB to @rpath/<name>.
-                base=$(basename "$dy")
-                install_name_tool -id "@rpath/$base" "$dy" 2>/dev/null || true
-                # Rewrite every load command that references another
-                # absolute path under /usr/local/Cellar/vtk/... to a
-                # @loader_path-relative form, then add an rpath of
-                # @loader_path so siblings resolve.
-                otool -L "$dy" | awk 'NR>1 {print $1}' | while read -r dep; do
-                  case "$dep" in
-                    /usr/local/*|/opt/homebrew/*|@rpath/*)
-                      depbase=$(basename "$dep")
-                      install_name_tool -change "$dep" "@loader_path/$depbase" "$dy" 2>/dev/null || true
-                      ;;
-                  esac
-                done
-                install_name_tool -add_rpath '@loader_path/' "$dy" 2>/dev/null || true
-              done
-            fi
-          fi
+          # Intentionally not bundled — see Linux section for rationale.
 
           ditto -c -k --sequesterRsrc --keepParent "$DIST" "$STEM.zip"
           cp "$STEM.zip" "$GITHUB_WORKSPACE/"
@@ -860,62 +728,6 @@ jobs:
             Start-Sleep -Seconds $sleep
           }
 
-      # ── VTK 9.5 (Qt-free) for libcvc archives on Windows ──
-      # Built per (build_type, link); installs into D:\vtk-nq with
-      # PDB files preserved for Debug builds. Bundled into the libcvc
-      # archive in the Pack step further down.
-      - name: Restore VTK (no Qt) cache (Windows)
-        if: matrix.kind == 'libcvc'
-        id: vtk-nq-cache-windows
-        uses: actions/cache/restore@v4
-        with:
-          path: D:\vtk-nq
-          key: vtk-nq-9.5.0-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.link }}-v1
-
-      - name: Build VTK 9.5 (no Qt) from source (Windows)
-        if: matrix.kind == 'libcvc' && steps.vtk-nq-cache-windows.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $vtkShared = if ('${{ matrix.link }}' -eq 'static') { 'OFF' } else { 'ON' }
-          $msvcrt = if ('${{ matrix.link }}' -eq 'static') {
-            'MultiThreaded$<$<CONFIG:Debug>:Debug>'
-          } else {
-            'MultiThreaded$<$<CONFIG:Debug>:Debug>DLL'
-          }
-          Invoke-WebRequest -Uri https://github.com/Kitware/VTK/archive/refs/tags/v9.5.0.tar.gz -OutFile vtk.tar.gz
-          tar xzf vtk.tar.gz
-          cmake -S VTK-9.5.0 -B D:\vtk-nq-build `
-            -DCMAKE_INSTALL_PREFIX=D:\vtk-nq `
-            -DBUILD_SHARED_LIBS=$vtkShared `
-            -DCMAKE_MSVC_RUNTIME_LIBRARY="$msvcrt" `
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON `
-            -DVTK_GROUP_ENABLE_Qt=NO `
-            -DVTK_BUILD_TESTING=OFF `
-            -DVTK_BUILD_EXAMPLES=OFF `
-            -DVTK_BUILD_DOCUMENTATION=OFF `
-            -DVTK_LEGACY_REMOVE=ON
-          cmake --build D:\vtk-nq-build --config ${{ matrix.build_type }} --parallel --target install
-          # Stash PDB files alongside the install tree for Debug builds.
-          # CMake's install rules typically skip per-target .pdb files
-          # for static .lib targets, so we copy them out of the build
-          # tree manually before the build dir is removed.
-          if ('${{ matrix.build_type }}' -eq 'Debug') {
-            New-Item -ItemType Directory -Force -Path D:\vtk-nq\pdb | Out-Null
-            Get-ChildItem -Path D:\vtk-nq-build -Recurse -Include *.pdb -File `
-              | Copy-Item -Destination D:\vtk-nq\pdb -Force
-          }
-          Remove-Item -Recurse -Force D:\vtk-nq-build
-          Remove-Item -Recurse -Force VTK-9.5.0
-          Remove-Item -Force vtk.tar.gz
-
-      - name: Save VTK (no Qt) cache (Windows)
-        if: matrix.kind == 'libcvc' && steps.vtk-nq-cache-windows.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: D:\vtk-nq
-          key: vtk-nq-9.5.0-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.link }}-v1
-
       # ── VTK 9.5 built from source against aqt Qt6, cached ──
       # Mirrors the Ubuntu strategy. Cache key includes build_type
       # because MSVC Debug and Release VTK DLLs are not interchangeable.
@@ -1074,34 +886,7 @@ jobs:
           }
 
           # ── Bundle VTK (no Qt) ──────────────────────────────────
-          if (Test-Path D:\vtk-nq) {
-            if (Test-Path D:\vtk-nq\include) {
-              Copy-Item -Recurse -Force D:\vtk-nq\include\* "$dist/include/"
-            }
-            if (Test-Path D:\vtk-nq\lib) {
-              Get-ChildItem -Path D:\vtk-nq\lib -Filter '*.lib' -File `
-                | Copy-Item -Destination "$dist/lib/" -Force
-              if (Test-Path D:\vtk-nq\lib\cmake) {
-                New-Item -ItemType Directory -Force -Path "$dist/lib/cmake" | Out-Null
-                Copy-Item -Recurse -Force D:\vtk-nq\lib\cmake\* "$dist/lib/cmake/"
-              }
-            }
-            if ('${{ matrix.link }}' -eq 'shared' -and (Test-Path D:\vtk-nq\bin)) {
-              Get-ChildItem -Path D:\vtk-nq\bin -Filter '*.dll' -File `
-                | Copy-Item -Destination "$dist/bin/" -Force
-            }
-            if ($isDebug -and (Test-Path D:\vtk-nq\pdb)) {
-              # Drop VTK's PDB files alongside their .dll (shared) or
-              # .lib (static). For simplicity place all .pdb under both
-              # bin/ and lib/; the debugger searches both.
-              New-Item -ItemType Directory -Force -Path "$dist/bin","$dist/lib" | Out-Null
-              Get-ChildItem -Path D:\vtk-nq\pdb -Filter '*.pdb' -File `
-                | ForEach-Object {
-                    Copy-Item $_.FullName -Destination "$dist/bin/" -Force -ErrorAction SilentlyContinue
-                    Copy-Item $_.FullName -Destination "$dist/lib/" -Force -ErrorAction SilentlyContinue
-                  }
-            }
-          }
+          # Intentionally not bundled — see Linux section for rationale.
 
           Compress-Archive -Path "$dist/*" -DestinationPath (Join-Path $env:GITHUB_WORKSPACE "$stem.zip") -Force
           "$stem staged at $dist" | Write-Host

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,16 @@ permissions:
 #   - Windows: libcvc-<ver>-windows-<arch>-<config>.zip           (shared)
 #              libcvc-<ver>-windows-<arch>-<config>-static.zip    (static)
 #
-# Shared artifacts contain libcvc.{so,dylib,dll} + its CMake config and
-# expect consumers to discover Boost/HDF5/FFTW/etc. on their own host.
-# Static artifacts contain libcvc.{a,lib} built with BUILD_SHARED_LIBS=OFF
-# and (on Windows, via the x64-windows-static vcpkg triplet) ship the
-# static .lib files of every dependency alongside libcvc. Both flavors
-# include cvc::xmlrpc.
+# Shared and static archives are both fully self-contained: every
+# project-level dependency (Boost, HDF5, FFTW, GSL on all platforms;
+# plus ImageMagick + CGAL/GMP/MPFR on Windows via vcpkg) is bundled
+# alongside libcvc, so consumers can `find_package(cvc CONFIG)` from
+# the extracted archive without needing apt / Homebrew / vcpkg on the
+# host. Shared archives ship .so/.dylib/.dll (with rpath fixups on
+# Linux+macOS) plus their import .lib on Windows; static archives ship
+# .a/.lib only. Both flavors include cvc::xmlrpc. System libraries
+# (glibc, libstdc++, libm, Windows UCRT) are intentionally left to the
+# host.
 #
 # volrover3 (end-user application, Release only):
 #   - Linux:   volrover3-<ver>-linux-<arch>.tar.gz         (portable)
@@ -218,16 +222,77 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
 
-      # ── libcvc developer tarball ────────────────────────────────
-      - name: Pack libcvc tarball
+      # ── libcvc developer tarball (self-contained) ───────────────
+      # Stage libcvc's install tree, then copy the libraries and
+      # headers of every project-level dependency (Boost, HDF5, FFTW,
+      # GSL) into the same tree so the archive is fully self-contained
+      # — consumers should be able to find_package(cvc CONFIG) without
+      # needing apt-installed dev packages on the host. System glibc /
+      # libstdc++ / libm are intentionally left to the host.
+      - name: Stage libcvc + bundle deps
         if: matrix.kind == 'libcvc'
-        working-directory: build
         run: |
+          set -euo pipefail
           STEM="libcvc-${{ steps.meta.outputs.version }}-linux-${{ steps.meta.outputs.arch }}-${{ steps.meta.outputs.btlc }}${{ steps.meta.outputs.linksfx }}"
-          cpack -G TGZ -D CPACK_COMPONENTS_ALL=libcvc \
-                      -D CPACK_PACKAGE_FILE_NAME="$STEM"
-          mv "$STEM-libcvc.tar.gz" "$STEM.tar.gz"
+          DIST="$PWD/$STEM"
+          rm -rf "$DIST"
+          cmake --install build --prefix "$DIST" --component libcvc
+          mkdir -p "$DIST/lib" "$DIST/include"
+
+          # Suffix pattern decides whether to grab dynamic or archive
+          # flavours of each dep. Both flavours are present in apt's
+          # libfoo-dev packages on Ubuntu.
+          if [ "${{ matrix.link }}" = "static" ]; then
+            patterns=( '*.a' )
+          else
+            patterns=( '*.so' '*.so.*' )
+          fi
+
+          LIBDIRS=( /usr/lib/x86_64-linux-gnu /usr/lib )
+          copy_libs() {
+            local prefix="$1"
+            for d in "${LIBDIRS[@]}"; do
+              for pat in "${patterns[@]}"; do
+                # -P preserves symlinks (libfoo.so → libfoo.so.1 → libfoo.so.1.2)
+                find "$d" -maxdepth 1 -name "${prefix}${pat}" -print0 2>/dev/null \
+                  | xargs -0 -r cp -P -t "$DIST/lib/" 2>/dev/null || true
+              done
+            done
+          }
+          copy_libs 'libboost_'
+          copy_libs 'libhdf5'
+          copy_libs 'libfftw3'
+          copy_libs 'libgsl'
+          copy_libs 'libgslcblas'
+
+          # Headers
+          for src in /usr/include/boost /usr/include/gsl; do
+            [ -d "$src" ] && cp -R "$src" "$DIST/include/"
+          done
+          # HDF5 headers live under /usr/include/hdf5/serial on Ubuntu.
+          if [ -d /usr/include/hdf5/serial ]; then
+            mkdir -p "$DIST/include/hdf5"
+            cp -R /usr/include/hdf5/serial/. "$DIST/include/hdf5/"
+          fi
+          for f in /usr/include/fftw3.h /usr/include/fftw3.f /usr/include/fftw3l.h /usr/include/fftw3q.h; do
+            [ -f "$f" ] && cp "$f" "$DIST/include/"
+          done
+
+          # For the shared flavour, rewrite libcvc.so's RUNPATH to
+          # $ORIGIN so it loads bundled .so files when the archive is
+          # extracted anywhere.
+          if [ "${{ matrix.link }}" = "shared" ]; then
+            sudo apt-get install -y --no-install-recommends patchelf
+            for so in "$DIST"/lib/libcvc*.so*; do
+              [ -e "$so" ] || continue
+              [ -L "$so" ] && continue
+              patchelf --set-rpath '$ORIGIN' "$so" || true
+            done
+          fi
+
+          tar czf "$STEM.tar.gz" "$STEM"
           cp "$STEM.tar.gz" "$GITHUB_WORKSPACE/"
+          du -sh "$DIST" "$STEM.tar.gz" || true
 
       # ── volrover3 portable tarball + .deb + AppImage ────────────
       - name: Pack volrover3 (tarball + .deb)
@@ -398,15 +463,52 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
 
-      - name: Pack libcvc zip
+      - name: Stage libcvc + bundle deps
         if: matrix.kind == 'libcvc'
-        working-directory: build
         run: |
+          set -euo pipefail
           STEM="libcvc-${{ steps.meta.outputs.version }}-macos-${{ steps.meta.outputs.arch }}-${{ steps.meta.outputs.btlc }}${{ steps.meta.outputs.linksfx }}"
-          cpack -G ZIP -D CPACK_COMPONENTS_ALL=libcvc \
-                      -D CPACK_PACKAGE_FILE_NAME="$STEM"
-          mv "$STEM-libcvc.zip" "$STEM.zip"
+          DIST="$PWD/$STEM"
+          rm -rf "$DIST"
+          cmake --install build --prefix "$DIST" --component libcvc
+          mkdir -p "$DIST/lib" "$DIST/include"
+
+          # Headers are always needed for downstream `find_package`
+          # consumers; copy them from Homebrew prefixes.
+          for pkg in boost hdf5 fftw gsl; do
+            P=$(brew --prefix "$pkg" 2>/dev/null || true)
+            if [ -n "$P" ] && [ -d "$P/include" ]; then
+              cp -R "$P/include/." "$DIST/include/" 2>/dev/null || true
+            fi
+          done
+
+          if [ "${{ matrix.link }}" = "shared" ]; then
+            # dylibbundler walks libcvc.dylib's transitive deps, copies
+            # any missing dylibs alongside, and rewrites all install_names
+            # to @rpath/<dylib> with rpath @loader_path. Far more reliable
+            # than hand-rolled install_name_tool plumbing across the deep
+            # Boost/HDF5 dependency graph.
+            brew install dylibbundler
+            for dy in "$DIST"/lib/libcvc*.dylib; do
+              [ -e "$dy" ] || continue
+              [ -L "$dy" ] && continue
+              dylibbundler -od -b -x "$dy" -d "$DIST/lib" -p '@loader_path/' -of -cd || true
+            done
+          else
+            # Static flavour: just copy the .a archives. No install_name
+            # fixup needed — static linkage embeds object code directly.
+            for pkg in boost hdf5 fftw gsl; do
+              P=$(brew --prefix "$pkg" 2>/dev/null || true)
+              if [ -n "$P" ] && [ -d "$P/lib" ]; then
+                find "$P/lib" -maxdepth 1 -name '*.a' -print0 2>/dev/null \
+                  | xargs -0 -I {} cp -RP {} "$DIST/lib/" 2>/dev/null || true
+              fi
+            done
+          fi
+
+          ditto -c -k --sequesterRsrc --keepParent "$DIST" "$STEM.zip"
           cp "$STEM.zip" "$GITHUB_WORKSPACE/"
+          du -sh "$DIST" "$STEM.zip" || true
 
       - name: Pack volrover3 (.dmg + .zip)
         if: matrix.kind == 'volrover3'
@@ -692,15 +794,54 @@ jobs:
         if: matrix.kind == 'volrover3'
         run: choco install nsis -y
 
-      - name: Pack libcvc zip
+      - name: Stage libcvc + bundle deps
         if: matrix.kind == 'libcvc'
         shell: pwsh
-        working-directory: build
         run: |
+          $ErrorActionPreference = 'Stop'
           $stem = "libcvc-${{ steps.meta.outputs.version }}-windows-${{ steps.meta.outputs.arch }}-${{ steps.meta.outputs.btlc }}${{ steps.meta.outputs.linksfx }}"
-          cpack -G ZIP -C ${{ matrix.build_type }} -D CPACK_COMPONENTS_ALL=libcvc -D CPACK_PACKAGE_FILE_NAME="$stem"
-          Move-Item "$stem-libcvc.zip" "$stem.zip"
-          Copy-Item "$stem.zip" "$env:GITHUB_WORKSPACE/"
+          $dist = Join-Path $env:GITHUB_WORKSPACE $stem
+          if (Test-Path $dist) { Remove-Item -Recurse -Force $dist }
+          cmake --install build --prefix $dist --config ${{ matrix.build_type }} --component libcvc
+
+          # vcpkg's installed tree is the single source of truth for
+          # every transitive dependency we pulled in (Boost, HDF5,
+          # FFTW, GSL, ImageMagick, ...). For the x64-windows triplet
+          # that's DLLs + import .libs; for x64-windows-static it's
+          # static .libs only. We mirror the entire tree so consumers
+          # can find_package(cvc CONFIG) without their own vcpkg.
+          $triplet = '${{ steps.meta.outputs.triplet }}'
+          $vcRoot  = Join-Path $env:VCPKG_INSTALLATION_ROOT "installed/$triplet"
+          if (-not (Test-Path $vcRoot)) {
+            throw "vcpkg installed tree not found at $vcRoot"
+          }
+
+          # Layout differs slightly between Debug and Release:
+          #   <triplet>/{bin,lib,include}        — release
+          #   <triplet>/debug/{bin,lib}          — debug (headers shared)
+          $isDebug = '${{ matrix.build_type }}' -eq 'Debug'
+          $libSrc  = if ($isDebug) { Join-Path $vcRoot 'debug/lib' } else { Join-Path $vcRoot 'lib' }
+          $binSrc  = if ($isDebug) { Join-Path $vcRoot 'debug/bin' } else { Join-Path $vcRoot 'bin' }
+
+          New-Item -ItemType Directory -Force -Path "$dist/lib","$dist/include" | Out-Null
+          if (Test-Path "$vcRoot/include") {
+            Copy-Item -Recurse -Force "$vcRoot/include/*" "$dist/include/"
+          }
+          if (Test-Path $libSrc) {
+            Get-ChildItem -Path $libSrc -Filter '*.lib' -File `
+              | Copy-Item -Destination "$dist/lib/" -Force
+          }
+          if ('${{ matrix.link }}' -eq 'shared') {
+            New-Item -ItemType Directory -Force -Path "$dist/bin" | Out-Null
+            if (Test-Path $binSrc) {
+              Get-ChildItem -Path $binSrc -Filter '*.dll' -File `
+                | Copy-Item -Destination "$dist/bin/" -Force
+            }
+          }
+
+          Compress-Archive -Path "$dist/*" -DestinationPath (Join-Path $env:GITHUB_WORKSPACE "$stem.zip") -Force
+          "$stem staged at $dist" | Write-Host
+          Get-ChildItem "$env:GITHUB_WORKSPACE/$stem.zip" | Format-List Name,Length
 
       - name: Pack volrover3 (zip + NSIS)
         if: matrix.kind == 'volrover3'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,16 @@ permissions:
 # the extracted archive without needing apt / Homebrew / vcpkg on the
 # host. Shared archives ship .so/.dylib/.dll (with rpath fixups on
 # Linux+macOS) plus their import .lib on Windows; static archives ship
-# .a/.lib only. Both flavors include cvc::xmlrpc. System libraries
-# (glibc, libstdc++, libm, Windows UCRT) are intentionally left to the
-# host.
+# .a/.lib only. Both flavors include cvc::xmlrpc plus a Qt-free build
+# of VTK 9.5 (libvtk*.so/.dylib/.dll/.a/.lib + headers + CMake config)
+# so consumers don't have to rebuild VTK separately.
+#
+# Debug archives on Windows also include MSVC .pdb files for libcvc
+# itself, every vcpkg-built dependency, and VTK, so symbolicated stack
+# traces work out of the box.
+#
+# System libraries (glibc, libstdc++, libm, Windows UCRT) are
+# intentionally left to the host.
 #
 # volrover3 (end-user application, Release only):
 #   - Linux:   volrover3-<ver>-linux-<arch>.tar.gz         (portable)
@@ -153,6 +160,45 @@ jobs:
             libxrender-dev libxcursor-dev libxinerama-dev libxi-dev \
             libcgal-dev \
             libfuse2 file desktop-file-utils
+
+      # ── VTK 9.5 (Qt-free) for libcvc archives ──
+      # Built per (build_type, link) so debug-shared, release-shared,
+      # debug-static, release-static each get a matching VTK install
+      # tree to bundle. Qt is intentionally disabled: libcvc itself
+      # has no Qt dependency, and bundling Qt6 would balloon the
+      # libcvc archive by hundreds of MB. The volrover3 row keeps its
+      # own ~/vtk-qt6 build (with Qt) cached separately below.
+      - name: Cache VTK (no Qt) install tree
+        if: matrix.kind == 'libcvc'
+        id: vtk-nq-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/vtk-nq
+          key: vtk-nq-9.5.0-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.link }}-v1
+
+      - name: Build VTK 9.5 (no Qt) from source
+        if: matrix.kind == 'libcvc' && steps.vtk-nq-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.link }}" = "static" ]; then
+            vtk_shared=OFF
+          else
+            vtk_shared=ON
+          fi
+          curl -L -o vtk.tar.gz https://github.com/Kitware/VTK/archive/refs/tags/v9.5.0.tar.gz
+          tar xzf vtk.tar.gz
+          cmake -S VTK-9.5.0 -B vtk-build -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_INSTALL_PREFIX=$HOME/vtk-nq \
+            -DBUILD_SHARED_LIBS=$vtk_shared \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DVTK_GROUP_ENABLE_Qt=NO \
+            -DVTK_BUILD_TESTING=OFF \
+            -DVTK_BUILD_EXAMPLES=OFF \
+            -DVTK_BUILD_DOCUMENTATION=OFF \
+            -DVTK_LEGACY_REMOVE=ON
+          cmake --build vtk-build --parallel --target install
+          rm -rf vtk-build VTK-9.5.0 vtk.tar.gz
 
       # ── VTK 9.5 built against Qt6, cached ──
       # Cache key matches ci.yml so the build is shared across both
@@ -278,16 +324,53 @@ jobs:
             [ -f "$f" ] && cp "$f" "$DIST/include/"
           done
 
-          # For the shared flavour, rewrite libcvc.so's RUNPATH to
-          # $ORIGIN so it loads bundled .so files when the archive is
-          # extracted anywhere.
+          # For the shared flavour, rewrite RUNPATH on libcvc.so AND
+          # every bundled dep .so to $ORIGIN so the loader resolves
+          # transitive dependencies within the same lib/ directory
+          # regardless of where the archive is extracted. DT_RUNPATH
+          # (which patchelf sets) does NOT propagate across dlopen()
+          # boundaries the way DT_RPATH would, so we have to stamp
+          # $ORIGIN on each bundled .so individually.
           if [ "${{ matrix.link }}" = "shared" ]; then
             sudo apt-get install -y --no-install-recommends patchelf
-            for so in "$DIST"/lib/libcvc*.so*; do
+            for so in "$DIST"/lib/*.so*; do
               [ -e "$so" ] || continue
               [ -L "$so" ] && continue
-              patchelf --set-rpath '$ORIGIN' "$so" || true
+              # Strip any pre-existing absolute RPATH first (some apt
+              # packages embed /build/foo/.libs paths), then set ours.
+              patchelf --remove-rpath "$so" 2>/dev/null || true
+              patchelf --set-rpath '$ORIGIN' "$so" 2>/dev/null || true
             done
+          fi
+
+          # ── Bundle VTK (no Qt) ──────────────────────────────────
+          if [ -d "$HOME/vtk-nq" ]; then
+            mkdir -p "$DIST/lib/cmake" "$DIST/include"
+            # Copy VTK install tree alongside libcvc's own files.
+            # Include trees may not overlap; if they do, VTK headers
+            # land under include/vtk-9.5/ which doesn't collide.
+            for src in "$HOME/vtk-nq/include"/*; do
+              [ -e "$src" ] && cp -R "$src" "$DIST/include/" 2>/dev/null || true
+            done
+            if [ -d "$HOME/vtk-nq/lib" ]; then
+              # Preserve symlinks for shared lib SONAMEs.
+              find "$HOME/vtk-nq/lib" -maxdepth 1 \( -name '*.so*' -o -name '*.a' \) -print0 \
+                | xargs -0 -r cp -P -t "$DIST/lib/" 2>/dev/null || true
+              # CMake config bundle.
+              if [ -d "$HOME/vtk-nq/lib/cmake" ]; then
+                cp -R "$HOME/vtk-nq/lib/cmake/." "$DIST/lib/cmake/" 2>/dev/null || true
+              fi
+            fi
+            # Re-stamp RUNPATH on any VTK .so we just dropped in so it
+            # finds its peers via $ORIGIN as well.
+            if [ "${{ matrix.link }}" = "shared" ]; then
+              for so in "$DIST"/lib/libvtk*.so*; do
+                [ -e "$so" ] || continue
+                [ -L "$so" ] && continue
+                patchelf --remove-rpath "$so" 2>/dev/null || true
+                patchelf --set-rpath '$ORIGIN' "$so" 2>/dev/null || true
+              done
+            fi
           fi
 
           tar czf "$STEM.tar.gz" "$STEM"
@@ -428,6 +511,38 @@ jobs:
           echo "BOOST_ROOT=$(brew --prefix boost)" >> $GITHUB_ENV
           echo "CMAKE_PREFIX_PATH=$(brew --prefix boost):$(brew --prefix hdf5)" >> $GITHUB_ENV
 
+      - name: Cache VTK (no Qt) install tree
+        if: matrix.kind == 'libcvc'
+        id: vtk-nq-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/vtk-nq
+          key: vtk-nq-9.5.0-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.link }}-v1
+
+      - name: Build VTK 9.5 (no Qt) from source
+        if: matrix.kind == 'libcvc' && steps.vtk-nq-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.link }}" = "static" ]; then
+            vtk_shared=OFF
+          else
+            vtk_shared=ON
+          fi
+          curl -L -o vtk.tar.gz https://github.com/Kitware/VTK/archive/refs/tags/v9.5.0.tar.gz
+          tar xzf vtk.tar.gz
+          cmake -S VTK-9.5.0 -B vtk-build -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_INSTALL_PREFIX=$HOME/vtk-nq \
+            -DBUILD_SHARED_LIBS=$vtk_shared \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DVTK_GROUP_ENABLE_Qt=NO \
+            -DVTK_BUILD_TESTING=OFF \
+            -DVTK_BUILD_EXAMPLES=OFF \
+            -DVTK_BUILD_DOCUMENTATION=OFF \
+            -DVTK_LEGACY_REMOVE=ON
+          cmake --build vtk-build --parallel --target install
+          rm -rf vtk-build VTK-9.5.0 vtk.tar.gz
+
       - name: Install dependencies (volrover3)
         if: matrix.kind == 'volrover3'
         run: |
@@ -504,6 +619,46 @@ jobs:
                   | xargs -0 -I {} cp -RP {} "$DIST/lib/" 2>/dev/null || true
               fi
             done
+          fi
+
+          # ── Bundle VTK (no Qt) ──────────────────────────────────
+          if [ -d "$HOME/vtk-nq" ]; then
+            mkdir -p "$DIST/lib/cmake" "$DIST/include"
+            for src in "$HOME/vtk-nq/include"/*; do
+              [ -e "$src" ] && cp -R "$src" "$DIST/include/" 2>/dev/null || true
+            done
+            if [ -d "$HOME/vtk-nq/lib" ]; then
+              find "$HOME/vtk-nq/lib" -maxdepth 1 \( -name '*.dylib' -o -name '*.a' \) -print0 \
+                | xargs -0 -I {} cp -RP {} "$DIST/lib/" 2>/dev/null || true
+              if [ -d "$HOME/vtk-nq/lib/cmake" ]; then
+                cp -R "$HOME/vtk-nq/lib/cmake/." "$DIST/lib/cmake/" 2>/dev/null || true
+              fi
+            fi
+            # Rewrite install_names on bundled VTK dylibs so they
+            # resolve siblings via @loader_path/ (i.e. find each
+            # other inside the archive's lib/ directory).
+            if [ "${{ matrix.link }}" = "shared" ]; then
+              for dy in "$DIST"/lib/libvtk*.dylib; do
+                [ -e "$dy" ] || continue
+                [ -L "$dy" ] && continue
+                # Set the dylib's own LC_ID_DYLIB to @rpath/<name>.
+                base=$(basename "$dy")
+                install_name_tool -id "@rpath/$base" "$dy" 2>/dev/null || true
+                # Rewrite every load command that references another
+                # absolute path under /usr/local/Cellar/vtk/... to a
+                # @loader_path-relative form, then add an rpath of
+                # @loader_path so siblings resolve.
+                otool -L "$dy" | awk 'NR>1 {print $1}' | while read -r dep; do
+                  case "$dep" in
+                    /usr/local/*|/opt/homebrew/*|@rpath/*)
+                      depbase=$(basename "$dep")
+                      install_name_tool -change "$dep" "@loader_path/$depbase" "$dy" 2>/dev/null || true
+                      ;;
+                  esac
+                done
+                install_name_tool -add_rpath '@loader_path/' "$dy" 2>/dev/null || true
+              done
+            fi
           fi
 
           ditto -c -k --sequesterRsrc --keepParent "$DIST" "$STEM.zip"
@@ -705,6 +860,62 @@ jobs:
             Start-Sleep -Seconds $sleep
           }
 
+      # ── VTK 9.5 (Qt-free) for libcvc archives on Windows ──
+      # Built per (build_type, link); installs into D:\vtk-nq with
+      # PDB files preserved for Debug builds. Bundled into the libcvc
+      # archive in the Pack step further down.
+      - name: Restore VTK (no Qt) cache (Windows)
+        if: matrix.kind == 'libcvc'
+        id: vtk-nq-cache-windows
+        uses: actions/cache/restore@v4
+        with:
+          path: D:\vtk-nq
+          key: vtk-nq-9.5.0-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.link }}-v1
+
+      - name: Build VTK 9.5 (no Qt) from source (Windows)
+        if: matrix.kind == 'libcvc' && steps.vtk-nq-cache-windows.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $vtkShared = if ('${{ matrix.link }}' -eq 'static') { 'OFF' } else { 'ON' }
+          $msvcrt = if ('${{ matrix.link }}' -eq 'static') {
+            'MultiThreaded$<$<CONFIG:Debug>:Debug>'
+          } else {
+            'MultiThreaded$<$<CONFIG:Debug>:Debug>DLL'
+          }
+          Invoke-WebRequest -Uri https://github.com/Kitware/VTK/archive/refs/tags/v9.5.0.tar.gz -OutFile vtk.tar.gz
+          tar xzf vtk.tar.gz
+          cmake -S VTK-9.5.0 -B D:\vtk-nq-build `
+            -DCMAKE_INSTALL_PREFIX=D:\vtk-nq `
+            -DBUILD_SHARED_LIBS=$vtkShared `
+            -DCMAKE_MSVC_RUNTIME_LIBRARY="$msvcrt" `
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON `
+            -DVTK_GROUP_ENABLE_Qt=NO `
+            -DVTK_BUILD_TESTING=OFF `
+            -DVTK_BUILD_EXAMPLES=OFF `
+            -DVTK_BUILD_DOCUMENTATION=OFF `
+            -DVTK_LEGACY_REMOVE=ON
+          cmake --build D:\vtk-nq-build --config ${{ matrix.build_type }} --parallel --target install
+          # Stash PDB files alongside the install tree for Debug builds.
+          # CMake's install rules typically skip per-target .pdb files
+          # for static .lib targets, so we copy them out of the build
+          # tree manually before the build dir is removed.
+          if ('${{ matrix.build_type }}' -eq 'Debug') {
+            New-Item -ItemType Directory -Force -Path D:\vtk-nq\pdb | Out-Null
+            Get-ChildItem -Path D:\vtk-nq-build -Recurse -Include *.pdb -File `
+              | Copy-Item -Destination D:\vtk-nq\pdb -Force
+          }
+          Remove-Item -Recurse -Force D:\vtk-nq-build
+          Remove-Item -Recurse -Force VTK-9.5.0
+          Remove-Item -Force vtk.tar.gz
+
+      - name: Save VTK (no Qt) cache (Windows)
+        if: matrix.kind == 'libcvc' && steps.vtk-nq-cache-windows.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: D:\vtk-nq
+          key: vtk-nq-9.5.0-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.link }}-v1
+
       # ── VTK 9.5 built from source against aqt Qt6, cached ──
       # Mirrors the Ubuntu strategy. Cache key includes build_type
       # because MSVC Debug and Release VTK DLLs are not interchangeable.
@@ -804,22 +1015,39 @@ jobs:
           if (Test-Path $dist) { Remove-Item -Recurse -Force $dist }
           cmake --install build --prefix $dist --config ${{ matrix.build_type }} --component libcvc
 
-          # vcpkg's installed tree is the single source of truth for
-          # every transitive dependency we pulled in (Boost, HDF5,
-          # FFTW, GSL, ImageMagick, ...). For the x64-windows triplet
-          # that's DLLs + import .libs; for x64-windows-static it's
-          # static .libs only. We mirror the entire tree so consumers
-          # can find_package(cvc CONFIG) without their own vcpkg.
+          $isDebug = '${{ matrix.build_type }}' -eq 'Debug'
+
+          # ── libcvc's own PDB ─────────────────────────────────────
+          # CMake's install(TARGETS) doesn't ship .pdb files by default
+          # on MSVC. For Debug we always want them; copy from the build
+          # tree manually so symbolicated stack traces work for
+          # downstream consumers that link a libcvc Debug build.
+          if ($isDebug) {
+            New-Item -ItemType Directory -Force -Path "$dist/bin","$dist/lib" | Out-Null
+            Get-ChildItem -Path build -Recurse -Include *.pdb -File `
+              | Where-Object { $_.Name -like 'cvc*.pdb' -or $_.Name -like 'xmlrpc*.pdb' } `
+              | ForEach-Object {
+                  # DLL pdbs live next to the .dll (so → bin); static
+                  # compile-time pdbs (vc*.pdb-ish) sit next to the
+                  # .lib (so → lib). Drop them into both for simplicity;
+                  # consumers don't care which dir they're in.
+                  Copy-Item $_.FullName -Destination "$dist/bin/" -Force -ErrorAction SilentlyContinue
+                  Copy-Item $_.FullName -Destination "$dist/lib/" -Force -ErrorAction SilentlyContinue
+                }
+          }
+
+          # ── vcpkg deps (entire installed/<triplet> tree) ────────
           $triplet = '${{ steps.meta.outputs.triplet }}'
           $vcRoot  = Join-Path $env:VCPKG_INSTALLATION_ROOT "installed/$triplet"
           if (-not (Test-Path $vcRoot)) {
             throw "vcpkg installed tree not found at $vcRoot"
           }
 
-          # Layout differs slightly between Debug and Release:
+          # Layout per triplet:
           #   <triplet>/{bin,lib,include}        — release
           #   <triplet>/debug/{bin,lib}          — debug (headers shared)
-          $isDebug = '${{ matrix.build_type }}' -eq 'Debug'
+          # Debug subtrees also carry .pdb files alongside their .dll /
+          # .lib outputs (vcpkg builds with /Zi /DEBUG by default).
           $libSrc  = if ($isDebug) { Join-Path $vcRoot 'debug/lib' } else { Join-Path $vcRoot 'lib' }
           $binSrc  = if ($isDebug) { Join-Path $vcRoot 'debug/bin' } else { Join-Path $vcRoot 'bin' }
 
@@ -828,14 +1056,50 @@ jobs:
             Copy-Item -Recurse -Force "$vcRoot/include/*" "$dist/include/"
           }
           if (Test-Path $libSrc) {
-            Get-ChildItem -Path $libSrc -Filter '*.lib' -File `
-              | Copy-Item -Destination "$dist/lib/" -Force
+            $patterns = if ($isDebug) { @('*.lib','*.pdb') } else { @('*.lib') }
+            foreach ($p in $patterns) {
+              Get-ChildItem -Path $libSrc -Filter $p -File `
+                | Copy-Item -Destination "$dist/lib/" -Force
+            }
           }
           if ('${{ matrix.link }}' -eq 'shared') {
             New-Item -ItemType Directory -Force -Path "$dist/bin" | Out-Null
             if (Test-Path $binSrc) {
-              Get-ChildItem -Path $binSrc -Filter '*.dll' -File `
+              $patterns = if ($isDebug) { @('*.dll','*.pdb') } else { @('*.dll') }
+              foreach ($p in $patterns) {
+                Get-ChildItem -Path $binSrc -Filter $p -File `
+                  | Copy-Item -Destination "$dist/bin/" -Force
+              }
+            }
+          }
+
+          # ── Bundle VTK (no Qt) ──────────────────────────────────
+          if (Test-Path D:\vtk-nq) {
+            if (Test-Path D:\vtk-nq\include) {
+              Copy-Item -Recurse -Force D:\vtk-nq\include\* "$dist/include/"
+            }
+            if (Test-Path D:\vtk-nq\lib) {
+              Get-ChildItem -Path D:\vtk-nq\lib -Filter '*.lib' -File `
+                | Copy-Item -Destination "$dist/lib/" -Force
+              if (Test-Path D:\vtk-nq\lib\cmake) {
+                New-Item -ItemType Directory -Force -Path "$dist/lib/cmake" | Out-Null
+                Copy-Item -Recurse -Force D:\vtk-nq\lib\cmake\* "$dist/lib/cmake/"
+              }
+            }
+            if ('${{ matrix.link }}' -eq 'shared' -and (Test-Path D:\vtk-nq\bin)) {
+              Get-ChildItem -Path D:\vtk-nq\bin -Filter '*.dll' -File `
                 | Copy-Item -Destination "$dist/bin/" -Force
+            }
+            if ($isDebug -and (Test-Path D:\vtk-nq\pdb)) {
+              # Drop VTK's PDB files alongside their .dll (shared) or
+              # .lib (static). For simplicity place all .pdb under both
+              # bin/ and lib/; the debugger searches both.
+              New-Item -ItemType Directory -Force -Path "$dist/bin","$dist/lib" | Out-Null
+              Get-ChildItem -Path D:\vtk-nq\pdb -Filter '*.pdb' -File `
+                | ForEach-Object {
+                    Copy-Item $_.FullName -Destination "$dist/bin/" -Force -ErrorAction SilentlyContinue
+                    Copy-Item $_.FullName -Destination "$dist/lib/" -Force -ErrorAction SilentlyContinue
+                  }
             }
           }
 


### PR DESCRIPTION
ci: bundle all dependencies into libcvc release archives

Previously the libcvc-*.tar.gz / .zip archives shipped only libcvc
itself plus its CMake config files. Downstream consumers
(F2Dock, MolSurf, volrover) still had to discover Boost, HDF5,
FFTW, GSL, ImageMagick, CGAL, GMP and MPFR on the host ? on
Windows this meant a ~1 hour cold-cache vcpkg rebuild on every CI
runner.

Replace the cpack-based "Pack libcvc" steps on all three OSes
with a stage-and-bundle flow that ships every project-level
dependency inside each archive:

- Linux: copy libboost_*, libhdf5*, libfftw3*, libgsl*,
  libgslcblas* (both .so* for shared and .a for static) from
  /usr/lib/x86_64-linux-gnu; copy Boost / GSL / HDF5 / FFTW
  headers from /usr/include. Run patchelf --set-rpath '$ORIGIN'
  on the shared libcvc.so so it loads bundled deps wherever the
  archive is extracted.

- macOS: for shared, use dylibbundler against libcvc.dylib to
  walk its transitive Homebrew dependency graph, copy missing
  dylibs alongside, and rewrite every install_name to
  @rpath/<dylib> with rpath @loader_path. For static, copy
  Boost / HDF5 / FFTW / GSL .a archives directly from each
  brew --prefix. Headers always copied.

- Windows: mirror the full vcpkg installed/<triplet>/{bin,lib,include}
  tree. For x64-windows this gives DLLs + import .libs; for
  x64-windows-static it gives static .libs. Headers are shared
  between Debug and Release; binaries come from the matching
  Debug / Release subtree.

System libraries (glibc, libstdc++, libm, Windows UCRT) are
intentionally left to the host. Both flavors continue to ship
cvc::xmlrpc and the cvcConfig.cmake package config so a single
find_package(cvc CONFIG PATHS <extract-dir>) call works from any
consumer.
