### PR TITLE
tests: fix std::min type mismatch in geometry_test (macOS arm64)

### DIFF
--- a/src/cvc/tests/geometry_test.cpp
+++ b/src/cvc/tests/geometry_test.cpp
@@ -1027,7 +1027,7 @@ TEST_F(GeometryTest, ProjectToTargetSurface) {
   // Vertices should be closer to target now
   // This is a basic sanity check - projection should change vertices
   bool projection_occurred = false;
-  for (size_t i = 0; i < std::min(source.num_points(), size_t(100)); i++) {
+  for (size_t i = 0; i < std::min<size_t>(source.num_points(), 100); i++) {
     double dist = 0.0;
     for (int j = 0; j < 3; j++) {
       double diff = source.points()[i][j] - target.points()[i][j];


### PR DESCRIPTION
`std::min(source.num_points(), size_t(100))` fails to deduce `_Tp` on macOS arm64 where `size_t` is `unsigned long` but `num_points()` returns `uint64_t` (= `unsigned long long`). Linux x86_64 happens to typedef both as `unsigned long` so this only broke on macOS.

Was latent until #55 turned on `CVC_BUILD_TESTS=ON` in the macOS `package-*` jobs. Fix is a one-line explicit template arg.

```cpp
-  for (size_t i = 0; i < std::min(source.num_points(), size_t(100)); i++) {
+  for (size_t i = 0; i < std::min<size_t>(source.num_points(), 100); i++) {
```