### PR TITLE
tests: deflake AppTest.ThreadFeedbackExceptionSafety by joining before progress read

### DIFF
--- a/src/cvc/tests/app_test.cpp
+++ b/src/cvc/tests/app_test.cpp
@@ -1603,17 +1603,23 @@ TEST_F(AppTest, ThreadFeedbackExceptionSafety) {
   }
   ASSERT_TRUE(exception_thrown.load());
 
-  // Join the thread BEFORE checking progress: thread_feedback's destructor
-  // runs as the catch block unwinds, and we need a happens-before edge
-  // between that destructor and our progress read. A fixed sleep is racy
-  // under CI load (the original 200 ms was occasionally insufficient on
-  // GitHub-hosted Linux runners), but join() is a hard synchronization
-  // point that guarantees the destructor has completed.
-  ASSERT_TRUE(ctx.hasThread(thread_key));
-  thread_ptr tptr = ctx.threads(thread_key);
-  ASSERT_TRUE(tptr);
-  if (tptr->joinable())
-    tptr->join();
+  // Synchronize with the worker BEFORE checking progress: thread_feedback's
+  // destructor runs as the catch block unwinds, and we need a happens-before
+  // edge between that destructor and our progress read. A fixed sleep was
+  // racy under CI load. Two cases, both safe:
+  //   (a) The worker has not yet finished — hasThread() returns true, we
+  //       grab the thread handle and join(). join() is a hard sync point
+  //       that guarantees the destructor (and finishThreadProgress) ran.
+  //   (b) The worker has already finished — hasThread() returns false
+  //       because thread_feedback's destructor called finishThreadProgress,
+  //       which erases _threads[key] and writes _threadProgressByKey[key]
+  //       = 1.0 atomically under _threadsMutex. Subsequent threadProgress
+  //       reads happen-after that write through the same mutex.
+  if (ctx.hasThread(thread_key)) {
+    thread_ptr tptr = ctx.threads(thread_key);
+    if (tptr && tptr->joinable())
+      tptr->join();
+  }
 
   // Progress should now be 100% — set by thread_feedback's destructor
   // during stack unwinding.

--- a/src/cvc/tests/app_test.cpp
+++ b/src/cvc/tests/app_test.cpp
@@ -1603,20 +1603,23 @@ TEST_F(AppTest, ThreadFeedbackExceptionSafety) {
   }
   ASSERT_TRUE(exception_thrown.load());
 
-  // Give thread time to exit
-  boost::this_thread::sleep_for(boost::chrono::milliseconds(200));
+  // Join the thread BEFORE checking progress: thread_feedback's destructor
+  // runs as the catch block unwinds, and we need a happens-before edge
+  // between that destructor and our progress read. A fixed sleep is racy
+  // under CI load (the original 200 ms was occasionally insufficient on
+  // GitHub-hosted Linux runners), but join() is a hard synchronization
+  // point that guarantees the destructor has completed.
+  ASSERT_TRUE(ctx.hasThread(thread_key));
+  thread_ptr tptr = ctx.threads(thread_key);
+  ASSERT_TRUE(tptr);
+  if (tptr->joinable())
+    tptr->join();
 
-  // Progress should still be set to 100% by thread_feedback destructor
+  // Progress should now be 100% — set by thread_feedback's destructor
+  // during stack unwinding.
   double progress = ctx.threadProgress(thread_key);
   EXPECT_NEAR(progress, 1.0, 0.01)
       << "Progress should be 100% even when exception occurs (RAII cleanup)";
-
-  // Clean up
-  if (ctx.hasThread(thread_key)) {
-    thread_ptr tptr = ctx.threads(thread_key);
-    if (tptr && tptr->joinable())
-      tptr->join();
-  }
 }
 
 TEST_F(AppTest, ThreadProgressWithThreadInterruption) {


### PR DESCRIPTION
## Race

The test signalled `exception_thrown = true` from the worker, then slept 200 ms on the main thread before reading progress. `thread_feedback`'s destructor runs as the catch block unwinds, sequenced *after* the atomic store inside the worker but **not** synchronized with the main thread's progress read. A 200 ms sleep is racy under CI load.

GHA Linux failed this test on attempt 1 of `--repeat until-pass:3` in run [25657642671](https://github.com/transfix/libcvc/actions/runs/25657642671). The retry masked it.

## Fix

`join()` the worker before reading progress. `join()` is a hard happens-before edge that guarantees the destructor has fully completed; the sleep is no longer needed and the test becomes deterministic.