### PR TITLE
ci: consume libcvc-deps v1.0.0 to skip VTK source build

### DIFF
--- a/.github/actions/fetch-libcvc-deps/action.yml
+++ b/.github/actions/fetch-libcvc-deps/action.yml
@@ -1,0 +1,167 @@
+name: 'Fetch libcvc-deps'
+description: |
+  Attempts to download a pinned libcvc-deps release archive matching
+  the current platform / build config and extract it to a known
+  prefix path. The extracted root contains a self-contained CMake
+  prefix (Boost, HDF5, FFTW, GSL, log4cplus, CGAL, ImageMagick,
+  Qt 6, VTK 9.5) so workflow steps can skip the slow
+  VTK-from-source build whenever a matching dep bundle is available.
+
+  Behaviour:
+    * Computes the URL from inputs (defaults match libcvc-deps's
+      release.yml stem naming).
+    * curl -fL the archive into a temp file; falls back to nothing
+      on any HTTP error (404, network blip, etc.) instead of
+      failing the build. This keeps the calling workflow robust to
+      the libcvc-deps release not yet existing for a given version.
+    * On success, extracts to <prefix>/libcvc-deps-<...> and emits
+      that path as the `path` output.
+    * Caller is expected to gate the from-source VTK build step on
+      `steps.<id>.outputs.path != ''` and to add `path` to
+      CMAKE_PREFIX_PATH when set.
+
+inputs:
+  version:
+    description: 'libcvc-deps release version (without leading v).'
+    required: false
+    default: '1.0.0'
+  os:
+    description: 'linux | macos | windows. Defaults to runner.os.'
+    required: false
+    default: ''
+  arch:
+    description: 'CPU arch (x86_64, arm64). Defaults to runner host arch.'
+    required: false
+    default: ''
+  build_type:
+    description: 'Debug or Release. Used to pick the matching archive flavor.'
+    required: true
+  link:
+    description: 'shared or static. Picks the -static suffix if static.'
+    required: false
+    default: 'shared'
+  prefix:
+    description: 'Directory under which to extract the archive.'
+    required: false
+    default: ''
+
+outputs:
+  path:
+    description: 'Absolute path to the extracted libcvc-deps root, or empty string if no matching archive was available.'
+    value: ${{ steps.extract.outputs.path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'libcvc-deps: try fetch + extract'
+      id: extract
+      shell: bash
+      env:
+        LCD_VERSION:    ${{ inputs.version }}
+        LCD_OS:         ${{ inputs.os }}
+        LCD_ARCH:       ${{ inputs.arch }}
+        LCD_BUILD_TYPE: ${{ inputs.build_type }}
+        LCD_LINK:       ${{ inputs.link }}
+        LCD_PREFIX:     ${{ inputs.prefix }}
+        RUNNER_OS:      ${{ runner.os }}
+      run: |
+        set -euo pipefail
+
+        # Resolve defaults from the runner context when caller did
+        # not pin os/arch/prefix.
+        os="${LCD_OS}"
+        if [ -z "$os" ]; then
+          case "$RUNNER_OS" in
+            Linux)   os=linux ;;
+            macOS)   os=macos ;;
+            Windows) os=windows ;;
+            *)       os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]') ;;
+          esac
+        fi
+
+        arch="${LCD_ARCH}"
+        if [ -z "$arch" ]; then
+          if [ "$os" = "windows" ]; then
+            arch="x86_64"
+          else
+            arch=$(uname -m)
+          fi
+        fi
+
+        btlc=$(echo "${LCD_BUILD_TYPE}" | tr '[:upper:]' '[:lower:]')
+
+        linksfx=""
+        if [ "${LCD_LINK}" = "static" ]; then
+          linksfx="-static"
+        fi
+
+        # Linux ships .tar.gz; macOS and Windows ship .zip.
+        if [ "$os" = "linux" ]; then
+          ext="tar.gz"
+        else
+          ext="zip"
+        fi
+
+        stem="libcvc-deps-${LCD_VERSION}-${os}-${arch}-${btlc}${linksfx}"
+        url="https://github.com/transfix/libcvc-deps/releases/download/v${LCD_VERSION}/${stem}.${ext}"
+
+        prefix="${LCD_PREFIX}"
+        if [ -z "$prefix" ]; then
+          if [ "$os" = "windows" ]; then
+            prefix="D:/libcvc-deps"
+          else
+            prefix="$HOME/libcvc-deps"
+          fi
+        fi
+        mkdir -p "$prefix"
+
+        echo "libcvc-deps: trying $url"
+        tmp="$(mktemp -d)"
+        archive="$tmp/${stem}.${ext}"
+        if ! curl -fL -o "$archive" "$url"; then
+          echo "libcvc-deps: archive not available (HTTP error); falling back."
+          echo "path=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Sanity-check the archive is non-empty before extracting.
+        if [ ! -s "$archive" ]; then
+          echo "libcvc-deps: archive is empty; ignoring."
+          echo "path=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        case "$ext" in
+          tar.gz)
+            tar -xzf "$archive" -C "$prefix"
+            ;;
+          zip)
+            # unzip is preinstalled on all GH runners (incl. Git Bash on Windows).
+            unzip -q "$archive" -d "$prefix"
+            ;;
+        esac
+
+        # Some archives extract as a single root dir matching $stem
+        # (Linux + macOS via tar/ditto-keepParent); the Windows zip
+        # is flat from libcvc-deps's `Compress-Archive -Path $dist/*`.
+        # Normalise both layouts so the output path always points at
+        # a directory that contains include/, lib/, etc.
+        if [ -d "$prefix/$stem" ]; then
+          root="$prefix/$stem"
+        elif [ -d "$prefix/lib" ] || [ -d "$prefix/include" ]; then
+          # Flat archive; the prefix itself is the root.
+          root="$prefix"
+        else
+          # Fall back to the largest subdirectory at the prefix.
+          root="$(find "$prefix" -mindepth 1 -maxdepth 1 -type d | head -n1)"
+        fi
+
+        if [ -z "$root" ] || [ ! -d "$root" ]; then
+          echo "libcvc-deps: extraction did not yield a usable root; falling back."
+          echo "path=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "libcvc-deps: ready at $root"
+        ls "$root" | head -20 || true
+        echo "path=$root" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,22 @@ jobs:
             libcgal-dev \
             libfuse2 file desktop-file-utils
 
+      # ── Optional: pull VTK from a libcvc-deps release bundle ──
+      # When a matching libcvc-deps release archive exists for this
+      # platform, downloading it is far cheaper than a cold-cache VTK
+      # source build (~25-40 min). On hit, the cache restore + source
+      # build are both skipped and CMAKE_PREFIX_PATH picks up VTK from
+      # the extracted libcvc-deps tree. On miss, the action emits an
+      # empty `path` output and we fall back to the previous
+      # cache-then-build path.
+      - name: Fetch libcvc-deps (optional speedup)
+        if: matrix.kind == 'volrover3'
+        id: libcvc-deps
+        uses: ./.github/actions/fetch-libcvc-deps
+        with:
+          build_type: Release
+          link: shared
+
       # ── VTK 9.5 built against Qt6, cached ──
       #
       # Ubuntu's prebuilt libvtk9-qt-dev is Qt5-only. We build VTK
@@ -213,7 +229,7 @@ jobs:
       # than as a post-job step that never runs when the workflow is
       # cancelled mid-flight.
       - name: Restore VTK (Qt6) cache
-        if: matrix.kind == 'volrover3'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps.outputs.path == ''
         id: vtk-cache
         uses: actions/cache/restore@v4
         with:
@@ -221,7 +237,7 @@ jobs:
           key: vtk-9.5.0-qt6-${{ runner.os }}-v2
 
       - name: Build VTK 9.5 from source (Qt6)
-        if: matrix.kind == 'volrover3' && steps.vtk-cache.outputs.cache-hit != 'true'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps.outputs.path == '' && steps.vtk-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           curl -L -o vtk.tar.gz https://github.com/Kitware/VTK/archive/refs/tags/v9.5.0.tar.gz
@@ -246,7 +262,7 @@ jobs:
       # the job (which may take another 5-15 min) has any chance of
       # being cancelled.
       - name: Save VTK (Qt6) cache
-        if: matrix.kind == 'volrover3' && steps.vtk-cache.outputs.cache-hit != 'true'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps.outputs.path == '' && steps.vtk-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: ~/vtk-qt6
@@ -256,7 +272,13 @@ jobs:
         run: |
           extra_prefix=""
           if [ "${{ matrix.kind }}" = "volrover3" ]; then
-            extra_prefix="$HOME/vtk-qt6"
+            # Prefer libcvc-deps when the speedup hit; else fall back
+            # to the from-source VTK install under ~/vtk-qt6.
+            if [ -n "${{ steps.libcvc-deps.outputs.path }}" ]; then
+              extra_prefix="${{ steps.libcvc-deps.outputs.path }}"
+            else
+              extra_prefix="$HOME/vtk-qt6"
+            fi
           fi
           # libcvc-kind builds enable tests so the same artifacts we
           # ship get exercised by ctest. volrover3 builds keep tests
@@ -387,8 +409,16 @@ jobs:
           # resolves them by name; libcvc.so.3 lives under
           # AppDir/usr/lib/x86_64-linux-gnu/ (Debian's GNUInstallDirs
           # default) which is not on the default search path. VTK 9.5
-          # was built into $HOME/vtk-qt6/lib (cached, off-system).
-          export LD_LIBRARY_PATH="$PWD/AppDir/usr/lib:$PWD/AppDir/usr/lib/x86_64-linux-gnu:$HOME/vtk-qt6/lib:${LD_LIBRARY_PATH:-}"
+          # was built into $HOME/vtk-qt6/lib (cached, off-system) or,
+          # when the libcvc-deps speedup hit, lives under the extracted
+          # libcvc-deps root.
+          vtk_lib_path=""
+          if [ -n "${{ steps.libcvc-deps.outputs.path }}" ]; then
+            vtk_lib_path="${{ steps.libcvc-deps.outputs.path }}/lib"
+          else
+            vtk_lib_path="$HOME/vtk-qt6/lib"
+          fi
+          export LD_LIBRARY_PATH="$PWD/AppDir/usr/lib:$PWD/AppDir/usr/lib/x86_64-linux-gnu:$vtk_lib_path:${LD_LIBRARY_PATH:-}"
           ./linuxdeploy --appdir AppDir --plugin qt --output appimage \
                         --desktop-file AppDir/volrover3.desktop \
                         --icon-file    AppDir/volrover_logo.png || \
@@ -788,13 +818,22 @@ jobs:
             ~\AppData\Local\vcpkg\archives
           key: vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-v6
 
+      # ── Optional: pull VTK from a libcvc-deps release bundle ──
+      - name: Fetch libcvc-deps (optional speedup)
+        if: matrix.kind == 'volrover3'
+        id: libcvc-deps-windows
+        uses: ./.github/actions/fetch-libcvc-deps
+        with:
+          build_type: Release
+          link: shared
+
       # ── VTK 9.5 built from source against aqt Qt6, cached ──
       # Mirrors the Ubuntu strategy. Cache key includes build_type
       # because MSVC Debug and Release VTK DLLs are not interchangeable.
       # Uses Visual Studio generator (windows-latest default) so we
       # don't need a separate MSVC env activation step.
       - name: Restore VTK (Qt6) cache (Windows)
-        if: matrix.kind == 'volrover3'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps-windows.outputs.path == ''
         id: vtk-cache-windows
         uses: actions/cache/restore@v4
         with:
@@ -802,7 +841,7 @@ jobs:
           key: vtk-9.5.0-qt6-${{ runner.os }}-${{ matrix.build_type }}-v1
 
       - name: Build VTK 9.5 from source against Qt6 (Windows)
-        if: matrix.kind == 'volrover3' && steps.vtk-cache-windows.outputs.cache-hit != 'true'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps-windows.outputs.path == '' && steps.vtk-cache-windows.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           Invoke-WebRequest -Uri https://github.com/Kitware/VTK/archive/refs/tags/v9.5.0.tar.gz -OutFile vtk.tar.gz
@@ -825,7 +864,7 @@ jobs:
           Remove-Item -Force vtk.tar.gz
 
       - name: Save VTK (Qt6) cache (Windows)
-        if: matrix.kind == 'volrover3' && steps.vtk-cache-windows.outputs.cache-hit != 'true'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps-windows.outputs.path == '' && steps.vtk-cache-windows.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: D:\vtk-qt6
@@ -838,7 +877,14 @@ jobs:
           $tests = if ('${{ matrix.kind }}' -eq 'libcvc') { 'ON' } else { 'OFF' }
           $prefixes = @()
           if ($env:QT_ROOT_DIR) { $prefixes += $env:QT_ROOT_DIR }
-          if ('${{ matrix.kind }}' -eq 'volrover3') { $prefixes += 'D:\vtk-qt6' }
+          if ('${{ matrix.kind }}' -eq 'volrover3') {
+            $depsPath = '${{ steps.libcvc-deps-windows.outputs.path }}'
+            if ($depsPath) {
+              $prefixes += $depsPath
+            } else {
+              $prefixes += 'D:\vtk-qt6'
+            }
+          }
           $qtPrefix = $prefixes -join ';'
           cmake -B build `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,11 +162,27 @@ jobs:
             libcgal-dev \
             libfuse2 file desktop-file-utils
 
+      # ── Optional: pull VTK from a libcvc-deps release bundle ──
+      # When a matching libcvc-deps release archive exists for this
+      # platform, downloading it (~500 MB) is far cheaper than a
+      # cold-cache VTK source build (~15-20 min). On hit, the
+      # subsequent VTK source build is skipped and CMAKE_PREFIX_PATH
+      # picks up VTK from the extracted libcvc-deps tree. On miss,
+      # the action emits an empty `path` output and we fall back to
+      # the previous from-source build.
+      - name: Fetch libcvc-deps (optional speedup)
+        if: matrix.kind == 'volrover3'
+        id: libcvc-deps
+        uses: ./.github/actions/fetch-libcvc-deps
+        with:
+          build_type: Release    # volrover3 jobs are Release-only
+          link: shared
+
       # ── VTK 9.5 built against Qt6, cached ──
       # Cache key matches ci.yml so the build is shared across both
       # workflows and only happens once per (vtk_version, qt_major, os).
       - name: Cache VTK (Qt6) install tree
-        if: matrix.kind == 'volrover3'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps.outputs.path == ''
         id: vtk-cache
         uses: actions/cache@v4
         with:
@@ -174,7 +190,7 @@ jobs:
           key: vtk-9.5.0-qt6-${{ runner.os }}-v2
 
       - name: Build VTK 9.5 from source (Qt6)
-        if: matrix.kind == 'volrover3' && steps.vtk-cache.outputs.cache-hit != 'true'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps.outputs.path == '' && steps.vtk-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           curl -L -o vtk.tar.gz https://github.com/Kitware/VTK/archive/refs/tags/v9.5.0.tar.gz
@@ -198,7 +214,13 @@ jobs:
         run: |
           extra_prefix=""
           if [ "${{ matrix.kind }}" = "volrover3" ]; then
-            extra_prefix="$HOME/vtk-qt6"
+            # Prefer the libcvc-deps tree when available, else fall
+            # back to the from-source VTK install under ~/vtk-qt6.
+            if [ -n "${{ steps.libcvc-deps.outputs.path }}" ]; then
+              extra_prefix="${{ steps.libcvc-deps.outputs.path }}"
+            else
+              extra_prefix="$HOME/vtk-qt6"
+            fi
           fi
           # link=shared → BUILD_SHARED_LIBS=ON (legacy default).
           # link=static → BUILD_SHARED_LIBS=OFF plus static dep flags so
@@ -360,8 +382,16 @@ jobs:
           # resolves them by name; libcvc.so.3 lives under
           # AppDir/usr/lib/x86_64-linux-gnu/ (Debian's GNUInstallDirs
           # default) which is not on the default search path. VTK 9.5
-          # was built into $HOME/vtk-qt6/lib (cached, off-system).
-          export LD_LIBRARY_PATH="$PWD/AppDir/usr/lib:$PWD/AppDir/usr/lib/x86_64-linux-gnu:$HOME/vtk-qt6/lib:${LD_LIBRARY_PATH:-}"
+          # was built into $HOME/vtk-qt6/lib (cached, off-system) or,
+          # when the libcvc-deps speedup hit, lives under the
+          # extracted libcvc-deps root.
+          vtk_lib_path=""
+          if [ -n "${{ steps.libcvc-deps.outputs.path }}" ]; then
+            vtk_lib_path="${{ steps.libcvc-deps.outputs.path }}/lib"
+          else
+            vtk_lib_path="$HOME/vtk-qt6/lib"
+          fi
+          export LD_LIBRARY_PATH="$PWD/AppDir/usr/lib:$PWD/AppDir/usr/lib/x86_64-linux-gnu:$vtk_lib_path:${LD_LIBRARY_PATH:-}"
           ./linuxdeploy --appdir AppDir --plugin qt --output appimage \
                         --desktop-file AppDir/volrover3.desktop \
                         --icon-file    AppDir/volrover_logo.png || \
@@ -762,11 +792,22 @@ jobs:
           path: D:\vcpkg-downloads
           key: vcpkg-downloads-${{ hashFiles('.github/workflows/release.yml') }}
 
+      # ── Optional: pull VTK from a libcvc-deps release bundle ──
+      # Same speedup as on Linux; saves ~15-20 min of from-source VTK
+      # build when a matching libcvc-deps archive is available.
+      - name: Fetch libcvc-deps (optional speedup)
+        if: matrix.kind == 'volrover3'
+        id: libcvc-deps-windows
+        uses: ./.github/actions/fetch-libcvc-deps
+        with:
+          build_type: Release    # volrover3 jobs are Release-only
+          link: shared
+
       # ── VTK 9.5 built from source against aqt Qt6, cached ──
       # Mirrors the Ubuntu strategy. Cache key includes build_type
       # because MSVC Debug and Release VTK DLLs are not interchangeable.
       - name: Restore VTK (Qt6) cache (Windows)
-        if: matrix.kind == 'volrover3'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps-windows.outputs.path == ''
         id: vtk-cache-windows
         uses: actions/cache/restore@v4
         with:
@@ -774,7 +815,7 @@ jobs:
           key: vtk-9.5.0-qt6-${{ runner.os }}-${{ matrix.build_type }}-v1
 
       - name: Build VTK 9.5 from source against Qt6 (Windows)
-        if: matrix.kind == 'volrover3' && steps.vtk-cache-windows.outputs.cache-hit != 'true'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps-windows.outputs.path == '' && steps.vtk-cache-windows.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           Invoke-WebRequest -Uri https://github.com/Kitware/VTK/archive/refs/tags/v9.5.0.tar.gz -OutFile vtk.tar.gz
@@ -797,7 +838,7 @@ jobs:
           Remove-Item -Force vtk.tar.gz
 
       - name: Save VTK (Qt6) cache (Windows)
-        if: matrix.kind == 'volrover3' && steps.vtk-cache-windows.outputs.cache-hit != 'true'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps-windows.outputs.path == '' && steps.vtk-cache-windows.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: D:\vtk-qt6
@@ -821,11 +862,19 @@ jobs:
             $msvcrt = 'MultiThreaded$<$<CONFIG:Debug>:Debug>DLL'
           }
           # Pin Qt6 to install-qt-action's tree (QT_ROOT_DIR) and add
-          # the from-source VTK install tree alongside it. CMAKE_PREFIX_PATH
+          # the from-source VTK install tree alongside it (or the
+          # libcvc-deps tree, when the speedup hit). CMAKE_PREFIX_PATH
           # is a semicolon-separated list on Windows.
           $prefixes = @()
           if ($env:QT_ROOT_DIR) { $prefixes += $env:QT_ROOT_DIR }
-          if ('${{ matrix.kind }}' -eq 'volrover3') { $prefixes += 'D:\vtk-qt6' }
+          if ('${{ matrix.kind }}' -eq 'volrover3') {
+            $depsPath = '${{ steps.libcvc-deps-windows.outputs.path }}'
+            if ($depsPath) {
+              $prefixes += $depsPath
+            } else {
+              $prefixes += 'D:\vtk-qt6'
+            }
+          }
           $qtPrefix = $prefixes -join ';'
           cmake -B build `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `


### PR DESCRIPTION
## What

Adds a `.github/actions/fetch-libcvc-deps` composite action and wires
it into both **ci.yml** (PR + push to master) and **release.yml** as
an optional speedup for the `volrover3` build jobs.

When a matching libcvc-deps release archive exists for the
`(version, OS, arch, build_type, link)` tuple, it is downloaded and
extracted; `CMAKE_PREFIX_PATH` then points at the libcvc-deps tree
and the from-source VTK build is skipped entirely:

- Linux: saves ~25-40 min cold cache, ~3-5 min warm cache.
- Windows: saves ~40-60 min cold cache, ~3-5 min warm cache.

## Fallback (no behavior change on miss)

On any failure — release not yet published, network 404, missing
asset for this OS/arch/config — the action emits an empty `path`
output and the existing VTK cache restore + source build path runs
unchanged. The libcvc job (no VTK) is unaffected either way.

## Companion repo

This PR pairs with [transfix/libcvc-deps](https://github.com/transfix/libcvc-deps),
which publishes the bundled VTK + Qt + boost + … archives via tagged
releases (v1.0.0 currently building).

## Verification

- YAML lints clean (\`yaml.safe_load\` on both workflows).
- The composite action returns an empty \`path\` output on 404, so
  branches without a matching libcvc-deps release continue to work.