### PR TITLE
ci(vcpkg): pin ImageMagick to 7.1.2-22, mirror via GitHub Releases

### DIFF
--- a/vcpkg-overlay/ports/imagemagick/portfile.cmake
+++ b/vcpkg-overlay/ports/imagemagick/portfile.cmake
@@ -26,15 +26,25 @@ if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
   message(FATAL_ERROR "imagemagick overlay port supports x64 only.")
 endif()
 
-set(IM_VERSION "7.1.2-21")
+set(IM_VERSION "7.1.2-22")
 
+# Mirror order matters: GitHub Releases is the canonical permanent home for
+# every published ImageMagick installer (assets are immutable once a tag
+# ships), so we try it first. imagemagick.org/archive/binaries/ only keeps
+# the *latest* point release live -- once a new -NN drops, the previous URL
+# returns 404 -- so it is best-effort fallback in case GitHub is unreachable.
+# vcpkg also resolves cached downloads (e.g. populated by a libcvc-deps
+# prefetch step) by SHA512 in $VCPKG_ROOT/downloads regardless of URL, so
+# this list never has to enumerate every conceivable mirror.
 vcpkg_download_distfile(IM_INSTALLER
-  URLS "https://imagemagick.org/archive/binaries/ImageMagick-${IM_VERSION}-Q16-HDRI-x64-dll.exe"
+  URLS
+    "https://github.com/ImageMagick/ImageMagick/releases/download/${IM_VERSION}/ImageMagick-${IM_VERSION}-Q16-HDRI-x64-dll.exe"
+    "https://imagemagick.org/archive/binaries/ImageMagick-${IM_VERSION}-Q16-HDRI-x64-dll.exe"
   FILENAME "ImageMagick-${IM_VERSION}-Q16-HDRI-x64-dll.exe"
-  SHA512 107455499f3f95e1a3e9b6ec32feb541cdf58a54237f96a6ac8390a1d55c00110bea188d0542234ba8c9ff1cab2ec436957820938109e2f4ac8abd468eb27a0c
+  SHA512 c3576a97380e172d6377a91831441d8f4f6bdf57819b8d6892a061355d80444bf68ef5cf08405396a5ca7cdff18eae65ab195319319d6d92026d9502b5de2fd7
 )
 
-# innoextract 1.9 supports Inno Setup 6.1.0 (the format used by IM 7.1.2-21).
+# innoextract 1.9 supports Inno Setup 6.x (the format used by IM 7.1.2-NN).
 vcpkg_download_distfile(INNOEXTRACT_ZIP
   URLS "https://github.com/dscharrer/innoextract/releases/download/1.9/innoextract-1.9-windows.zip"
   FILENAME "innoextract-1.9-windows.zip"

--- a/vcpkg-overlay/ports/imagemagick/vcpkg.json
+++ b/vcpkg-overlay/ports/imagemagick/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imagemagick",
-  "version": "7.1.2-21",
+  "version": "7.1.2-22",
   "port-version": 0,
   "description": "ImageMagick Q16-HDRI development files for Windows, repackaged from the official upstream Inno Setup installer.",
   "homepage": "https://imagemagick.org/",


### PR DESCRIPTION
## Problem

The Windows package job has been failing because `imagemagick.org/archive/binaries/ImageMagick-7.1.2-21-Q16-HDRI-x64-dll.exe` now returns 404. The upstream archive directory keeps **only the latest point release** live -- as soon as 7.1.2-22 shipped, the previous pinned URL went away.

This blocks the Windows release for both `libcvc-*` and `volrover3-*` packaging jobs.

## Fix

1. Bump `IM_VERSION` to `7.1.2-22`.
2. Switch the **primary** download URL to `github.com/ImageMagick/ImageMagick/releases/download/<tag>/` -- GitHub release assets are immutable once a tag is published, so old pins never break.
3. Keep `imagemagick.org/archive/binaries/` as a best-effort **secondary** mirror; `vcpkg_download_distfile` tries the URL list in order.
4. Update SHA512 to match the 7.1.2-22 installer (verified by downloading from GitHub Releases).
5. Bump `vcpkg.json` version to match.

## Robust against libcvc-deps unavailability

This fix is **independent of the libcvc-deps prefetch step**: when the prefetched archive is present, vcpkg still resolves the cached download by SHA512 (so the portfile picks it up without touching the network). When libcvc-deps is unavailable or the archive lacks ImageMagick, the portfile falls through to GitHub Releases, which is permanent.

## Verification

- `HEAD https://github.com/ImageMagick/ImageMagick/releases/download/7.1.2-22/ImageMagick-7.1.2-22-Q16-HDRI-x64-dll.exe` -> 200, 24,198,536 bytes.
- Local SHA512: `c3576a97380e172d6377a91831441d8f4f6bdf57819b8d6892a061355d80444bf68ef5cf08405396a5ca7cdff18eae65ab195319319d6d92026d9502b5de2fd7`.
- Awaiting CI confirmation on the `package-windows` jobs.
