### PR TITLE
ci(vcpkg): build only matrix.build_type configuration of each port

### DIFF
--- a/.github/actions/fetch-libcvc-deps/action.yml
+++ b/.github/actions/fetch-libcvc-deps/action.yml
@@ -24,7 +24,7 @@ inputs:
   version:
     description: 'libcvc-deps release version (without leading v).'
     required: false
-    default: '1.0.0'
+    default: '1.0.1'
   os:
     description: 'linux | macos | windows. Defaults to runner.os.'
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -744,7 +744,27 @@ jobs:
           "VCPKG_FORCE_BUILD_TYPE=$btlc" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
           "VCPKG_OVERLAY_TRIPLETS=${{ github.workspace }}\vcpkg-overlay\triplets" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
 
+      # ── Optional: pull all third-party deps from a libcvc-deps bundle ──
+      # When a matching libcvc-deps release archive exists for this
+      # platform + matrix.build_type, downloading it (~minutes) is far
+      # cheaper than letting vcpkg compile Boost/HDF5/FFTW/GSL/log4cplus/
+      # CGAL/ImageMagick from source AND building VTK separately
+      # (~25-40 min cold). On hit, we skip:
+      #   * vcpkg restore + install + save
+      #   * install-qt-action (Qt6 is in the bundle)
+      #   * VTK cache restore + from-source build (volrover3 only)
+      # On miss (e.g. libcvc-deps release not yet published, network
+      # blip), the action emits an empty `path` output and we fall back
+      # to the previous vcpkg / aqtinstall / VTK-from-source path.
+      - name: Fetch libcvc-deps (Windows speedup)
+        id: libcvc-deps-windows
+        uses: ./.github/actions/fetch-libcvc-deps
+        with:
+          build_type: ${{ matrix.build_type }}
+          link: shared
+
       - name: Restore vcpkg cache
+        if: steps.libcvc-deps-windows.outputs.path == ''
         id: vcpkg-cache
         uses: actions/cache/restore@v4
         with:
@@ -761,9 +781,10 @@ jobs:
       # we route Qt around vcpkg entirely; VTK and CGAL still come from
       # vcpkg (they are smaller and don't have a comparable prebuilt).
       # install-qt-action prepends Qt's bin/ to PATH and exports
-      # Qt6_DIR + QT_ROOT_DIR for CMake to find.
+      # Qt6_DIR + QT_ROOT_DIR for CMake to find. Skipped on libcvc-deps
+      # hit (Qt6 ships inside the bundle).
       - name: Install Qt6 (volrover3)
-        if: matrix.kind == 'volrover3'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps-windows.outputs.path == ''
         uses: jurplel/install-qt-action@v4
         with:
           version: '6.7.*'
@@ -788,6 +809,7 @@ jobs:
           sub-packages: '["nvcc", "cudart", "visual_studio_integration"]'
 
       - name: Install dependencies
+        if: steps.libcvc-deps-windows.outputs.path == ''
         shell: pwsh
         env:
           # Pull our hand-rolled imagemagick overlay port (Q16-HDRI x64,
@@ -829,7 +851,7 @@ jobs:
       # Persist vcpkg state as soon as install completes successfully so
       # later cancellations don't strand a 20+ minute build.
       - name: Save vcpkg cache
-        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        if: steps.libcvc-deps-windows.outputs.path == '' && steps.vcpkg-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |
@@ -837,15 +859,6 @@ jobs:
             ${{ env.VCPKG_INSTALLATION_ROOT }}\packages
             ~\AppData\Local\vcpkg\archives
           key: vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-v7
-
-      # ── Optional: pull VTK from a libcvc-deps release bundle ──
-      - name: Fetch libcvc-deps (optional speedup)
-        if: matrix.kind == 'volrover3'
-        id: libcvc-deps-windows
-        uses: ./.github/actions/fetch-libcvc-deps
-        with:
-          build_type: Release
-          link: shared
 
       # ── VTK 9.5 built from source against aqt Qt6, cached ──
       # Mirrors the Ubuntu strategy. Cache key includes build_type
@@ -895,15 +908,16 @@ jobs:
         run: |
           $vol = if ('${{ matrix.kind }}' -eq 'volrover3') { 'ON' } else { 'OFF' }
           $tests = if ('${{ matrix.kind }}' -eq 'libcvc') { 'ON' } else { 'OFF' }
+          $depsPath = '${{ steps.libcvc-deps-windows.outputs.path }}'
           $prefixes = @()
+          # libcvc-deps (when present) ships Boost/HDF5/FFTW/GSL/log4cplus/
+          # CGAL/ImageMagick + Qt6 + VTK for BOTH kinds, so prefer it.
+          if ($depsPath) {
+            $prefixes += $depsPath
+          }
           if ($env:QT_ROOT_DIR) { $prefixes += $env:QT_ROOT_DIR }
-          if ('${{ matrix.kind }}' -eq 'volrover3') {
-            $depsPath = '${{ steps.libcvc-deps-windows.outputs.path }}'
-            if ($depsPath) {
-              $prefixes += $depsPath
-            } else {
-              $prefixes += 'D:\vtk-qt6'
-            }
+          if ('${{ matrix.kind }}' -eq 'volrover3' -and -not $depsPath) {
+            $prefixes += 'D:\vtk-qt6'
           }
           $qtPrefix = $prefixes -join ';'
           cmake -B build `

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,10 +719,30 @@ jobs:
           "VCPKG_BUILDTREES=D:\vcpkg-buildtrees" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
           "VCPKG_PACKAGES=D:\vcpkg-packages"     | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
 
+          # Restrict vcpkg to building only the matrix.build_type
+          # configuration of each port (instead of the upstream default
+          # which always builds both Debug+Release). The overlay triplet
+          # at vcpkg-overlay/triplets/x64-windows.cmake reads
+          # VCPKG_FORCE_BUILD_TYPE and applies it as VCPKG_BUILD_TYPE.
+          $btlc = '${{ matrix.build_type }}'.ToLower()
+          "VCPKG_FORCE_BUILD_TYPE=$btlc" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          "VCPKG_OVERLAY_TRIPLETS=${{ github.workspace }}\vcpkg-overlay\triplets" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+
           $cAfter = (Get-PSDrive C).Free / 1GB
           $dAfter = (Get-PSDrive D).Free / 1GB
           Write-Host ("Free space on C: {0:N1} GB -> {1:N1} GB" -f $cBefore, $cAfter)
           Write-Host ("Free space on D: {0:N1} GB -> {1:N1} GB" -f $dBefore, $dAfter)
+
+      # Configure vcpkg to build only the matrix.build_type config for
+      # libcvc Windows jobs (the volrover3-gated disk-routing step
+      # above already exports VCPKG_FORCE_BUILD_TYPE for volrover3).
+      - name: Configure vcpkg overlay triplet (libcvc Windows)
+        if: matrix.kind == 'libcvc'
+        shell: pwsh
+        run: |
+          $btlc = '${{ matrix.build_type }}'.ToLower()
+          "VCPKG_FORCE_BUILD_TYPE=$btlc" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          "VCPKG_OVERLAY_TRIPLETS=${{ github.workspace }}\vcpkg-overlay\triplets" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
 
       - name: Restore vcpkg cache
         id: vcpkg-cache
@@ -732,9 +752,9 @@ jobs:
             ${{ env.VCPKG_INSTALLATION_ROOT }}\installed
             ${{ env.VCPKG_INSTALLATION_ROOT }}\packages
             ~\AppData\Local\vcpkg\archives
-          key: vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-v6
+          key: vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-v7
           restore-keys: |
-            vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-
+            vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-v7-
 
       # Install Qt6 from official prebuilt binaries via aqtinstall.
       # vcpkg's qt6-base port builds Qt from source (~30+ min cold) so
@@ -816,7 +836,7 @@ jobs:
             ${{ env.VCPKG_INSTALLATION_ROOT }}\installed
             ${{ env.VCPKG_INSTALLATION_ROOT }}\packages
             ~\AppData\Local\vcpkg\archives
-          key: vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-v6
+          key: vcpkg-pkg-${{ matrix.kind }}-${{ matrix.build_type }}-v7
 
       # ── Optional: pull VTK from a libcvc-deps release bundle ──
       - name: Fetch libcvc-deps (optional speedup)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -666,9 +666,9 @@ jobs:
             ${{ env.VCPKG_INSTALLATION_ROOT }}\installed
             ${{ env.VCPKG_INSTALLATION_ROOT }}\packages
             ~\AppData\Local\vcpkg\archives
-          key: vcpkg-release-${{ matrix.kind }}-${{ matrix.build_type }}-${{ steps.meta.outputs.triplet }}-v6
+          key: vcpkg-release-${{ matrix.kind }}-${{ matrix.build_type }}-${{ steps.meta.outputs.triplet }}-v7
           restore-keys: |
-            vcpkg-release-${{ matrix.kind }}-${{ matrix.build_type }}-${{ steps.meta.outputs.triplet }}-
+            vcpkg-release-${{ matrix.kind }}-${{ matrix.build_type }}-${{ steps.meta.outputs.triplet }}-v7-
 
       # Install Qt6 from official prebuilt binaries via aqtinstall.
       # vcpkg's qt6-base port builds Qt from source (~30+ min cold) so
@@ -712,6 +712,16 @@ jobs:
           "VCPKG_DOWNLOADS=D:\vcpkg-downloads"   | Out-File -Append $env:GITHUB_ENV
           "VCPKG_BUILDTREES=D:\vcpkg-buildtrees" | Out-File -Append $env:GITHUB_ENV
           "VCPKG_PACKAGES=D:\vcpkg-packages"     | Out-File -Append $env:GITHUB_ENV
+
+          # Restrict vcpkg to building only the matrix.build_type
+          # configuration of each port (instead of building both
+          # Debug+Release upstream-default). The overlay triplet at
+          # vcpkg-overlay/triplets/x64-windows{,-static}.cmake reads
+          # VCPKG_FORCE_BUILD_TYPE and applies it as VCPKG_BUILD_TYPE.
+          $btlc = '${{ matrix.build_type }}'.ToLower()
+          "VCPKG_FORCE_BUILD_TYPE=$btlc" | Out-File -Append $env:GITHUB_ENV
+          "VCPKG_OVERLAY_TRIPLETS=${{ github.workspace }}\vcpkg-overlay\triplets" | Out-File -Append $env:GITHUB_ENV
+
           Get-PSDrive -PSProvider FileSystem | Format-Table -AutoSize
 
       # Persist vcpkg's source-tarball download cache across runs so a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -655,11 +655,31 @@ jobs:
           echo "linksfx=$LINKSFX"  >> "$GITHUB_OUTPUT"
           echo "triplet=$TRIPLET"  >> "$GITHUB_OUTPUT"
 
+      # ── Optional: pull all third-party deps from a libcvc-deps bundle ──
+      # libcvc-deps ships Boost/HDF5/FFTW/GSL/log4cplus/CGAL/ImageMagick
+      # + Qt 6 + VTK 9.5 as a self-contained CMake prefix. When a
+      # matching archive is available we skip vcpkg + aqtinstall + VTK
+      # build entirely (~tens of minutes saved on cold cache).
+      #
+      # NOTE: the Windows libcvc-deps archive is shared-only (no
+      # -static flavor). Static matrix entries also consume the shared
+      # archive: libcvc itself stays static (BUILD_SHARED_LIBS=OFF) but
+      # third-party deps are linked as DLLs. The Configure step below
+      # then switches the MSVC runtime to /MD so libcvc objects can
+      # safely cross API boundaries with the shared-CRT-built deps.
+      - name: Fetch libcvc-deps (Windows speedup)
+        id: libcvc-deps-windows
+        uses: ./.github/actions/fetch-libcvc-deps
+        with:
+          build_type: ${{ matrix.build_type }}
+          link: shared
+
       # Cache key intentionally excludes hashFiles(workflow) so editing
       # this file does not invalidate the warm vcpkg cache. The triplet
       # is part of the key so static (x64-windows-static) and shared
       # (x64-windows) builds do not share buildtrees.
       - name: Cache vcpkg installed packages
+        if: steps.libcvc-deps-windows.outputs.path == ''
         uses: actions/cache@v4
         with:
           path: |
@@ -674,9 +694,10 @@ jobs:
       # vcpkg's qt6-base port builds Qt from source (~30+ min cold) so
       # we route Qt around vcpkg entirely; VTK and CGAL still come from
       # vcpkg. install-qt-action prepends Qt's bin/ to PATH and exports
-      # Qt6_DIR + QT_ROOT_DIR for CMake to find.
+      # Qt6_DIR + QT_ROOT_DIR for CMake to find. Skipped on libcvc-deps
+      # hit (Qt6 ships inside the bundle).
       - name: Install Qt6 (volrover3)
-        if: matrix.kind == 'volrover3'
+        if: matrix.kind == 'volrover3' && steps.libcvc-deps-windows.outputs.path == ''
         uses: jurplel/install-qt-action@v4
         with:
           version: '6.7.*'
@@ -750,6 +771,7 @@ jobs:
           sub-packages: '["nvcc", "cudart", "visual_studio_integration"]'
 
       - name: Install dependencies
+        if: steps.libcvc-deps-windows.outputs.path == ''
         shell: pwsh
         env:
           # Pull our hand-rolled imagemagick overlay port (Q16-HDRI x64,
@@ -796,22 +818,11 @@ jobs:
           }
 
       - name: Save vcpkg downloads cache (Windows)
-        if: always() && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true'
+        if: always() && steps.libcvc-deps-windows.outputs.path == '' && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: D:\vcpkg-downloads
           key: vcpkg-downloads-${{ hashFiles('.github/workflows/release.yml') }}
-
-      # ── Optional: pull VTK from a libcvc-deps release bundle ──
-      # Same speedup as on Linux; saves ~15-20 min of from-source VTK
-      # build when a matching libcvc-deps archive is available.
-      - name: Fetch libcvc-deps (optional speedup)
-        if: matrix.kind == 'volrover3'
-        id: libcvc-deps-windows
-        uses: ./.github/actions/fetch-libcvc-deps
-        with:
-          build_type: Release    # volrover3 jobs are Release-only
-          link: shared
 
       # ── VTK 9.5 built from source against aqt Qt6, cached ──
       # Mirrors the Ubuntu strategy. Cache key includes build_type
@@ -861,12 +872,20 @@ jobs:
           # CGAL/SDF/Mesher are always built; only volrover3 toggles
           # the GUI app and its extra deps.
           $xmlrpc = if ('${{ matrix.kind }}' -eq 'libcvc') { 'ON' } else { 'OFF' }
+          $depsPath = '${{ steps.libcvc-deps-windows.outputs.path }}'
           # link=shared → BUILD_SHARED_LIBS=ON + x64-windows triplet (DLLs)
           # link=static → BUILD_SHARED_LIBS=OFF + x64-windows-static triplet
           #   (.lib for libcvc and every vcpkg dep, MSVC static runtime).
-          if ('${{ matrix.link }}' -eq 'static') {
+          # libcvc-deps Windows is shared-only: when it hits on a static
+          # matrix entry, force /MD (DLL CRT) so libcvc objects can
+          # cross API boundaries with the /MD-built libcvc-deps DLLs
+          # without heap mismatches. libcvc itself stays static.
+          if ('${{ matrix.link }}' -eq 'static' -and -not $depsPath) {
             $shared = 'OFF'
             $msvcrt = 'MultiThreaded$<$<CONFIG:Debug>:Debug>'
+          } elseif ('${{ matrix.link }}' -eq 'static') {
+            $shared = 'OFF'
+            $msvcrt = 'MultiThreaded$<$<CONFIG:Debug>:Debug>DLL'
           } else {
             $shared = 'ON'
             $msvcrt = 'MultiThreaded$<$<CONFIG:Debug>:Debug>DLL'
@@ -876,14 +895,12 @@ jobs:
           # libcvc-deps tree, when the speedup hit). CMAKE_PREFIX_PATH
           # is a semicolon-separated list on Windows.
           $prefixes = @()
+          # libcvc-deps (when present) ships Boost/HDF5/FFTW/GSL/log4cplus/
+          # CGAL/ImageMagick + Qt6 + VTK for BOTH kinds, so prefer it.
+          if ($depsPath) { $prefixes += $depsPath }
           if ($env:QT_ROOT_DIR) { $prefixes += $env:QT_ROOT_DIR }
-          if ('${{ matrix.kind }}' -eq 'volrover3') {
-            $depsPath = '${{ steps.libcvc-deps-windows.outputs.path }}'
-            if ($depsPath) {
-              $prefixes += $depsPath
-            } else {
-              $prefixes += 'D:\vtk-qt6'
-            }
+          if ('${{ matrix.kind }}' -eq 'volrover3' -and -not $depsPath) {
+            $prefixes += 'D:\vtk-qt6'
           }
           $qtPrefix = $prefixes -join ';'
           cmake -B build `
@@ -942,36 +959,56 @@ jobs:
                 }
           }
 
-          # ── vcpkg deps (entire installed/<triplet> tree) ────────
-          $triplet = '${{ steps.meta.outputs.triplet }}'
-          $vcRoot  = Join-Path $env:VCPKG_INSTALLATION_ROOT "installed/$triplet"
-          if (-not (Test-Path $vcRoot)) {
-            throw "vcpkg installed tree not found at $vcRoot"
-          }
+          # ── third-party deps: from vcpkg installed/ OR libcvc-deps ──
+          # On libcvc-deps hit (steps.libcvc-deps-windows.outputs.path
+          # non-empty) the dep tree is laid out flat under $depsPath
+          # with include/, lib/, bin/ at the root (shared build, no
+          # debug/ subtree). On miss, deps come from vcpkg's
+          # installed/<triplet>/{bin,lib,include}{,/debug}.
+          $depsPath = '${{ steps.libcvc-deps-windows.outputs.path }}'
+          if ($depsPath) {
+            $libSrc = Join-Path $depsPath 'lib'
+            $binSrc = Join-Path $depsPath 'bin'
+            $incSrc = Join-Path $depsPath 'include'
+            $havePdbs = $isDebug   # libcvc-deps debug bundles ship .pdb
+          } else {
+            $triplet = '${{ steps.meta.outputs.triplet }}'
+            $vcRoot  = Join-Path $env:VCPKG_INSTALLATION_ROOT "installed/$triplet"
+            if (-not (Test-Path $vcRoot)) {
+              throw "vcpkg installed tree not found at $vcRoot"
+            }
 
-          # Layout per triplet:
-          #   <triplet>/{bin,lib,include}        — release
-          #   <triplet>/debug/{bin,lib}          — debug (headers shared)
-          # Debug subtrees also carry .pdb files alongside their .dll /
-          # .lib outputs (vcpkg builds with /Zi /DEBUG by default).
-          $libSrc  = if ($isDebug) { Join-Path $vcRoot 'debug/lib' } else { Join-Path $vcRoot 'lib' }
-          $binSrc  = if ($isDebug) { Join-Path $vcRoot 'debug/bin' } else { Join-Path $vcRoot 'bin' }
+            # Layout per triplet:
+            #   <triplet>/{bin,lib,include}        — release
+            #   <triplet>/debug/{bin,lib}          — debug (headers shared)
+            # Debug subtrees also carry .pdb files alongside their .dll /
+            # .lib outputs (vcpkg builds with /Zi /DEBUG by default).
+            $libSrc  = if ($isDebug) { Join-Path $vcRoot 'debug/lib' } else { Join-Path $vcRoot 'lib' }
+            $binSrc  = if ($isDebug) { Join-Path $vcRoot 'debug/bin' } else { Join-Path $vcRoot 'bin' }
+            $incSrc  = Join-Path $vcRoot 'include'
+            $havePdbs = $isDebug
+          }
 
           New-Item -ItemType Directory -Force -Path "$dist/lib","$dist/include" | Out-Null
-          if (Test-Path "$vcRoot/include") {
-            Copy-Item -Recurse -Force "$vcRoot/include/*" "$dist/include/"
+          if (Test-Path $incSrc) {
+            Copy-Item -Recurse -Force "$incSrc/*" "$dist/include/"
           }
           if (Test-Path $libSrc) {
-            $patterns = if ($isDebug) { @('*.lib','*.pdb') } else { @('*.lib') }
+            $patterns = if ($havePdbs) { @('*.lib','*.pdb') } else { @('*.lib') }
             foreach ($p in $patterns) {
               Get-ChildItem -Path $libSrc -Filter $p -File `
                 | Copy-Item -Destination "$dist/lib/" -Force
             }
           }
-          if ('${{ matrix.link }}' -eq 'shared') {
+          # On libcvc-deps hit, third-party DLLs need to ship even for
+          # static matrix entries because libcvc-deps is shared-only on
+          # Windows (libcvc itself is still .lib; consumers load the
+          # shipped DLLs at runtime).
+          $shipBin = ('${{ matrix.link }}' -eq 'shared') -or [bool]$depsPath
+          if ($shipBin) {
             New-Item -ItemType Directory -Force -Path "$dist/bin" | Out-Null
             if (Test-Path $binSrc) {
-              $patterns = if ($isDebug) { @('*.dll','*.pdb') } else { @('*.dll') }
+              $patterns = if ($havePdbs) { @('*.dll','*.pdb') } else { @('*.dll') }
               foreach ($p in $patterns) {
                 Get-ChildItem -Path $binSrc -Filter $p -File `
                   | Copy-Item -Destination "$dist/bin/" -Force

--- a/vcpkg-overlay/ports/imagemagick/portfile.cmake
+++ b/vcpkg-overlay/ports/imagemagick/portfile.cmake
@@ -83,17 +83,38 @@ endif()
 # the vcpkg include root. CMake's FindImageMagick recognises this layout.
 file(COPY "${APP_DIR}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
+# Determine which configurations vcpkg expects from this port. When the
+# triplet sets VCPKG_BUILD_TYPE to "release" or "debug", vcpkg's policy
+# checks reject the opposite tree existing, so we must skip populating
+# it. Default (unset) means both.
+set(_im_want_release TRUE)
+set(_im_want_debug   TRUE)
+if(DEFINED VCPKG_BUILD_TYPE)
+  if(VCPKG_BUILD_TYPE STREQUAL "release")
+    set(_im_want_debug FALSE)
+  elseif(VCPKG_BUILD_TYPE STREQUAL "debug")
+    set(_im_want_release FALSE)
+  endif()
+endif()
+
 # Import libraries.
 file(GLOB IM_LIBS "${APP_DIR}/lib/CORE_RL_*.lib")
 if(NOT IM_LIBS)
   message(FATAL_ERROR "No CORE_RL_*.lib files found under ${APP_DIR}/lib")
 endif()
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib")
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib")
-file(COPY ${IM_LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-# Upstream ships only one (release) build; alias it for Debug so
-# vcpkg's debug-config also resolves.
-file(COPY ${IM_LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+set(_im_lib_dirs)
+if(_im_want_release)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib")
+  file(COPY ${IM_LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+  list(APPEND _im_lib_dirs "${CURRENT_PACKAGES_DIR}/lib")
+endif()
+if(_im_want_debug)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib")
+  # Upstream ships only one (release) build; alias it for Debug so
+  # vcpkg's debug-config also resolves.
+  file(COPY ${IM_LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+  list(APPEND _im_lib_dirs "${CURRENT_PACKAGES_DIR}/debug/lib")
+endif()
 
 # CMake's FindImageMagick.cmake searches for Magick++/MagickCore/
 # MagickWand/MagickWand-7.Q16HDRI/etc. and also CORE_RL_Magick++_,
@@ -103,8 +124,7 @@ file(COPY ${IM_LIBS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
 # 'CORE_RL_<component>_.lib', so create canonical-named hardlinks/
 # copies (Magick++.lib, MagickCore.lib, MagickWand.lib) to make
 # find_library() succeed regardless of FindImageMagick vintage.
-foreach(_im_lib_dir
-    "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug/lib")
+foreach(_im_lib_dir IN LISTS _im_lib_dirs)
   foreach(_im_component Magick++ MagickCore MagickWand)
     set(_src "${_im_lib_dir}/CORE_RL_${_im_component}_.lib")
     set(_dst "${_im_lib_dir}/${_im_component}.lib")
@@ -121,11 +141,15 @@ file(GLOB IM_DLLS
   "${APP_DIR}/IM_MOD_RL_*.dll"
   "${APP_DIR}/FILTER_*.dll"
 )
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
 if(IM_DLLS)
-  file(COPY ${IM_DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-  file(COPY ${IM_DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+  if(_im_want_release)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
+    file(COPY ${IM_DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+  endif()
+  if(_im_want_debug)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(COPY ${IM_DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+  endif()
 endif()
 
 # License.

--- a/vcpkg-overlay/triplets/x64-windows-static.cmake
+++ b/vcpkg-overlay/triplets/x64-windows-static.cmake
@@ -1,0 +1,10 @@
+# vcpkg overlay triplet: x64-windows-static
+#
+# See x64-windows.cmake for rationale. This is the static-CRT/static-lib
+# variant used by the release.yml `link: static` matrix entries.
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE static)
+set(VCPKG_LIBRARY_LINKAGE static)
+if(DEFINED ENV{VCPKG_FORCE_BUILD_TYPE} AND NOT "$ENV{VCPKG_FORCE_BUILD_TYPE}" STREQUAL "")
+    set(VCPKG_BUILD_TYPE "$ENV{VCPKG_FORCE_BUILD_TYPE}")
+endif()

--- a/vcpkg-overlay/triplets/x64-windows.cmake
+++ b/vcpkg-overlay/triplets/x64-windows.cmake
@@ -1,0 +1,18 @@
+# vcpkg overlay triplet: x64-windows
+#
+# Overrides the upstream x64-windows triplet so that we can restrict
+# vcpkg to building only one of {Debug,Release} per CI job, instead of
+# building both configurations (the upstream default). Each Windows CI
+# job consumes only its matching matrix.build_type, so the other half
+# is wasted ~equal-time work.
+#
+# Activated by setting the VCPKG_FORCE_BUILD_TYPE environment variable
+# to "release" or "debug" before invoking vcpkg / cmake. When the env
+# var is unset or empty, behavior matches the upstream default (both
+# debug and release built).
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+if(DEFINED ENV{VCPKG_FORCE_BUILD_TYPE} AND NOT "$ENV{VCPKG_FORCE_BUILD_TYPE}" STREQUAL "")
+    set(VCPKG_BUILD_TYPE "$ENV{VCPKG_FORCE_BUILD_TYPE}")
+endif()


### PR DESCRIPTION
﻿# Build only matrix.build_type configuration in vcpkg

## Problem

`vcpkg install` defaults to building both Debug and Release variants of every port. Each Windows CI matrix entry only consumes one of those configurations (matching `matrix.build_type`), so roughly half of the ~20+ minute vcpkg install time is wasted on the unused config.

## Fix

Ship overlay triplets at `vcpkg-overlay/triplets/`:

- `x64-windows.cmake` -- DLL / shared CRT
- `x64-windows-static.cmake` -- static CRT / static lib (release.yml only)

Both inherit the upstream defaults but, when the env var `VCPKG_FORCE_BUILD_TYPE` is set to `release` or `debug`, apply it as `VCPKG_BUILD_TYPE` so vcpkg builds only that single configuration.

## CI/CD wiring

Windows steps in `ci.yml` and `release.yml` export `VCPKG_FORCE_BUILD_TYPE` (lowercased `matrix.build_type`) and `VCPKG_OVERLAY_TRIPLETS` (the new dir) into `` before `vcpkg install`. CMake configure inherits both, so the consumer triplet matches the install triplet.

Cache keys bumped v6 -> v7 to evict the existing both-config caches.

## ImageMagick portfile

The overlay portfile populated lib/ and debug/lib/ (and bin/ + debug/bin/) unconditionally. With `VCPKG_BUILD_TYPE=release` vcpkg's post-install policy check would reject unexpected `debug/` output (and vice versa). The portfile now gates each copy on `VCPKG_BUILD_TYPE`, populating both when unrestricted.

## Expected impact

Windows package jobs (libcvc/volrover3 x Debug/Release x shared/static) should each see vcpkg install time roughly halve once the new caches are warm. Cold cache cost is also reduced.

## Verification

CI on this PR validates by re-running all Windows matrix entries in ci.yml under the new overlay; existing test suite + post-install link check confirm consumers still find the libraries they need.
