### PR TITLE
fix(windeployqt): pass --debug for Debug installs

### DIFF
--- a/src/volrover3/CMakeLists.txt
+++ b/src/volrover3/CMakeLists.txt
@@ -305,9 +305,17 @@ if(WIN32)
     # CPack runs `cmake --install` per-component before invoking the
     # archive / NSIS generator, so this install(CODE) script is the right
     # hook to materialize Qt's platform plugins into the staged tree.
+    #
+    # Pass --debug / --release matching the install config so windeployqt
+    # walks the correctly-suffixed Qt6 modules (Qt6Cored.dll vs
+    # Qt6Core.dll). Without this it always asks for the release modules,
+    # which emits "module Qt6*d could not be found" warnings on Debug
+    # installs and silently ships the wrong-config DLLs (the bundled
+    # volrover3.exe is linked against Qt6*d.dll, so the Debug package
+    # then fails to launch on a clean machine).
     install(CODE "
       execute_process(COMMAND \"${WINDEPLOYQT_EXECUTABLE}\"
-        --release
+        $<IF:$<CONFIG:Debug>,--debug,--release>
         --no-translations
         --no-system-d3d-compiler
         --no-opengl-sw


### PR DESCRIPTION
On Debug Windows builds, the Pack volrover3 step emits warnings:

    Warning: module Qt6OpenGLWidgetsd could not be found
    Warning: module Qt6Widgetsd could not be found
    Warning: module Qt6Guid could not be found
    Warning: module Qt6Cored could not be found
    Warning: module Qt6OpenGLd could not be found

windeployqt is invoked with a hard-coded ``--release`` flag, so on
Debug builds it walks for the release-suffixed Qt6 modules
(Qt6Core.dll, etc.) instead of the actual Debug ones (Qt6Cored.dll)
that volrover3.exe is linked against. Result: the Debug zip / NSIS
package silently ships the wrong-config Qt DLLs, and the bundled
volrover3.exe fails to launch on a clean machine (Qt6Cored.dll
missing).

Replace the literal ``--release`` with a generator expression so the
correct flag is baked into the install script per-config:

    $<IF:$<CONFIG:Debug>,--debug,--release>

Generator expressions inside ``install(CODE …)`` are expanded by CMake
at install-script generation time, per multi-config configuration,
which works correctly with the Visual Studio generator used on the
Windows CI runners.

No Release-config behavior change.