### PR TITLE
fix(cmake): wrap external include dirs in BUILD_INTERFACE

### DIFF
--- a/CMake/SetupBoost.cmake
+++ b/CMake/SetupBoost.cmake
@@ -26,8 +26,13 @@ function(SetupBoost TargetName)
     message(STATUS "Boost include dirs: ${Boost_INCLUDE_DIRS}")
     message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
     
-    # Use modern target-based approach
-    target_include_directories(${TargetName} PUBLIC ${Boost_INCLUDE_DIRS})
+    # Use modern target-based approach. Wrap each include dir in
+    # $<BUILD_INTERFACE:...> so a bundled toolchain (e.g. libcvc-deps
+    # under a parent project's build tree) doesn't leak a build-dir path
+    # into the installed cvc target's INTERFACE_INCLUDE_DIRECTORIES.
+    foreach(_boost_inc IN LISTS Boost_INCLUDE_DIRS)
+      target_include_directories(${TargetName} PUBLIC "$<BUILD_INTERFACE:${_boost_inc}>")
+    endforeach()
     target_link_libraries(${TargetName} PUBLIC ${Boost_LIBRARIES})
     
     # Platform-specific definitions

--- a/CMake/SetupGSL.cmake
+++ b/CMake/SetupGSL.cmake
@@ -11,7 +11,9 @@ function(SetupGSL TargetName)
     message(STATUS "GSL libraries: ${GSL_LIBRARIES}")
     
     # Use modern target-based approach
-    target_include_directories(${TargetName} PUBLIC ${GSL_INCLUDE_DIRS})
+    foreach(_gsl_inc IN LISTS GSL_INCLUDE_DIRS)
+      target_include_directories(${TargetName} PUBLIC "$<BUILD_INTERFACE:${_gsl_inc}>")
+    endforeach()
     target_link_libraries(${TargetName} PUBLIC ${GSL_LIBRARIES})
     
     if(CMAKE_GSL_CXX_FLAGS)

--- a/src/cvc/CMakeLists.txt
+++ b/src/cvc/CMakeLists.txt
@@ -679,14 +679,24 @@ if(CVC_ENABLE_IMAGEMAGICK)
   target_compile_definitions(cvc PUBLIC CVC_ENABLE_IMAGEMAGICK
     MAGICKCORE_QUANTUM_DEPTH=${CVC_IMAGEMAGICK_QUANTUM_DEPTH}
     MAGICKCORE_HDRI_ENABLE=${CVC_IMAGEMAGICK_HDRI_ENABLE})
-  target_include_directories(cvc PUBLIC ${ImageMagick_INCLUDE_DIRS})
+  # Wrap each external include dir in its own BUILD_INTERFACE genex so a
+  # bundled toolchain (e.g. libcvc-deps living under a parent project's
+  # build tree) does not leak a build-dir path into the installed cvc
+  # target's INTERFACE_INCLUDE_DIRECTORIES (CMake rejects that with
+  # "path is prefixed in the build directory").
+  foreach(_im_inc IN LISTS ImageMagick_INCLUDE_DIRS)
+    target_include_directories(cvc PUBLIC "$<BUILD_INTERFACE:${_im_inc}>")
+  endforeach()
   target_link_libraries(cvc PUBLIC ${ImageMagick_LIBRARIES})
 endif()
 
 # FFTW linking
 if(CVC_ENABLE_FFTW)
   target_compile_definitions(cvc PUBLIC CVC_ENABLE_FFTW)
-  target_include_directories(cvc PUBLIC ${FFTW3_INCLUDE_DIRS})
+  # Same BUILD_INTERFACE wrapping rationale as the ImageMagick block above.
+  foreach(_fftw_inc IN LISTS FFTW3_INCLUDE_DIRS)
+    target_include_directories(cvc PUBLIC "$<BUILD_INTERFACE:${_fftw_inc}>")
+  endforeach()
   target_link_libraries(cvc PUBLIC ${FFTW3_LIBRARIES})
 endif()
 

--- a/src/volutils/CMakeLists.txt
+++ b/src/volutils/CMakeLists.txt
@@ -48,9 +48,14 @@ if(CVC_ENABLE_IMAGEMAGICK)
   target_compile_definitions(volutils PRIVATE
     MAGICKCORE_QUANTUM_DEPTH=16
     MAGICKCORE_HDRI_ENABLE=0)
-  # Also add to cvc library for volume_ops.cpp
+  # Also add to cvc library for volume_ops.cpp. Wrap each include dir
+  # in $<BUILD_INTERFACE:...> so a bundled toolchain doesn't leak a
+  # build-dir path into the installed cvc target's
+  # INTERFACE_INCLUDE_DIRECTORIES.
   target_compile_definitions(cvc PUBLIC CVC_ENABLE_IMAGEMAGICK)
-  target_include_directories(cvc PUBLIC ${ImageMagick_INCLUDE_DIRS})
+  foreach(_im_inc IN LISTS ImageMagick_INCLUDE_DIRS)
+    target_include_directories(cvc PUBLIC "$<BUILD_INTERFACE:${_im_inc}>")
+  endforeach()
   target_link_libraries(cvc PUBLIC ${ImageMagick_LIBRARIES})
 endif()
 
@@ -59,7 +64,9 @@ if(CVC_ENABLE_FFTW)
   target_include_directories(volutils PRIVATE ${FFTW3_INCLUDE_DIRS})
   target_link_libraries(volutils PRIVATE ${FFTW3_LIBRARIES})
   target_compile_definitions(cvc PUBLIC CVC_ENABLE_FFTW)
-  target_include_directories(cvc PUBLIC ${FFTW3_INCLUDE_DIRS})
+  foreach(_fftw_inc IN LISTS FFTW3_INCLUDE_DIRS)
+    target_include_directories(cvc PUBLIC "$<BUILD_INTERFACE:${_fftw_inc}>")
+  endforeach()
   target_link_libraries(cvc PUBLIC ${FFTW3_LIBRARIES})
 endif()
 


### PR DESCRIPTION
Fixes CMake Target cvc INTERFACE_INCLUDE_DIRECTORIES contains path which is prefixed in the build directory when libcvc is built as a FetchContent subproject under a parent whose FFTW/ImageMagick include dirs live under the parent build tree (e.g. libcvc-deps unpacked into `<parent>/build/_deps/libcvc-deps/include`). Each external absolute include is now wrapped in `<BUILD_INTERFACE:...>` like the inc/ + binary-inc/ entries above. Companion to MolSurf PR #1 / #6. Tag v3.2.2 already pushed pointing at this commit.