### PR TITLE
fix(cmake): wrap external include dirs in BUILD_INTERFACE (folds v3.2.2 + v3.2.3)

### DIFF
--- a/CMake/SetupBoost.cmake
+++ b/CMake/SetupBoost.cmake
@@ -26,8 +26,13 @@ function(SetupBoost TargetName)
     message(STATUS "Boost include dirs: ${Boost_INCLUDE_DIRS}")
     message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
     
-    # Use modern target-based approach
-    target_include_directories(${TargetName} PUBLIC ${Boost_INCLUDE_DIRS})
+    # Use modern target-based approach. Wrap each include dir in
+    # $<BUILD_INTERFACE:...> so a bundled toolchain (e.g. libcvc-deps
+    # under a parent project's build tree) doesn't leak a build-dir path
+    # into the installed cvc target's INTERFACE_INCLUDE_DIRECTORIES.
+    foreach(_boost_inc IN LISTS Boost_INCLUDE_DIRS)
+      target_include_directories(${TargetName} PUBLIC "$<BUILD_INTERFACE:${_boost_inc}>")
+    endforeach()
     target_link_libraries(${TargetName} PUBLIC ${Boost_LIBRARIES})
     
     # Platform-specific definitions

--- a/CMake/SetupGSL.cmake
+++ b/CMake/SetupGSL.cmake
@@ -11,7 +11,9 @@ function(SetupGSL TargetName)
     message(STATUS "GSL libraries: ${GSL_LIBRARIES}")
     
     # Use modern target-based approach
-    target_include_directories(${TargetName} PUBLIC ${GSL_INCLUDE_DIRS})
+    foreach(_gsl_inc IN LISTS GSL_INCLUDE_DIRS)
+      target_include_directories(${TargetName} PUBLIC "$<BUILD_INTERFACE:${_gsl_inc}>")
+    endforeach()
     target_link_libraries(${TargetName} PUBLIC ${GSL_LIBRARIES})
     
     if(CMAKE_GSL_CXX_FLAGS)

--- a/src/cvc/CMakeLists.txt
+++ b/src/cvc/CMakeLists.txt
@@ -679,14 +679,24 @@ if(CVC_ENABLE_IMAGEMAGICK)
   target_compile_definitions(cvc PUBLIC CVC_ENABLE_IMAGEMAGICK
     MAGICKCORE_QUANTUM_DEPTH=${CVC_IMAGEMAGICK_QUANTUM_DEPTH}
     MAGICKCORE_HDRI_ENABLE=${CVC_IMAGEMAGICK_HDRI_ENABLE})
-  target_include_directories(cvc PUBLIC ${ImageMagick_INCLUDE_DIRS})
+  # Wrap each external include dir in its own BUILD_INTERFACE genex so a
+  # bundled toolchain (e.g. libcvc-deps living under a parent project's
+  # build tree) does not leak a build-dir path into the installed cvc
+  # target's INTERFACE_INCLUDE_DIRECTORIES (CMake rejects that with
+  # "path is prefixed in the build directory").
+  foreach(_im_inc IN LISTS ImageMagick_INCLUDE_DIRS)
+    target_include_directories(cvc PUBLIC "$<BUILD_INTERFACE:${_im_inc}>")
+  endforeach()
   target_link_libraries(cvc PUBLIC ${ImageMagick_LIBRARIES})
 endif()
 
 # FFTW linking
 if(CVC_ENABLE_FFTW)
   target_compile_definitions(cvc PUBLIC CVC_ENABLE_FFTW)
-  target_include_directories(cvc PUBLIC ${FFTW3_INCLUDE_DIRS})
+  # Same BUILD_INTERFACE wrapping rationale as the ImageMagick block above.
+  foreach(_fftw_inc IN LISTS FFTW3_INCLUDE_DIRS)
+    target_include_directories(cvc PUBLIC "$<BUILD_INTERFACE:${_fftw_inc}>")
+  endforeach()
   target_link_libraries(cvc PUBLIC ${FFTW3_LIBRARIES})
 endif()
 

--- a/src/volutils/CMakeLists.txt
+++ b/src/volutils/CMakeLists.txt
@@ -48,9 +48,14 @@ if(CVC_ENABLE_IMAGEMAGICK)
   target_compile_definitions(volutils PRIVATE
     MAGICKCORE_QUANTUM_DEPTH=16
     MAGICKCORE_HDRI_ENABLE=0)
-  # Also add to cvc library for volume_ops.cpp
+  # Also add to cvc library for volume_ops.cpp. Wrap each include dir
+  # in $<BUILD_INTERFACE:...> so a bundled toolchain doesn't leak a
+  # build-dir path into the installed cvc target's
+  # INTERFACE_INCLUDE_DIRECTORIES.
   target_compile_definitions(cvc PUBLIC CVC_ENABLE_IMAGEMAGICK)
-  target_include_directories(cvc PUBLIC ${ImageMagick_INCLUDE_DIRS})
+  foreach(_im_inc IN LISTS ImageMagick_INCLUDE_DIRS)
+    target_include_directories(cvc PUBLIC "$<BUILD_INTERFACE:${_im_inc}>")
+  endforeach()
   target_link_libraries(cvc PUBLIC ${ImageMagick_LIBRARIES})
 endif()
 
@@ -59,7 +64,9 @@ if(CVC_ENABLE_FFTW)
   target_include_directories(volutils PRIVATE ${FFTW3_INCLUDE_DIRS})
   target_link_libraries(volutils PRIVATE ${FFTW3_LIBRARIES})
   target_compile_definitions(cvc PUBLIC CVC_ENABLE_FFTW)
-  target_include_directories(cvc PUBLIC ${FFTW3_INCLUDE_DIRS})
+  foreach(_fftw_inc IN LISTS FFTW3_INCLUDE_DIRS)
+    target_include_directories(cvc PUBLIC "$<BUILD_INTERFACE:${_fftw_inc}>")
+  endforeach()
   target_link_libraries(cvc PUBLIC ${FFTW3_LIBRARIES})
 endif()
 


### PR DESCRIPTION
Squashes the two fixes that were tagged v3.2.2 and v3.2.3 into a single commit. Both have the same root cause (absolute include paths from bundled toolchain leaking into the cvc target's PUBLIC include list, breaking parent FetchContent builds) and the same fix shape (wrap in $<BUILD_INTERFACE:...>).

After this merges, v3.2.1 will be force-retagged onto master HEAD and the v3.2.2 + v3.2.3 tags + GitHub releases will be deleted. No downstream had consumed v3.2.2 or v3.2.3.

Files patched:
- src/cvc/CMakeLists.txt:      FFTW3_INCLUDE_DIRS, ImageMagick_INCLUDE_DIRS
- src/volutils/CMakeLists.txt: ImageMagick_INCLUDE_DIRS, FFTW3_INCLUDE_DIRS (cvc PUBLIC additions only)
- CMake/SetupBoost.cmake:      Boost_INCLUDE_DIRS
- CMake/SetupGSL.cmake:        GSL_INCLUDE_DIRS