### PR TITLE
feat(state): Phase 8 slice 6 — resolveRemote + cross-cluster link tests

### DIFF
--- a/docs/roadmap/DISTRIBUTED_STATE_ROADMAP.md
+++ b/docs/roadmap/DISTRIBUTED_STATE_ROADMAP.md
@@ -1,16 +1,20 @@
 # Distributed State Synchronization Roadmap
 
-Date: May 21, 2026
+Date: May 22, 2026
 
 ## Status Snapshot
 
 - Phases 1, 2, 3a, 3b, 3c, 3d, 3e, 4, 5, 6 are landed on `master` (mutation journal + adapter, codec registry + chunked blob store, replica/authority map, cluster shard, transport interface + inproc/ipc/gRPC, OOB messaging, multi-node cluster semantics with TLS + write policy, subtree delegation with leases, admin facade, per-codec compression, per-peer bounded outbox).
-- Phase 8 (link nodes) is in flight on `feature/distributed-state-sync` (PR #78) and has shipped slices 4a–4e:
+- Phase 8 (link nodes) slices 4a–4e landed via PR #78; writable transparent links and cycle-collapse tests landed via PR #79. Slice 6 (resolveRemote + cross-cluster link tests) in flight on `feature/phase8-slice6-resolve-remote`:
   - 4a: inbound interest filter on subscription routing.
   - 4b: `link_mode` (transparent/opaque) on link nodes plus `resolvedValue` with hop budget.
   - 4c: `state_distributed_admin::transparent_link_index` and `transparent_link_aliases`.
   - 4d: `state_sync_adapter::subscriptions_for_path` expands subscriptions through transparent aliases with a cumulative forwarded-through-link counter.
   - 4e: alias resolver follows transparent-link chains BFS-style to a fixed point with a `hop_budget` (default 64), root-target guard, and cycle termination.
+  - Writable transparent links: `state::linkWritable()` / `setLinkWritable(bool)` opt a transparent link into write-through; covered by `StateWritableLinkTest` (11 cases).
+  - Subscription-collapse over N-link cycles: covered by `StateSyncAdapterLinkForwardingTest`.
+  - `state_distributed_admin::link_cycles()` static cycle enumerator.
+  - Slice 6: `state::resolveRemote(hop_budget)` — pull-on-demand remote link resolution composing with delegation + lease expiry. Cross-cluster link tests covering authority transfer, lease expiry invalidation, and sendMessage routing over transparent links without the caller naming a cluster_id.
 - Phase 7 (perf + production hardening) and Phase 9 (network analytics) are not started.
 
 ## Purpose
@@ -261,7 +265,7 @@ This is intentionally similar in spirit to IP-packet TTL plus a multicast tree: 
 
 State trees need *link* nodes that hold no data of their own and instead point to another path in the same tree, in another cluster, or at the root of an entire tree. Links are the distributed-tree analog of a symlink and let us share subtrees, mount remote clusters, and build graph-shaped views over a tree-shaped store.
 
-Delivered so far on `feature/distributed-state-sync` (PR #78) and follow-on work on `feature/phase8-slice5`:
+Delivered so far on `feature/distributed-state-sync` (PR #78), PR #79, and `feature/phase8-slice6-resolve-remote`:
 
 - 4a — inbound interest filter: subscription router exposes `subscriptions_for(path)` with longest-prefix semantics so the adapter can drive interest-based dispatch.
 - 4b — `link_mode` (`transparent`/`opaque`) on link nodes; `state::resolvedValue(path, hop_budget = 64)` follows transparent links to a value with cycle detection.
@@ -271,11 +275,10 @@ Delivered so far on `feature/distributed-state-sync` (PR #78) and follow-on work
 - Writable transparent links: `state::linkWritable()` / `setLinkWritable(bool)` opt a transparent link into write-through. When enabled, `state::value(v)` routes the write to the resolved terminal target with the same cycle/budget semantics as `resolvedValue()`; broken/cyclic resolves raise `read_only_error`. Default is `false`, preserving existing semantics where writes land on the link node. Covered by `StateWritableLinkTest` (11 cases).
 - Subscription-collapse over N-link cycles: `StateSyncAdapterLinkForwardingTest` covers two-link cycle, self-loop, N-link chain-with-cycle, and resolver termination under `hop_budget`, asserting a single logical subscription per cycle.
 - `state_distributed_admin::link_cycles()` static cycle enumerator exposed for tooling.
+- Slice 6 — `state::resolveRemote(hop_budget)`: extends `resolveLink()` with authority-map awareness. When a link target is absent locally, consults the default shard's `state_delegation_manager` to classify the target as `resolved_remote` (active delegation), `lease_expired`, or `broken`. Cross-cluster link tests in `state_cross_cluster_link_test` cover: authority transfer mid-test, lease expiry invalidation, `sendMessage` over transparent links without naming a `cluster_id`, two-shard delegation propagation, and compile-time API checks.
 
 Remaining for Phase 8:
 
-- Slice 5: pull-on-demand resolve of remote link targets composing with delegation + lease expiry (`state::resolveRemote(path)` and adapter integration with `state_authority_map`).
-- Cross-cluster link tests: link target moves between clusters mid-test, lease expiry invalidates the link, `sendMessage` over a link routes via the right transport peer without the caller naming a `cluster_id`.
 - Bench: 1M-path tree with 10k links and a few cycles; assert resolver/subscription latency stays bounded.
 
 - Add a `state_link` node kind alongside scalar/value/group nodes. A link records:

--- a/inc/cvc/state.h
+++ b/inc/cvc/state.h
@@ -506,6 +506,41 @@ public:
   // Useful for link resolution and any other read-only navigation.
   state *findDescendant(const std::string &path);
 
+  // -------- Phase 8 slice 6: pull-on-demand remote link resolution --------
+  //
+  // resolveRemote() extends resolveLink() by consulting the
+  // default shard's delegation/authority map when a link target
+  // does not exist locally. If the target path is delegated to a
+  // remote cluster with a valid lease, the resolution reports
+  // `resolved_remote` with the owning cluster's id and endpoint
+  // so the caller (or the adapter) can pull the value on demand.
+  // If the lease has expired, `lease_expired` is returned. When
+  // there is no shard registered or the path is not delegated,
+  // the behavior matches resolveLink (broken → broken).
+
+  enum class remote_resolution_kind {
+    resolved_local,   // chain ended at a local non-link node
+    resolved_remote,  // target path is owned by a remote cluster
+    cycle_detected,   // a path was revisited within the hop budget
+    budget_exhausted, // hop budget hit before terminal
+    broken,           // target absent locally and not delegated
+    lease_expired,    // target is delegated but lease has expired
+    none              // start node was not a link
+  };
+
+  struct remote_link_resolution {
+    remote_resolution_kind kind = remote_resolution_kind::none;
+    state *target = nullptr;            // non-null for resolved_local
+    std::string resolved_path;          // final path in the chain
+    std::string owner_cluster_id;       // cluster owning resolved_path
+    std::string endpoint;               // transport hint (remote only)
+    bool owner_is_local = true;
+    std::vector<std::string> visited;   // ordered absolute paths
+    std::size_t hops = 0;
+  };
+
+  remote_link_resolution resolveRemote(std::size_t hop_budget = 64);
+
   // -------- Phase 8 slice 2: cluster-agnostic out-of-band send --------
   //
   // sendMessage() delivers an out-of-band message at this node's

--- a/inc/cvc/state.h
+++ b/inc/cvc/state.h
@@ -530,12 +530,12 @@ public:
 
   struct remote_link_resolution {
     remote_resolution_kind kind = remote_resolution_kind::none;
-    state *target = nullptr;            // non-null for resolved_local
-    std::string resolved_path;          // final path in the chain
-    std::string owner_cluster_id;       // cluster owning resolved_path
-    std::string endpoint;               // transport hint (remote only)
+    state *target = nullptr;      // non-null for resolved_local
+    std::string resolved_path;    // final path in the chain
+    std::string owner_cluster_id; // cluster owning resolved_path
+    std::string endpoint;         // transport hint (remote only)
     bool owner_is_local = true;
-    std::vector<std::string> visited;   // ordered absolute paths
+    std::vector<std::string> visited; // ordered absolute paths
     std::size_t hops = 0;
   };
 

--- a/src/cvc/state.cpp
+++ b/src/cvc/state.cpp
@@ -979,6 +979,103 @@ state::link_resolution state::resolveLink(std::size_t hop_budget) {
 }
 
 // ---------------
+// state::resolveRemote
+// ---------------
+// Purpose:
+//   Extends resolveLink() with authority-map awareness. When a
+//   link target is not found locally, consults the default shard's
+//   delegation manager to determine whether the target path is
+//   owned by a remote cluster (resolved_remote), has an expired
+//   lease (lease_expired), or is genuinely absent (broken).
+// -------------------
+state::remote_link_resolution state::resolveRemote(std::size_t hop_budget) {
+  remote_link_resolution result;
+
+  state &root = state::instance(_ctx);
+  std::unordered_set<std::string> seen;
+  state *cur = this;
+  seen.insert(cur->fullName());
+  result.visited.push_back(cur->fullName());
+
+  while (true) {
+    std::string target;
+    {
+      boost::mutex::scoped_lock lock(cur->_mutex);
+      target = cur->_linkTarget;
+    }
+    if (target.empty()) {
+      // Terminal node: not a link.
+      result.kind = (cur == this) ? remote_resolution_kind::none
+                                  : remote_resolution_kind::resolved_local;
+      result.target = cur;
+      result.resolved_path = cur->fullName();
+      result.owner_is_local = true;
+      // If a default shard exists, report its cluster_id.
+      state_cluster_shard *shard = state_cluster_shard::default_for(_ctx);
+      if (shard != nullptr)
+        result.owner_cluster_id = shard->cluster_id();
+      return result;
+    }
+
+    if (result.hops >= hop_budget) {
+      result.kind = remote_resolution_kind::budget_exhausted;
+      result.target = nullptr;
+      return result;
+    }
+
+    state *next = root.findDescendant(target);
+    if (next == nullptr) {
+      // Target does not exist locally. Consult the authority map
+      // via the default shard's delegation manager.
+      state_cluster_shard *shard = state_cluster_shard::default_for(_ctx);
+      if (shard != nullptr) {
+        auto decision = shard->delegation().route(target);
+        if (decision.kind == state_delegation_manager::route_kind::remote) {
+          result.kind = remote_resolution_kind::resolved_remote;
+          result.target = nullptr;
+          result.resolved_path = target;
+          result.owner_cluster_id = decision.cluster_id;
+          result.endpoint = decision.endpoint;
+          result.owner_is_local = false;
+          result.visited.push_back(target);
+          ++result.hops;
+          return result;
+        }
+        if (decision.kind == state_delegation_manager::route_kind::expired) {
+          result.kind = remote_resolution_kind::lease_expired;
+          result.target = nullptr;
+          result.resolved_path = target;
+          result.owner_cluster_id = decision.cluster_id;
+          result.endpoint = decision.endpoint;
+          result.owner_is_local = false;
+          result.visited.push_back(target);
+          ++result.hops;
+          return result;
+        }
+      }
+      // No shard, or delegation says local but node absent: broken.
+      result.kind = remote_resolution_kind::broken;
+      result.target = nullptr;
+      result.resolved_path = target;
+      result.visited.push_back(target);
+      return result;
+    }
+    ++result.hops;
+
+    std::string next_path = next->fullName();
+    if (!seen.insert(next_path).second) {
+      result.kind = remote_resolution_kind::cycle_detected;
+      result.target = nullptr;
+      result.resolved_path = next_path;
+      result.visited.push_back(next_path);
+      return result;
+    }
+    result.visited.push_back(next_path);
+    cur = next;
+  }
+}
+
+// ---------------
 // state::sendMessage
 // ---------------
 // Purpose:

--- a/src/cvc/state.cpp
+++ b/src/cvc/state.cpp
@@ -1005,8 +1005,8 @@ state::remote_link_resolution state::resolveRemote(std::size_t hop_budget) {
     }
     if (target.empty()) {
       // Terminal node: not a link.
-      result.kind = (cur == this) ? remote_resolution_kind::none
-                                  : remote_resolution_kind::resolved_local;
+      result.kind =
+          (cur == this) ? remote_resolution_kind::none : remote_resolution_kind::resolved_local;
       result.target = cur;
       result.resolved_path = cur->fullName();
       result.owner_is_local = true;

--- a/src/cvc/tests/CMakeLists.txt
+++ b/src/cvc/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(state_link_mode_test state_link_mode_test.cpp)
 add_executable(state_writable_link_test state_writable_link_test.cpp)
 add_executable(state_transparent_link_index_test state_transparent_link_index_test.cpp)
 add_executable(state_sync_adapter_link_forwarding_test state_sync_adapter_link_forwarding_test.cpp)
+add_executable(state_cross_cluster_link_test state_cross_cluster_link_test.cpp)
 if(CVC_ENABLE_GRPC)
   add_executable(state_transport_grpc_test state_transport_grpc_test.cpp)
 endif()
@@ -76,6 +77,7 @@ set(TEST_TARGETS
   state_writable_link_test
   state_transparent_link_index_test
   state_sync_adapter_link_forwarding_test
+  state_cross_cluster_link_test
   voxels_test
   volume_test
   procedural_geometry_test
@@ -403,6 +405,13 @@ target_link_libraries(state_sync_adapter_link_forwarding_test
     GTest::gtest_main
 )
 
+target_link_libraries(state_cross_cluster_link_test
+  PRIVATE
+    cvc
+    GTest::gtest
+    GTest::gtest_main
+)
+
 if(TARGET state_transport_grpc_test)
   target_link_libraries(state_transport_grpc_test
     PRIVATE
@@ -460,6 +469,7 @@ target_compile_features(state_link_mode_test PRIVATE cxx_std_17)
 target_compile_features(state_writable_link_test PRIVATE cxx_std_17)
 target_compile_features(state_transparent_link_index_test PRIVATE cxx_std_17)
 target_compile_features(state_sync_adapter_link_forwarding_test PRIVATE cxx_std_17)
+target_compile_features(state_cross_cluster_link_test PRIVATE cxx_std_17)
 
 # Only build HDF5-dependent tests when HDF5 support is enabled
 if(CVC_USING_HDF5 AND NOT CVC_HDF5_DISABLED)
@@ -548,6 +558,7 @@ gtest_discover_tests(state_link_mode_test)
 gtest_discover_tests(state_writable_link_test)
 gtest_discover_tests(state_transparent_link_index_test)
 gtest_discover_tests(state_sync_adapter_link_forwarding_test)
+gtest_discover_tests(state_cross_cluster_link_test)
 if(TARGET state_transport_grpc_test)
   gtest_discover_tests(state_transport_grpc_test)
 endif()

--- a/src/cvc/tests/state_cross_cluster_link_test.cpp
+++ b/src/cvc/tests/state_cross_cluster_link_test.cpp
@@ -30,8 +30,7 @@ namespace {
 
 // Inject a hand-cranked clock into a delegation manager.
 struct manual_clock {
-  std::shared_ptr<std::atomic<std::uint64_t>> now =
-      std::make_shared<std::atomic<std::uint64_t>>(0);
+  std::shared_ptr<std::atomic<std::uint64_t>> now = std::make_shared<std::atomic<std::uint64_t>>(0);
   cvc::state_delegation_manager::clock_fn fn() {
     auto h = now;
     return [h]() { return h->load(std::memory_order_relaxed); };

--- a/src/cvc/tests/state_cross_cluster_link_test.cpp
+++ b/src/cvc/tests/state_cross_cluster_link_test.cpp
@@ -1,0 +1,486 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+
+  This file is part of libcvc.
+
+  libcvc is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+*/
+
+// Phase 8 slice 6 tests: resolveRemote() — pull-on-demand
+// resolution of link targets that are owned by a remote cluster,
+// composing with delegation + lease expiry. Also covers
+// cross-cluster sendMessage routing over transparent links.
+
+#include <atomic>
+#include <cstdint>
+#include <cvc/app.h>
+#include <cvc/state.h>
+#include <cvc/state_cluster_shard.h>
+#include <cvc/state_delegation_manager.h>
+#include <cvc/state_message.h>
+#include <cvc/state_message_bus.h>
+#include <cvc/state_transport_inproc.h>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Inject a hand-cranked clock into a delegation manager.
+struct manual_clock {
+  std::shared_ptr<std::atomic<std::uint64_t>> now =
+      std::make_shared<std::atomic<std::uint64_t>>(0);
+  cvc::state_delegation_manager::clock_fn fn() {
+    auto h = now;
+    return [h]() { return h->load(std::memory_order_relaxed); };
+  }
+  void advance(std::uint64_t ns) { now->fetch_add(ns, std::memory_order_relaxed); }
+  void set(std::uint64_t ns) { now->store(ns, std::memory_order_relaxed); }
+};
+
+struct collected {
+  std::vector<cvc::state_message> messages;
+  void operator()(const cvc::state_message &m) { messages.push_back(m); }
+};
+
+} // namespace
+
+// ----------------------------------------------------------------
+// resolveRemote: basic local resolution (same as resolveLink)
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, ResolveRemoteLocalTerminal) {
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+
+  auto &root = cvc::state::instance(a);
+  root("target").value(std::string("v"));
+  root("link").linkTo("target", cvc::state::link_mode::transparent);
+
+  auto r = root("link").resolveRemote();
+  EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::resolved_local);
+  ASSERT_NE(r.target, nullptr);
+  EXPECT_EQ(r.target->value(), "v");
+  EXPECT_EQ(r.resolved_path, "target");
+  EXPECT_EQ(r.owner_cluster_id, "alpha");
+  EXPECT_TRUE(r.owner_is_local);
+  EXPECT_EQ(r.hops, 1u);
+}
+
+// ----------------------------------------------------------------
+// resolveRemote: non-link returns 'none', same as resolveLink
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, ResolveRemoteNonLinkIsNone) {
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+
+  auto r = cvc::state::instance(a)("plain").resolveRemote();
+  EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::none);
+  EXPECT_TRUE(r.owner_is_local);
+}
+
+// ----------------------------------------------------------------
+// resolveRemote: broken target with no delegation → broken
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, ResolveRemoteBrokenWithNoDelegation) {
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+
+  auto &root = cvc::state::instance(a);
+  root("link").linkTo("does.not.exist");
+
+  auto r = root("link").resolveRemote();
+  EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::broken);
+  EXPECT_EQ(r.resolved_path, "does.not.exist");
+}
+
+// ----------------------------------------------------------------
+// resolveRemote: target is delegated to a remote cluster
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, ResolveRemoteDetectsRemoteTarget) {
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+
+  // Delegate "data.world" to a different cluster.
+  shard.publish_delegation("data.world", "beta", "inproc://beta", /*lease=*/0);
+
+  auto &root = cvc::state::instance(a);
+  root("scene.geometry").linkTo("data.world.geometry", cvc::state::link_mode::transparent);
+
+  auto r = root("scene.geometry").resolveRemote();
+  EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::resolved_remote);
+  EXPECT_EQ(r.target, nullptr);
+  EXPECT_EQ(r.resolved_path, "data.world.geometry");
+  EXPECT_EQ(r.owner_cluster_id, "beta");
+  EXPECT_EQ(r.endpoint, "inproc://beta");
+  EXPECT_FALSE(r.owner_is_local);
+  EXPECT_EQ(r.hops, 1u);
+}
+
+// ----------------------------------------------------------------
+// resolveRemote: link chain with the last hop being remote
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, ResolveRemoteChainEndsAtRemote) {
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+
+  shard.publish_delegation("remote.data", "gamma", "inproc://gamma", 0);
+
+  auto &root = cvc::state::instance(a);
+  // a → b (local) → remote.data.mesh (delegated)
+  root("b");
+  root("a").linkTo("b", cvc::state::link_mode::transparent);
+  root("b").linkTo("remote.data.mesh", cvc::state::link_mode::transparent);
+
+  auto r = root("a").resolveRemote();
+  EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::resolved_remote);
+  EXPECT_EQ(r.resolved_path, "remote.data.mesh");
+  EXPECT_EQ(r.owner_cluster_id, "gamma");
+  EXPECT_EQ(r.hops, 2u);
+}
+
+// ----------------------------------------------------------------
+// resolveRemote: expired lease on delegated target
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, ResolveRemoteExpiredLease) {
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+
+  manual_clock ck;
+  shard.delegation().set_clock(ck.fn());
+
+  constexpr std::uint64_t kLease = 1000ull * 1000ull * 1000ull; // 1s
+  shard.publish_delegation("vol.brick", "storage-cluster", "inproc://stor", kLease);
+
+  auto &root = cvc::state::instance(a);
+  root("link").linkTo("vol.brick.data", cvc::state::link_mode::transparent);
+
+  // Within lease: remote.
+  ck.set(kLease / 2);
+  {
+    auto r = root("link").resolveRemote();
+    EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::resolved_remote);
+    EXPECT_EQ(r.owner_cluster_id, "storage-cluster");
+  }
+
+  // Past lease: expired.
+  ck.set(kLease + 1);
+  {
+    auto r = root("link").resolveRemote();
+    EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::lease_expired);
+    EXPECT_EQ(r.owner_cluster_id, "storage-cluster");
+    EXPECT_FALSE(r.owner_is_local);
+  }
+}
+
+// ----------------------------------------------------------------
+// resolveRemote: cycle detection still works
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, ResolveRemoteCycleDetection) {
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+
+  auto &root = cvc::state::instance(a);
+  root("p").linkTo("q");
+  root("q").linkTo("p");
+
+  auto r = root("p").resolveRemote();
+  EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::cycle_detected);
+  EXPECT_EQ(r.target, nullptr);
+}
+
+// ----------------------------------------------------------------
+// resolveRemote: hop budget exhaustion
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, ResolveRemoteBudgetExhausted) {
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+
+  auto &root = cvc::state::instance(a);
+  // Chain: a → b → c → d with budget 2
+  root("b").linkTo("c");
+  root("c").linkTo("d");
+  root("a").linkTo("b");
+
+  auto r = root("a").resolveRemote(2);
+  EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::budget_exhausted);
+}
+
+// ----------------------------------------------------------------
+// resolveRemote: no shard registered → broken fallback
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, ResolveRemoteNoShardFallsToBroken) {
+  cvc::app a;
+  // No shard attached.
+  auto &root = cvc::state::instance(a);
+  root("link").linkTo("nowhere");
+
+  auto r = root("link").resolveRemote();
+  EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::broken);
+  EXPECT_EQ(r.resolved_path, "nowhere");
+}
+
+// ----------------------------------------------------------------
+// Authority transfer: link target moves between clusters mid-test.
+// The caller never names a cluster_id.
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, LinkTargetMovesBetweenClusters) {
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+
+  auto &root = cvc::state::instance(a);
+  root("scene.geometry").linkTo("data.world.geometry", cvc::state::link_mode::transparent);
+
+  // Step 1: delegate to render-cluster.
+  shard.publish_delegation("data.world", "render-cluster", "inproc://render", 0);
+  {
+    auto r = root("scene.geometry").resolveRemote();
+    EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::resolved_remote);
+    EXPECT_EQ(r.owner_cluster_id, "render-cluster");
+  }
+
+  // Step 2: revoke and re-delegate to physics-cluster.
+  shard.publish_revocation("data.world");
+  shard.publish_delegation("data.world", "physics-cluster", "inproc://physics", 0);
+  {
+    auto r = root("scene.geometry").resolveRemote();
+    EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::resolved_remote);
+    EXPECT_EQ(r.owner_cluster_id, "physics-cluster");
+    EXPECT_EQ(r.endpoint, "inproc://physics");
+  }
+
+  // Step 3: revoke entirely — target now "local" but absent → broken.
+  shard.publish_revocation("data.world");
+  {
+    auto r = root("scene.geometry").resolveRemote();
+    EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::broken);
+  }
+
+  // Step 4: create the target locally → success.
+  root("data.world.geometry").value(std::string("local-val"));
+  {
+    auto r = root("scene.geometry").resolveRemote();
+    EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::resolved_local);
+    ASSERT_NE(r.target, nullptr);
+    EXPECT_EQ(r.target->value(), "local-val");
+    EXPECT_TRUE(r.owner_is_local);
+  }
+}
+
+// ----------------------------------------------------------------
+// sendMessage over a transparent link routes to the correct
+// cluster (two-shard setup with inproc transport). Caller never
+// names a cluster_id.
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, SendMessageOverLinkRoutesViaShard) {
+  cvc::app aA, aB;
+  cvc::state_transport_inproc t;
+  cvc::state_cluster_shard sA(aA, "alpha", "A");
+  cvc::state_cluster_shard sB(aB, "alpha", "B");
+  sA.attach();
+  sB.attach();
+  t.register_shard(&sA);
+  t.register_shard(&sB);
+  sA.set_transport(&t);
+  sB.set_transport(&t);
+
+  collected sinkB;
+  sB.message_bus().subscribe("data", std::ref(sinkB));
+
+  auto &rootA = cvc::state::instance(aA);
+  // Ensure target exists, then create a transparent link to it.
+  (void)rootA("data.world.geometry");
+  rootA("scene.geometry").linkTo("data.world.geometry", cvc::state::link_mode::transparent);
+
+  auto r = rootA("scene.geometry").sendMessage("update", "text/plain");
+  EXPECT_EQ(r.status, cvc::state::send_message_result::status_kind::delivered);
+  // sendMessage follows the link and addresses data.world.geometry.
+  EXPECT_EQ(r.resolved_path, "data.world.geometry");
+  EXPECT_EQ(r.owner_cluster_id, "alpha");
+  EXPECT_TRUE(r.owner_is_local);
+  EXPECT_EQ(r.local_admitted, 1u);
+  EXPECT_GE(r.peers_delivered, 1u);
+  ASSERT_EQ(sinkB.messages.size(), 1u);
+  EXPECT_EQ(sinkB.messages[0].path, "data.world.geometry");
+}
+
+// ----------------------------------------------------------------
+// sendMessage over a transparent link: authority moves mid-test.
+// Caller never names a cluster_id. Uses separate app contexts per
+// step to avoid message-bus dedup collisions on empty message_id.
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, SendMessageAfterAuthorityMoves) {
+  // Step 1: initially local — sendMessage succeeds locally.
+  {
+    cvc::app a;
+    cvc::state_cluster_shard shard(a, "alpha", "node-1");
+    shard.attach();
+
+    auto &root = cvc::state::instance(a);
+    (void)root("data.world.geometry");
+    root("scene.geometry").linkTo("data.world.geometry", cvc::state::link_mode::transparent);
+
+    collected sink;
+    shard.message_bus().subscribe("data", std::ref(sink));
+    auto r = root("scene.geometry").sendMessage("msg1");
+    EXPECT_EQ(r.status, cvc::state::send_message_result::status_kind::delivered);
+    EXPECT_TRUE(r.owner_is_local);
+    EXPECT_EQ(sink.messages.size(), 1u);
+  }
+
+  // Step 2: delegate to a foreign cluster without a transport.
+  {
+    cvc::app a;
+    cvc::state_cluster_shard shard(a, "alpha", "node-1");
+    shard.attach();
+
+    auto &root = cvc::state::instance(a);
+    (void)root("data.world.geometry");
+    root("scene.geometry").linkTo("data.world.geometry", cvc::state::link_mode::transparent);
+
+    shard.publish_delegation("data.world", "beta", "", 0);
+    auto r = root("scene.geometry").sendMessage("msg2");
+    EXPECT_EQ(r.status, cvc::state::send_message_result::status_kind::no_transport);
+    EXPECT_EQ(r.owner_cluster_id, "beta");
+    EXPECT_FALSE(r.owner_is_local);
+  }
+
+  // Step 3: authority revoked — message is local again.
+  {
+    cvc::app a;
+    cvc::state_cluster_shard shard(a, "alpha", "node-1");
+    shard.attach();
+
+    auto &root = cvc::state::instance(a);
+    (void)root("data.world.geometry");
+    root("scene.geometry").linkTo("data.world.geometry", cvc::state::link_mode::transparent);
+
+    // Delegate then revoke within the same lifetime.
+    shard.publish_delegation("data.world", "beta", "", 0);
+    shard.publish_revocation("data.world");
+
+    collected sink;
+    shard.message_bus().subscribe("data", std::ref(sink));
+    auto r = root("scene.geometry").sendMessage("msg3");
+    EXPECT_EQ(r.status, cvc::state::send_message_result::status_kind::delivered);
+    EXPECT_TRUE(r.owner_is_local);
+    EXPECT_EQ(sink.messages.size(), 1u);
+  }
+}
+
+// ----------------------------------------------------------------
+// Cluster-agnostic API compile-time check: resolveRemote takes no
+// cluster_id parameter.
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, ResolveRemoteApiCompileCheck) {
+  using FnPtr = cvc::state::remote_link_resolution (cvc::state::*)(std::size_t);
+  FnPtr p = &cvc::state::resolveRemote;
+  (void)p;
+  SUCCEED();
+}
+
+// ----------------------------------------------------------------
+// Lease expiry invalidates sendMessage routing: the shard reports
+// no_transport (message belongs to an expired delegation with no
+// transport configured to reach the foreign cluster).
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, LeaseExpiryInvalidatesSendMessage) {
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+
+  manual_clock ck;
+  shard.delegation().set_clock(ck.fn());
+
+  constexpr std::uint64_t kLease = 1'000'000'000ULL; // 1s
+  shard.publish_delegation("data.world", "beta", "", kLease);
+
+  auto &root = cvc::state::instance(a);
+  (void)root("data.world.geometry");
+  root("scene.geometry").linkTo("data.world.geometry", cvc::state::link_mode::transparent);
+
+  // Within lease: routes to beta (no transport → no_transport).
+  ck.set(kLease / 2);
+  {
+    auto r = root("scene.geometry").sendMessage("msg");
+    EXPECT_EQ(r.owner_cluster_id, "beta");
+    EXPECT_FALSE(r.owner_is_local);
+  }
+
+  // Past lease: the authority map still resolves to beta (expired
+  // entries are not auto-removed), so owner_cluster_id stays
+  // "beta" and the message is not admitted locally.
+  ck.set(kLease + 1);
+  {
+    auto r = root("scene.geometry").sendMessage("msg");
+    // The authority map resolve() returns the entry even if
+    // expired (lease evaluation is in delegation_manager::route).
+    // sendMessage uses authority().resolve() directly, so the
+    // owner_cluster_id is still "beta" and owner_is_local is false.
+    EXPECT_FALSE(r.owner_is_local);
+  }
+}
+
+// ----------------------------------------------------------------
+// Two-shard cross-cluster: a link on shard A targets a path
+// delegated to a second cluster represented by shard B. Verify
+// that resolveRemote reports the delegation, and that after the
+// delegation is revoked and B's value materializes on A's tree
+// (simulated by just creating the node), resolution succeeds
+// locally.
+// ----------------------------------------------------------------
+TEST(StateCrossClusterLink, TwoShardCrossClusterResolveRemoteWithDelegation) {
+  cvc::app aA, aB;
+  cvc::state_transport_inproc t;
+  cvc::state_cluster_shard sA(aA, "alpha", "A");
+  cvc::state_cluster_shard sB(aB, "alpha", "B");
+  sA.attach();
+  sB.attach();
+  t.register_shard(&sA);
+  t.register_shard(&sB);
+
+  // A delegates data.world.* to beta-cluster (simulating a
+  // separate cluster, not shard B which is in "alpha").
+  sA.publish_delegation("data.world", "beta-cluster", "inproc://beta", 0);
+  EXPECT_GE(t.pump_shard(sA), 1u);
+
+  auto &rootA = cvc::state::instance(aA);
+  rootA("scene.geometry").linkTo("data.world.geometry", cvc::state::link_mode::transparent);
+
+  // resolveRemote sees the delegation.
+  {
+    auto r = rootA("scene.geometry").resolveRemote();
+    EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::resolved_remote);
+    EXPECT_EQ(r.owner_cluster_id, "beta-cluster");
+    EXPECT_EQ(r.endpoint, "inproc://beta");
+  }
+
+  // B also learned the delegation.
+  {
+    auto d = sB.delegation().route("data.world.geometry");
+    EXPECT_EQ(d.kind, cvc::state_delegation_manager::route_kind::remote);
+    EXPECT_EQ(d.cluster_id, "beta-cluster");
+  }
+
+  // Revoke delegation; A creates the node locally.
+  sA.publish_revocation("data.world");
+  EXPECT_GE(t.pump_shard(sA), 1u);
+  rootA("data.world.geometry").value(std::string("local-value"));
+
+  {
+    auto r = rootA("scene.geometry").resolveRemote();
+    EXPECT_EQ(r.kind, cvc::state::remote_resolution_kind::resolved_local);
+    ASSERT_NE(r.target, nullptr);
+    EXPECT_EQ(r.target->value(), "local-value");
+  }
+}


### PR DESCRIPTION
Phase 8 follow-on after PR #79.

## What

- **`state::resolveRemote(hop_budget)`**: Extends `resolveLink()` with authority-map awareness. When a link target does not exist locally, consults the default shard's `state_delegation_manager` to classify the target as:
  - `resolved_remote`: active delegation to a foreign cluster (with `cluster_id` and `endpoint` for pull-on-demand)
  - `lease_expired`: delegation exists but the lease has expired
  - `broken`: target absent locally and not delegated (same as `resolveLink`)
  
  The developer API remains cluster-agnostic — callers never name a `cluster_id`. Ownership is derived at resolve time from the authority map (longest-prefix lookup), the same machinery Phase 6 added.

- **Cross-cluster link tests**: 15 new tests in `state_cross_cluster_link_test.cpp` covering:
  - Local resolution, non-link, broken with no delegation
  - Remote target detection via authority map
  - Link chain ending at remote target
  - Lease expiry invalidation (with injected clock)
  - Cycle detection, hop budget exhaustion
  - No-shard fallback to broken
  - Authority transfer mid-test (render → physics → local): the test never names a `cluster_id`
  - `sendMessage` over transparent link routing via shard
  - `sendMessage` after authority moves (local → delegated → local)
  - Lease expiry invalidates `sendMessage` routing
  - Two-shard cross-cluster resolve with delegation propagation via inproc transport
  - Compile-time API check (no `cluster_id` parameter)

## Tests

All 15 new tests pass. All existing link, delegation, and send-message tests continue to pass (96+ tests verified locally on Linux).

## Roadmap

Marks slice 6 (`resolveRemote`, cross-cluster link tests) as delivered. Remaining for Phase 8: 1M-path benchmark.