### PR TITLE
feat(state): Phase 8 link benchmark suite + CI master-only gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,7 @@ jobs:
           #   BunnySDF_IsoRoundtrip|QualityImproveAllMethods : heavy Debug-only
           STRESS_REGEX='(Stress|Convergence|Benchmark|Performance|BunnySDF_IsoRoundtrip|QualityImproveAllMethods)'
           if [ "${{ github.event_name }}" = "push" ]; then
+            CVC_DISTRIBUTED_STATE_BENCH=1 \
             ctest --test-dir build \
                   --build-config ${{ matrix.build_type }} \
                   --output-on-failure --parallel \
@@ -591,6 +592,7 @@ jobs:
           # See linux ctest step for rationale.
           STRESS_REGEX='(Stress|Convergence|Benchmark|Performance|BunnySDF_IsoRoundtrip|QualityImproveAllMethods)'
           if [ "${{ github.event_name }}" = "push" ]; then
+            CVC_DISTRIBUTED_STATE_BENCH=1 \
             ctest --test-dir build --build-config ${{ matrix.build_type }} \
                   --output-on-failure --parallel --repeat until-pass:3 --timeout 3600
           else
@@ -1053,6 +1055,7 @@ jobs:
           # See linux ctest step for rationale.
           $stressRegex = '(Stress|Convergence|Benchmark|Performance|BunnySDF_IsoRoundtrip|QualityImproveAllMethods)'
           if ('${{ github.event_name }}' -eq 'push') {
+            $env:CVC_DISTRIBUTED_STATE_BENCH = '1'
             ctest --test-dir build --build-config ${{ matrix.build_type }} `
                   --output-on-failure --parallel --repeat until-pass:3 --timeout 3600
           } else {

--- a/docs/roadmap/DISTRIBUTED_STATE_ROADMAP.md
+++ b/docs/roadmap/DISTRIBUTED_STATE_ROADMAP.md
@@ -5,7 +5,7 @@ Date: May 22, 2026
 ## Status Snapshot
 
 - Phases 1, 2, 3a, 3b, 3c, 3d, 3e, 4, 5, 6 are landed on `master` (mutation journal + adapter, codec registry + chunked blob store, replica/authority map, cluster shard, transport interface + inproc/ipc/gRPC, OOB messaging, multi-node cluster semantics with TLS + write policy, subtree delegation with leases, admin facade, per-codec compression, per-peer bounded outbox).
-- Phase 8 (link nodes) slices 4a–4e landed via PR #78; writable transparent links and cycle-collapse tests landed via PR #79. Slice 6 (resolveRemote + cross-cluster link tests) in flight on `feature/phase8-slice6-resolve-remote`:
+- Phase 8 (link nodes) is complete: slices 4a–4e landed via PR #78, writable transparent links and cycle-collapse tests via PR #79, resolveRemote + cross-cluster link tests via PR #80, link benchmark suite via PR #81.
   - 4a: inbound interest filter on subscription routing.
   - 4b: `link_mode` (transparent/opaque) on link nodes plus `resolvedValue` with hop budget.
   - 4c: `state_distributed_admin::transparent_link_index` and `transparent_link_aliases`.
@@ -261,11 +261,11 @@ This is intentionally similar in spirit to IP-packet TTL plus a multicast tree: 
 - Add admin tooling for inspection, manual resync, and blob garbage collection.
 - Document operational patterns for small interactive clusters and larger distributed processing clusters.
 
-### Phase 8: Link Nodes (Symbolic References) (in progress)
+### Phase 8: Link Nodes (Symbolic References) (complete)
 
 State trees need *link* nodes that hold no data of their own and instead point to another path in the same tree, in another cluster, or at the root of an entire tree. Links are the distributed-tree analog of a symlink and let us share subtrees, mount remote clusters, and build graph-shaped views over a tree-shaped store.
 
-Delivered so far on `feature/distributed-state-sync` (PR #78), PR #79, and `feature/phase8-slice6-resolve-remote`:
+Delivered on `feature/distributed-state-sync` (PR #78), PR #79, PR #80 (resolveRemote), and PR #81 (link benchmark):
 
 - 4a — inbound interest filter: subscription router exposes `subscriptions_for(path)` with longest-prefix semantics so the adapter can drive interest-based dispatch.
 - 4b — `link_mode` (`transparent`/`opaque`) on link nodes; `state::resolvedValue(path, hop_budget = 64)` follows transparent links to a value with cycle detection.
@@ -276,10 +276,11 @@ Delivered so far on `feature/distributed-state-sync` (PR #78), PR #79, and `feat
 - Subscription-collapse over N-link cycles: `StateSyncAdapterLinkForwardingTest` covers two-link cycle, self-loop, N-link chain-with-cycle, and resolver termination under `hop_budget`, asserting a single logical subscription per cycle.
 - `state_distributed_admin::link_cycles()` static cycle enumerator exposed for tooling.
 - Slice 6 — `state::resolveRemote(hop_budget)`: extends `resolveLink()` with authority-map awareness. When a link target is absent locally, consults the default shard's `state_delegation_manager` to classify the target as `resolved_remote` (active delegation), `lease_expired`, or `broken`. Cross-cluster link tests in `state_cross_cluster_link_test` cover: authority transfer mid-test, lease expiry invalidation, `sendMessage` over transparent links without naming a `cluster_id`, two-shard delegation propagation, and compile-time API checks.
+- Link benchmark (`state_link_bench_test`): 7 opt-in benchmarks (gated on `CVC_DISTRIBUTED_STATE_BENCH=1`) exercising `resolveLink`, `resolvedValue`, `resolveRemote` on 1M-path trees, and `transparent_link_index`, `transparent_link_aliases`, `subscriptions_for_path`, `link_cycles` on 100k-path trees. 3 always-on correctness companions. CI excludes the `StateLinkBenchmark` suite on PRs via the existing `Benchmark` stress-regex and enables the env gate on push-to-master for full execution.
 
 Remaining for Phase 8:
 
-- Bench: 1M-path tree with 10k links and a few cycles; assert resolver/subscription latency stays bounded.
+*None — Phase 8 is complete.*
 
 - Add a `state_link` node kind alongside scalar/value/group nodes. A link records:
   - target `path` (absolute, may be the empty path meaning the tree root) — this is the **only** required field for the developer-facing API,

--- a/src/cvc/tests/CMakeLists.txt
+++ b/src/cvc/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(state_writable_link_test state_writable_link_test.cpp)
 add_executable(state_transparent_link_index_test state_transparent_link_index_test.cpp)
 add_executable(state_sync_adapter_link_forwarding_test state_sync_adapter_link_forwarding_test.cpp)
 add_executable(state_cross_cluster_link_test state_cross_cluster_link_test.cpp)
+add_executable(state_link_bench_test state_link_bench_test.cpp)
 if(CVC_ENABLE_GRPC)
   add_executable(state_transport_grpc_test state_transport_grpc_test.cpp)
 endif()
@@ -78,6 +79,7 @@ set(TEST_TARGETS
   state_transparent_link_index_test
   state_sync_adapter_link_forwarding_test
   state_cross_cluster_link_test
+  state_link_bench_test
   voxels_test
   volume_test
   procedural_geometry_test
@@ -412,6 +414,13 @@ target_link_libraries(state_cross_cluster_link_test
     GTest::gtest_main
 )
 
+target_link_libraries(state_link_bench_test
+  PRIVATE
+    cvc
+    GTest::gtest
+    GTest::gtest_main
+)
+
 if(TARGET state_transport_grpc_test)
   target_link_libraries(state_transport_grpc_test
     PRIVATE
@@ -470,6 +479,7 @@ target_compile_features(state_writable_link_test PRIVATE cxx_std_17)
 target_compile_features(state_transparent_link_index_test PRIVATE cxx_std_17)
 target_compile_features(state_sync_adapter_link_forwarding_test PRIVATE cxx_std_17)
 target_compile_features(state_cross_cluster_link_test PRIVATE cxx_std_17)
+target_compile_features(state_link_bench_test PRIVATE cxx_std_17)
 
 # Only build HDF5-dependent tests when HDF5 support is enabled
 if(CVC_USING_HDF5 AND NOT CVC_HDF5_DISABLED)
@@ -559,6 +569,7 @@ gtest_discover_tests(state_writable_link_test)
 gtest_discover_tests(state_transparent_link_index_test)
 gtest_discover_tests(state_sync_adapter_link_forwarding_test)
 gtest_discover_tests(state_cross_cluster_link_test)
+gtest_discover_tests(state_link_bench_test)
 if(TARGET state_transport_grpc_test)
   gtest_discover_tests(state_transport_grpc_test)
 endif()

--- a/src/cvc/tests/state_link_bench_test.cpp
+++ b/src/cvc/tests/state_link_bench_test.cpp
@@ -1,0 +1,462 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+
+  This file is part of libcvc.
+
+  libcvc is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+*/
+
+// Phase 8 benchmark: 1M-path tree with 10k links (including a few
+// cycles). Asserts that resolver and subscription latency stay
+// bounded. Gated on CVC_DISTRIBUTED_STATE_BENCH=1 so normal CI is
+// not affected; always-on correctness companions run unconditionally.
+//
+// Output format (when enabled):
+//   BENCH <name> N=<count> wall_ns_total=<n> wall_ns_per_op=<n>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cvc/app.h>
+#include <cvc/state.h>
+#include <cvc/state_cluster_shard.h>
+#include <cvc/state_distributed_admin.h>
+#include <cvc/state_sync_adapter.h>
+#include <gtest/gtest.h>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+bool bench_enabled() {
+  const char *v = std::getenv("CVC_DISTRIBUTED_STATE_BENCH");
+  return v && std::string(v) == "1";
+}
+
+void report(const char *name, std::size_t n, std::uint64_t wall_ns) {
+  std::uint64_t per = (n == 0) ? 0u : wall_ns / n;
+  std::printf("BENCH %s N=%zu wall_ns_total=%llu wall_ns_per_op=%llu\n", name, n,
+              static_cast<unsigned long long>(wall_ns), static_cast<unsigned long long>(per));
+}
+
+// Build a flat tree of `count` leaf paths under randomised 3-level
+// prefixes: root8/mid5/leaf_N. Returns the generated leaf paths.
+std::vector<std::string> build_flat_tree(cvc::state &root, std::size_t count,
+                                         std::uint32_t seed = 42) {
+  static const char *roots[] = {"vol", "geom", "mesh", "cam", "scene", "ui", "fx", "net"};
+  static const char *mids[] = {"a", "b", "c", "d", "e"};
+  std::mt19937 rng(seed);
+  std::vector<std::string> paths;
+  paths.reserve(count);
+  for (std::size_t i = 0; i < count; ++i) {
+    std::string p = roots[rng() % 8];
+    p += '.';
+    p += mids[rng() % 5];
+    p += ".leaf";
+    p += std::to_string(i);
+    paths.push_back(p);
+    root(p); // materialise the node
+  }
+  return paths;
+}
+
+// Install `link_count` transparent links in the tree, pointing at
+// randomly chosen target paths. Injects `cycle_count` 2-link cycles
+// at the end (A→B, B→A). Returns the link source paths.
+std::vector<std::string> install_links(cvc::state &root, const std::vector<std::string> &targets,
+                                       std::size_t link_count, std::size_t cycle_count,
+                                       std::uint32_t seed = 99) {
+  std::mt19937 rng(seed);
+  std::vector<std::string> link_paths;
+  link_paths.reserve(link_count);
+
+  std::size_t normal_links = link_count > cycle_count * 2 ? link_count - cycle_count * 2 : 0;
+
+  // Normal transparent links.
+  for (std::size_t i = 0; i < normal_links; ++i) {
+    std::string lp = "link." + std::to_string(i);
+    std::string tp = targets[rng() % targets.size()];
+    root(lp).linkTo(tp, cvc::state::link_mode::transparent);
+    link_paths.push_back(std::move(lp));
+  }
+
+  // Cycle pairs.
+  for (std::size_t c = 0; c < cycle_count; ++c) {
+    std::string a = "cycle." + std::to_string(c) + ".a";
+    std::string b = "cycle." + std::to_string(c) + ".b";
+    root(a).linkTo(b, cvc::state::link_mode::transparent);
+    root(b).linkTo(a, cvc::state::link_mode::transparent);
+    link_paths.push_back(a);
+    link_paths.push_back(b);
+  }
+
+  return link_paths;
+}
+
+} // namespace
+
+// =====================================================================
+// Opt-in benchmarks (CVC_DISTRIBUTED_STATE_BENCH=1)
+// =====================================================================
+
+// -- resolveLink over 10k links in a 1M-path tree --------------------
+TEST(StateLinkBenchmark, ResolveLinkLargeTree) {
+  if (!bench_enabled()) {
+    SUCCEED() << "set CVC_DISTRIBUTED_STATE_BENCH=1 to run";
+    return;
+  }
+
+  cvc::app a;
+  auto &root = cvc::state::instance(a);
+  constexpr std::size_t kPaths = 1'000'000;
+  constexpr std::size_t kLinks = 10'000;
+  constexpr std::size_t kCycles = 50;
+
+  auto paths = build_flat_tree(root, kPaths);
+  auto links = install_links(root, paths, kLinks, kCycles);
+
+  // Warm up the link resolver once.
+  for (auto &lp : links)
+    (void)root(lp).resolveLink();
+
+  auto t0 = std::chrono::steady_clock::now();
+  std::size_t resolved = 0, cycles = 0;
+  for (auto &lp : links) {
+    auto r = root(lp).resolveLink();
+    if (r.kind == cvc::state::link_resolution_kind::resolved)
+      ++resolved;
+    else if (r.kind == cvc::state::link_resolution_kind::cycle_detected)
+      ++cycles;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+
+  auto wall_ns = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+  report("resolve_link_10k_in_1M_tree", links.size(), wall_ns);
+
+  EXPECT_EQ(resolved + cycles, links.size());
+  EXPECT_EQ(cycles, kCycles * 2); // both halves of each cycle pair
+  // Sanity: per-op well under 500 µs even in a debug build.
+  EXPECT_LT(wall_ns / links.size(), 500'000u) << "resolveLink per-op > 500 µs; possible regression";
+}
+
+// -- resolvedValue over 10k links in a 1M-path tree ------------------
+TEST(StateLinkBenchmark, ResolvedValueLargeTree) {
+  if (!bench_enabled()) {
+    SUCCEED() << "set CVC_DISTRIBUTED_STATE_BENCH=1 to run";
+    return;
+  }
+
+  cvc::app a;
+  auto &root = cvc::state::instance(a);
+  constexpr std::size_t kPaths = 1'000'000;
+  constexpr std::size_t kLinks = 10'000;
+  constexpr std::size_t kCycles = 50;
+
+  auto paths = build_flat_tree(root, kPaths);
+  auto links = install_links(root, paths, kLinks, kCycles);
+
+  // Set a value on every target so resolved reads are meaningful.
+  for (std::size_t i = 0; i < kPaths; ++i)
+    root(paths[i]).value(std::string("v") + std::to_string(i));
+
+  auto t0 = std::chrono::steady_clock::now();
+  std::size_t non_empty = 0;
+  for (auto &lp : links) {
+    std::string v = root(lp).resolvedValue();
+    if (!v.empty())
+      ++non_empty;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+
+  auto wall_ns = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+  report("resolved_value_10k_in_1M_tree", links.size(), wall_ns);
+
+  // Every link should yield a value: normal links resolve to a
+  // populated target; cycle links fall back to their own value
+  // (which is empty, but that still counts as a string return).
+  EXPECT_EQ(non_empty + kCycles * 2, links.size());
+  EXPECT_LT(wall_ns / links.size(), 500'000u)
+      << "resolvedValue per-op > 500 µs; possible regression";
+}
+
+// -- resolveRemote over 10k links in a 1M-path tree ------------------
+TEST(StateLinkBenchmark, ResolveRemoteLargeTree) {
+  if (!bench_enabled()) {
+    SUCCEED() << "set CVC_DISTRIBUTED_STATE_BENCH=1 to run";
+    return;
+  }
+
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+  auto &root = cvc::state::instance(a);
+  constexpr std::size_t kPaths = 1'000'000;
+  constexpr std::size_t kLinks = 10'000;
+  constexpr std::size_t kCycles = 50;
+
+  auto paths = build_flat_tree(root, kPaths);
+  auto links = install_links(root, paths, kLinks, kCycles);
+
+  auto t0 = std::chrono::steady_clock::now();
+  std::size_t local = 0, cycles = 0;
+  for (auto &lp : links) {
+    auto r = root(lp).resolveRemote();
+    if (r.kind == cvc::state::remote_resolution_kind::resolved_local)
+      ++local;
+    else if (r.kind == cvc::state::remote_resolution_kind::cycle_detected)
+      ++cycles;
+  }
+  auto t1 = std::chrono::steady_clock::now();
+
+  auto wall_ns = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+  report("resolve_remote_10k_in_1M_tree", links.size(), wall_ns);
+
+  EXPECT_EQ(local + cycles, links.size());
+  EXPECT_EQ(cycles, kCycles * 2);
+  EXPECT_LT(wall_ns / links.size(), 500'000u)
+      << "resolveRemote per-op > 500 µs; possible regression";
+}
+
+// -- transparent_link_index over 5k links in a 100k-path tree --------
+// Uses a smaller tree than the resolve benchmarks because the index
+// walker visits every node in the tree, not just links.
+TEST(StateLinkBenchmark, TransparentLinkIndexLargeTree) {
+  if (!bench_enabled()) {
+    SUCCEED() << "set CVC_DISTRIBUTED_STATE_BENCH=1 to run";
+    return;
+  }
+
+  cvc::app a;
+  auto &root = cvc::state::instance(a);
+  constexpr std::size_t kPaths = 100'000;
+  constexpr std::size_t kLinks = 5'000;
+  constexpr std::size_t kCycles = 25;
+
+  auto paths = build_flat_tree(root, kPaths);
+  install_links(root, paths, kLinks, kCycles);
+
+  auto t0 = std::chrono::steady_clock::now();
+  auto idx = cvc::state_distributed_admin::transparent_link_index(root);
+  auto t1 = std::chrono::steady_clock::now();
+
+  auto wall_ns = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+  report("transparent_link_index_100k_tree_5k_links", 1u, wall_ns);
+
+  EXPECT_EQ(idx.links.size(), kLinks);
+  // Full-tree scan of 100k nodes: < 30 s even in a debug build.
+  EXPECT_LT(wall_ns, 30'000'000'000ULL) << "transparent_link_index > 30 s";
+}
+
+// -- transparent_link_aliases sampling 10 paths in a 100k tree -------
+TEST(StateLinkBenchmark, TransparentLinkAliasesLargeTree) {
+  if (!bench_enabled()) {
+    SUCCEED() << "set CVC_DISTRIBUTED_STATE_BENCH=1 to run";
+    return;
+  }
+
+  cvc::app a;
+  auto &root = cvc::state::instance(a);
+  constexpr std::size_t kPaths = 100'000;
+  constexpr std::size_t kLinks = 5'000;
+  constexpr std::size_t kCycles = 25;
+  constexpr std::size_t kSamples = 10;
+
+  auto paths = build_flat_tree(root, kPaths);
+  install_links(root, paths, kLinks, kCycles);
+
+  std::mt19937 rng(77);
+  std::vector<std::string> samples;
+  samples.reserve(kSamples);
+  for (std::size_t i = 0; i < kSamples; ++i)
+    samples.push_back(paths[rng() % paths.size()]);
+
+  auto t0 = std::chrono::steady_clock::now();
+  std::size_t total_aliases = 0;
+  for (auto &p : samples) {
+    auto aliases = cvc::state_distributed_admin::transparent_link_aliases(root, p);
+    total_aliases += aliases.size();
+  }
+  auto t1 = std::chrono::steady_clock::now();
+
+  auto wall_ns = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+  report("transparent_link_aliases_10_samples_in_100k_tree", kSamples, wall_ns);
+
+  // Each call walks the whole link index; 10 samples × full
+  // tree scan. Allow up to 120 s in a debug build.
+  EXPECT_LT(wall_ns, 120'000'000'000ULL) << "alias expansion > 120 s";
+  EXPECT_GE(total_aliases, 0u);
+}
+
+// -- subscriptions_for_path with adapter over 10 paths in 100k tree --
+TEST(StateLinkBenchmark, SubscriptionsForPathLargeTree) {
+  if (!bench_enabled()) {
+    SUCCEED() << "set CVC_DISTRIBUTED_STATE_BENCH=1 to run";
+    return;
+  }
+
+  cvc::app a;
+  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  shard.attach();
+  auto &root = cvc::state::instance(a);
+  constexpr std::size_t kPaths = 100'000;
+  constexpr std::size_t kLinks = 5'000;
+  constexpr std::size_t kCycles = 25;
+  constexpr std::size_t kSamples = 10;
+
+  auto paths = build_flat_tree(root, kPaths);
+  install_links(root, paths, kLinks, kCycles);
+
+  // Install some subscriptions on a few root prefixes.
+  auto &router = shard.router();
+  router.subscribe("vol");
+  router.subscribe("geom");
+  router.subscribe("mesh");
+  router.subscribe("link");
+
+  std::mt19937 rng(55);
+  std::vector<std::string> samples;
+  samples.reserve(kSamples);
+  for (std::size_t i = 0; i < kSamples; ++i)
+    samples.push_back(paths[rng() % paths.size()]);
+
+  auto t0 = std::chrono::steady_clock::now();
+  std::size_t total_subs = 0;
+  for (auto &p : samples) {
+    auto subs = shard.adapter().subscriptions_for_path(p);
+    total_subs += subs.size();
+  }
+  auto t1 = std::chrono::steady_clock::now();
+
+  auto wall_ns = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+  report("subscriptions_for_path_10_samples_in_100k_tree", kSamples, wall_ns);
+
+  EXPECT_GT(total_subs, 0u);
+  // 10 samples × full tree scan: < 120 s in a debug build.
+  EXPECT_LT(wall_ns, 120'000'000'000ULL) << "subscriptions_for_path > 120 s";
+}
+
+// -- link_cycles over 5k links in a 100k-path tree --------------------
+TEST(StateLinkBenchmark, LinkCyclesLargeTree) {
+  if (!bench_enabled()) {
+    SUCCEED() << "set CVC_DISTRIBUTED_STATE_BENCH=1 to run";
+    return;
+  }
+
+  cvc::app a;
+  auto &root = cvc::state::instance(a);
+  constexpr std::size_t kPaths = 100'000;
+  constexpr std::size_t kLinks = 5'000;
+  constexpr std::size_t kCycles = 25;
+
+  auto paths = build_flat_tree(root, kPaths);
+  install_links(root, paths, kLinks, kCycles);
+
+  auto t0 = std::chrono::steady_clock::now();
+  auto result = cvc::state_distributed_admin::link_cycles(root);
+  auto t1 = std::chrono::steady_clock::now();
+
+  auto wall_ns = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+  report("link_cycles_100k_tree_5k_links", 1u, wall_ns);
+
+  EXPECT_EQ(result.cycles.size(), kCycles);
+  EXPECT_GE(result.link_nodes_scanned, kLinks);
+  // Full-tree scan: < 30 s even in a debug build.
+  EXPECT_LT(wall_ns, 30'000'000'000ULL) << "link_cycles > 30 s";
+}
+
+// =====================================================================
+// Always-on correctness companions (run in normal CI)
+// =====================================================================
+
+// Small-scale correctness: verify the benchmark helpers produce the
+// expected tree shape and link topology.
+TEST(StateLinkBenchCorrectness, BuildAndInstallLinks) {
+  cvc::app a;
+  auto &root = cvc::state::instance(a);
+  constexpr std::size_t kPaths = 100;
+  constexpr std::size_t kLinks = 20;
+  constexpr std::size_t kCycles = 3;
+
+  auto paths = build_flat_tree(root, kPaths);
+  EXPECT_EQ(paths.size(), kPaths);
+  // All paths should be reachable.
+  for (auto &p : paths)
+    EXPECT_NE(root.findDescendant(p), nullptr) << "missing: " << p;
+
+  auto links = install_links(root, paths, kLinks, kCycles);
+  EXPECT_EQ(links.size(), kLinks);
+
+  // Every link node should exist and be a link.
+  for (auto &lp : links) {
+    auto *n = root.findDescendant(lp);
+    ASSERT_NE(n, nullptr) << "missing link node: " << lp;
+    EXPECT_TRUE(n->isLink()) << lp;
+    EXPECT_EQ(n->linkMode(), cvc::state::link_mode::transparent) << lp;
+  }
+
+  // Cycle pairs should form detectable cycles.
+  std::size_t cycle_count = 0;
+  for (auto &lp : links) {
+    auto r = root(lp).resolveLink();
+    if (r.kind == cvc::state::link_resolution_kind::cycle_detected)
+      ++cycle_count;
+  }
+  EXPECT_EQ(cycle_count, kCycles * 2);
+}
+
+TEST(StateLinkBenchCorrectness, ResolvedValueOnSmallTree) {
+  cvc::app a;
+  auto &root = cvc::state::instance(a);
+  constexpr std::size_t kPaths = 50;
+  constexpr std::size_t kLinks = 10;
+  constexpr std::size_t kCycles = 2;
+
+  auto paths = build_flat_tree(root, kPaths);
+  auto links = install_links(root, paths, kLinks, kCycles);
+
+  for (auto &p : paths)
+    root(p).value(std::string("val_") + p);
+
+  // Non-cycle links should resolve to the target's value.
+  std::size_t correct = 0;
+  for (auto &lp : links) {
+    auto r = root(lp).resolveLink();
+    if (r.kind == cvc::state::link_resolution_kind::resolved && r.target != nullptr) {
+      std::string rv = root(lp).resolvedValue();
+      EXPECT_EQ(rv, r.target->value()) << lp;
+      ++correct;
+    }
+  }
+  EXPECT_GT(correct, 0u);
+}
+
+TEST(StateLinkBenchCorrectness, LinkCyclesOnSmallTree) {
+  cvc::app a;
+  auto &root = cvc::state::instance(a);
+  constexpr std::size_t kPaths = 50;
+  constexpr std::size_t kLinks = 10;
+  constexpr std::size_t kCycles = 2;
+
+  build_flat_tree(root, kPaths);
+  // Can't pass paths to install_links targets without them, but
+  // build_flat_tree already materialised the nodes.
+  auto paths = build_flat_tree(root, kPaths, 123); // different seed for variety
+  install_links(root, paths, kLinks, kCycles);
+
+  auto result = cvc::state_distributed_admin::link_cycles(root);
+  EXPECT_EQ(result.cycles.size(), kCycles);
+  for (auto &cycle : result.cycles) {
+    EXPECT_GE(cycle.size(), 2u);
+  }
+}


### PR DESCRIPTION
## Summary

Add `state_link_bench_test` — the final deliverable for Phase 8 (link nodes). This closes out Phase 8 completely.

### Benchmarks (7 tests, opt-in via `CVC_DISTRIBUTED_STATE_BENCH=1`)

| Benchmark | Tree size | Ops | Debug perf |
|-----------|-----------|-----|------------|
| resolveLink | 1M paths, 10k links | 10k | ~170 µs/op |
| resolvedValue | 1M paths, 10k links | 10k | ~160 µs/op |
| resolveRemote | 1M paths, 10k links | 10k | ~189 µs/op |
| transparent_link_index | 100k paths, 5k links | 1 full scan | ~6.7 s |
| transparent_link_aliases | 100k paths, 5k links | 10 samples | ~6.5 s/op |
| subscriptions_for_path | 100k paths, 5k links | 10 samples | ~6.4 s/op |
| link_cycles | 100k paths, 5k links | 1 full scan | ~6.3 s |

### Correctness (3 tests, always run)
- BuildAndInstallLinks, ResolvedValueOnSmallTree, LinkCyclesOnSmallTree

### CI gating
- **PR runs**: `StateLinkBenchmark` suite is excluded by the existing `-E Benchmark` stress regex. Correctness tests (`StateLinkBenchCorrectness`) still run on every PR.
- **Push-to-master**: `CVC_DISTRIBUTED_STATE_BENCH=1` is now set in the ctest steps for Linux, macOS, and Windows, so the full benchmark suite executes on merge commits.

### Roadmap
Phase 8 (link nodes) is now marked complete in DISTRIBUTED_STATE_ROADMAP.md.