### PR TITLE
feat: Volume/geometry streaming with brick manifests and lazy hydration

### DIFF
--- a/inc/cvc/state_brick_manifest.h
+++ b/inc/cvc/state_brick_manifest.h
@@ -1,0 +1,190 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+
+  This file is part of libcvc.
+
+  libcvc is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+*/
+
+#ifndef __CVC_STATE_BRICK_MANIFEST_H__
+#define __CVC_STATE_BRICK_MANIFEST_H__
+
+#include <cstdint>
+#include <cvc/namespace.h>
+#include <cvc/state_blob_store.h>
+#include <cvc/state_chunked_blob.h>
+#include <cvc/state_compression_registry.h>
+#include <string>
+#include <vector>
+
+namespace CVC_NAMESPACE {
+
+// ----------------
+// cvc::brick_extent
+// ----------------
+// Spatial metadata for a single chunk within a brick-aware manifest.
+// Describes where in the logical volume (or geometry vertex range)
+// this chunk's data lives.
+//
+struct brick_extent {
+  // Volume bricks: origin voxel in the source volume.
+  std::uint64_t origin_x = 0;
+  std::uint64_t origin_y = 0;
+  std::uint64_t origin_z = 0;
+
+  // Volume bricks: size in voxels along each axis.
+  std::uint64_t size_x = 0;
+  std::uint64_t size_y = 0;
+  std::uint64_t size_z = 0;
+
+  // Variable index (for multi-variable datasets).
+  std::uint32_t variable_index = 0;
+
+  // Geometry chunks: vertex/element range [begin, end).
+  std::uint64_t element_begin = 0;
+  std::uint64_t element_end = 0;
+};
+
+// ----------------
+// cvc::state_brick_manifest
+// ----------------
+// Extension of state_chunk_manifest that adds per-chunk spatial
+// metadata. This enables receivers to fetch only the bricks they
+// need (e.g. visible volume subregions, nearby geometry) rather
+// than downloading the entire payload.
+//
+// Wire format (little-endian):
+//   magic[4]    = 'C','V','B','1'
+//   version     = uint32 (currently 1)
+//   chunk_size  = uint32 (nominal chunk size in bytes)
+//   total_size  = uint64 (sum of uncompressed chunk sizes)
+//   codec_len   = uint32; codec[codec_len]
+//   content_len = uint32; content_digest[content_len]
+//
+//   Volume header (present when has_volume_header == true):
+//     has_volume_header = uint8 (1)
+//     vol_xdim, vol_ydim, vol_zdim = uint64[3]
+//     voxel_type   = uint32
+//     brick_xdim, brick_ydim, brick_zdim = uint64[3]
+//   else:
+//     has_volume_header = uint8 (0)
+//
+//   count = uint32
+//   for each chunk:
+//     digest_len   = uint32; digest[digest_len]
+//     stored_bytes = uint32
+//     origin_x,y,z = uint64[3]
+//     size_x,y,z   = uint64[3]
+//     variable_index = uint32
+//     element_begin  = uint64
+//     element_end    = uint64
+//
+struct state_brick_manifest {
+  std::uint32_t version = 1;
+  std::uint32_t chunk_size = 0;
+  std::uint64_t total_size = 0;
+  std::string codec;
+  std::string content_digest;
+
+  // Per-chunk data.
+  std::vector<std::string> chunks;
+  std::vector<std::uint32_t> chunk_bytes;
+  std::vector<brick_extent> extents;
+
+  // Optional volume grid header.
+  bool has_volume_header = false;
+  std::uint64_t vol_xdim = 0, vol_ydim = 0, vol_zdim = 0;
+  std::uint32_t voxel_type = 0;
+  std::uint64_t brick_xdim = 0, brick_ydim = 0, brick_zdim = 0;
+
+  std::vector<unsigned char> serialize() const;
+  static bool parse(const std::vector<unsigned char> &bytes, state_brick_manifest &out);
+
+  // Query: return indices of chunks whose spatial extent overlaps
+  // the given axis-aligned box [lo, hi) in voxel coordinates.
+  std::vector<std::size_t> bricks_in_region(std::uint64_t lo_x, std::uint64_t lo_y,
+                                            std::uint64_t lo_z, std::uint64_t hi_x,
+                                            std::uint64_t hi_y, std::uint64_t hi_z) const;
+};
+
+// ----------------
+// cvc::state_brick_writer
+// ----------------
+// Splits a volume payload into spatially-addressed bricks and
+// writes each brick as a content-addressed chunk in the blob store.
+//
+class state_brick_writer {
+public:
+  explicit state_brick_writer(state_blob_store &store, std::uint32_t brick_dim = 32,
+                              const state_compression_registry *compression = nullptr);
+
+  // Split the raw voxel `bytes` of a volume with the given grid
+  // dimensions and voxel size into bricks and write them. Returns
+  // the manifest blob_ref.
+  state_blob_ref put_volume(const unsigned char *voxel_data, std::uint64_t xdim, std::uint64_t ydim,
+                            std::uint64_t zdim, std::uint32_t voxel_size, std::uint32_t voxel_type,
+                            const std::string &codec = std::string());
+
+  // Write a geometry payload as element-range-addressed chunks.
+  // `bytes` is the raw serialized geometry bytes, partitioned
+  // into `bytes.size() / chunk_byte_size` chunks. Returns the
+  // manifest blob_ref.
+  state_blob_ref put_geometry(const std::vector<unsigned char> &bytes, std::uint64_t num_elements,
+                              const std::string &codec = std::string());
+
+  state_blob_store &store() { return _store; }
+  std::uint32_t brick_dim() const { return _brick_dim; }
+
+private:
+  state_blob_store &_store;
+  std::uint32_t _brick_dim;
+  const state_compression_registry *_compression;
+};
+
+// ----------------
+// cvc::state_brick_reader
+// ----------------
+// Reads a brick manifest and can reassemble the full payload or
+// fetch individual bricks by spatial query.
+//
+class state_brick_reader {
+public:
+  explicit state_brick_reader(state_blob_store &store,
+                              const state_compression_registry *compression = nullptr);
+
+  // Load+parse a brick manifest by digest.
+  bool load_manifest(const std::string &digest, state_brick_manifest &out) const;
+
+  // Which chunks are missing from the local store.
+  std::vector<std::string> missing_chunks(const state_brick_manifest &m) const;
+
+  // Reassemble the full payload. Returns false if any chunk is
+  // missing.
+  bool get(const state_brick_manifest &m, std::vector<unsigned char> &out) const;
+
+  // Fetch a single brick chunk by index. Returns false if the
+  // chunk is not in the local store.
+  bool get_brick(const state_brick_manifest &m, std::size_t brick_index,
+                 std::vector<unsigned char> &out) const;
+
+  // Fetch bricks that overlap a spatial region and write them into
+  // a pre-allocated voxel buffer. Returns the number of bricks
+  // fetched. Missing bricks are skipped (partial result).
+  std::size_t get_region(const state_brick_manifest &m, unsigned char *dest_buffer,
+                         std::uint64_t dest_xdim, std::uint64_t dest_ydim, std::uint64_t dest_zdim,
+                         std::uint32_t voxel_size, std::uint64_t lo_x, std::uint64_t lo_y,
+                         std::uint64_t lo_z, std::uint64_t hi_x, std::uint64_t hi_y,
+                         std::uint64_t hi_z) const;
+
+  state_blob_store &store() { return _store; }
+
+private:
+  state_blob_store &_store;
+  const state_compression_registry *_compression;
+};
+
+} // namespace CVC_NAMESPACE
+
+#endif // __CVC_STATE_BRICK_MANIFEST_H__

--- a/inc/cvc/state_data_hydrator.h
+++ b/inc/cvc/state_data_hydrator.h
@@ -1,0 +1,144 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+
+  This file is part of libcvc.
+
+  libcvc is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+*/
+
+#ifndef __CVC_STATE_DATA_HYDRATOR_H__
+#define __CVC_STATE_DATA_HYDRATOR_H__
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cvc/namespace.h>
+#include <cvc/state_blob_store.h>
+#include <cvc/state_chunked_blob.h>
+#include <cvc/state_codec_registry.h>
+#include <cvc/state_compression_registry.h>
+#include <cvc/state_transport.h>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace CVC_NAMESPACE {
+
+class state;
+
+// ----------------
+// cvc::state_data_hydrator
+// ----------------
+// Purpose:
+//   Provides lazy hydration of blob-referenced data objects in the
+//   distributed state tree. When a remote mutation arrives with a
+//   blob_ref payload, the hydrator:
+//     1. Checks if all chunks are present locally.
+//     2. If not, requests missing chunks from the transport.
+//     3. Reassembles the blob and decodes via the codec registry.
+//     4. Installs the decoded data on the state node.
+//     5. Notifies waiters.
+//
+//   Consumers can call wait_for_data<T>(path, timeout) to block
+//   until the data is hydrated, or poll with is_hydrated(path).
+//
+// Threading:
+//   All public methods are thread-safe.
+//
+class state_data_hydrator {
+public:
+  enum class hydration_status {
+    unknown, // no pending hydration for this path
+    pending, // chunks still missing, fetch in progress
+    ready,   // all chunks present, data decoded and installed
+    failed   // fetch or decode failed
+  };
+
+  // Callback signature for hydration completion.
+  using on_hydrated_func = std::function<void(const std::string &path, hydration_status status)>;
+
+  state_data_hydrator(state_blob_store &store, state_codec_registry &codecs,
+                      const state_compression_registry *compression = nullptr);
+
+  // Set the transport used to fetch missing chunks from remote
+  // peers. Without a transport, the hydrator can only work with
+  // chunks already in the local store.
+  void set_transport(state_transport *t) noexcept { _transport = t; }
+
+  // Request hydration of a blob-referenced payload at `path`.
+  // This is called automatically when a shard ingests a remote
+  // SET_DATA mutation with a blob payload. It can also be called
+  // manually.
+  //
+  // `manifest_digest` is the blob_ref.digest from the mutation.
+  // `type_name` is the mutation's type_name for codec lookup.
+  // `target` is the state node where the decoded data will be
+  // installed (via target->data(decoded_value)).
+  //
+  // Returns the current hydration status after the call.
+  hydration_status request(const std::string &path, const std::string &manifest_digest,
+                           const std::string &type_name, state *target = nullptr);
+
+  // Query the hydration status of a path.
+  hydration_status status(const std::string &path) const;
+
+  // Returns true if the blob at `path` has been fully hydrated.
+  bool is_hydrated(const std::string &path) const;
+
+  // Block until the blob at `path` is hydrated or the timeout
+  // expires. Returns the final status. A zero timeout waits
+  // indefinitely.
+  hydration_status wait(const std::string &path,
+                        std::chrono::milliseconds timeout = std::chrono::milliseconds(0)) const;
+
+  // Register a callback that fires when any path completes
+  // hydration (status == ready or failed).
+  void on_hydrated(on_hydrated_func callback);
+
+  // Remove a pending entry for `path`. Returns true if it existed.
+  bool cancel(const std::string &path);
+
+  // Retry all pending hydrations (e.g. after a transport
+  // reconnection). Returns the number of entries retried.
+  std::size_t retry_pending();
+
+  // Diagnostics.
+  std::size_t pending_count() const;
+  std::uint64_t total_hydrated() const noexcept { return _total_hydrated.load(); }
+  std::uint64_t total_failed() const noexcept { return _total_failed.load(); }
+  std::uint64_t total_chunks_fetched() const noexcept { return _total_chunks_fetched.load(); }
+
+private:
+  struct entry {
+    std::string manifest_digest;
+    std::string type_name;
+    state *target = nullptr;
+    hydration_status status = hydration_status::pending;
+  };
+
+  void try_hydrate(const std::string &path, entry &e);
+  void notify(const std::string &path, hydration_status status);
+
+  state_blob_store &_store;
+  state_codec_registry &_codecs;
+  const state_compression_registry *_compression;
+  state_transport *_transport = nullptr;
+
+  mutable std::mutex _mutex;
+  mutable std::condition_variable _cv;
+  std::unordered_map<std::string, entry> _entries;
+  std::vector<on_hydrated_func> _callbacks;
+
+  std::atomic<std::uint64_t> _total_hydrated{0};
+  std::atomic<std::uint64_t> _total_failed{0};
+  std::atomic<std::uint64_t> _total_chunks_fetched{0};
+};
+
+} // namespace CVC_NAMESPACE
+
+#endif // __CVC_STATE_DATA_HYDRATOR_H__

--- a/inc/cvc/state_transport.h
+++ b/inc/cvc/state_transport.h
@@ -17,6 +17,8 @@
 #include <cvc/state_change_journal.h>
 #include <cvc/state_message.h>
 #include <cvc/state_peer_registry.h>
+#include <functional>
+#include <string>
 #include <vector>
 
 namespace CVC_NAMESPACE {
@@ -106,6 +108,40 @@ public:
   // (back-compat default).
   state_peer_registry &peers() noexcept { return _peers; }
   const state_peer_registry &peers() const noexcept { return _peers; }
+
+  // -------- Chunk fetch (volume/geometry streaming) --------
+  //
+  // Callback-based chunk retrieval from remote peers. The
+  // transport asks registered remote peers for the chunk; the
+  // first peer that has it delivers the bytes to `on_chunk`.
+  //
+  // The default implementation is a no-op (returns false) so
+  // existing transports continue to compile until they implement
+  // the path. Concrete transports that support multi-host blob
+  // transfer override this.
+  //
+  // `on_chunk(digest, bytes)` is called at most once; if no peer
+  // has the chunk the call returns false.
+  using chunk_callback =
+      std::function<void(const std::string &digest, const std::vector<unsigned char> &bytes)>;
+
+  virtual bool fetch_chunk(const std::string &digest, chunk_callback on_chunk) {
+    (void)digest;
+    (void)on_chunk;
+    return false;
+  }
+
+  // Batch variant: fetch all chunks whose digests are in
+  // `digests`. `on_chunk` is called once per successfully
+  // fetched chunk. Returns the number of chunks fetched.
+  virtual std::size_t fetch_chunks(const std::vector<std::string> &digests,
+                                   chunk_callback on_chunk) {
+    std::size_t n = 0;
+    for (const auto &d : digests)
+      if (fetch_chunk(d, on_chunk))
+        ++n;
+    return n;
+  }
 
 protected:
   state_peer_registry _peers;

--- a/inc/cvc/state_transport_inproc.h
+++ b/inc/cvc/state_transport_inproc.h
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <cvc/namespace.h>
+#include <cvc/state_blob_store.h>
 #include <cvc/state_bounded_queue.h>
 #include <cvc/state_transport.h>
 #include <memory>
@@ -63,6 +64,13 @@ public:
   std::size_t pump_shard(state_cluster_shard &shard) override;
   std::size_t pump_all() override;
   void flush() override;
+
+  // Chunk fetch: look for the digest in each registered shard's
+  // associated blob store (if the shard exposes one). For inproc,
+  // this is a synchronous local lookup.
+  bool fetch_chunk(const std::string &digest, chunk_callback on_chunk) override;
+  std::size_t fetch_chunks(const std::vector<std::string> &digests,
+                           chunk_callback on_chunk) override;
 
   // Install a bounded message outbox for `peer`. `capacity` is the
   // maximum number of pending messages; `policy` selects the
@@ -141,6 +149,12 @@ public:
   std::uint64_t total_messages_published() const noexcept { return _msg_published.load(); }
   std::uint64_t total_messages_delivered() const noexcept { return _msg_delivered.load(); }
 
+  // Set a blob store that fetch_chunk() searches when looking for
+  // chunks requested by peers. Without this, fetch_chunk returns
+  // false (no blobs available).
+  void set_blob_store(state_blob_store *store) noexcept { _blob_store = store; }
+  state_blob_store *blob_store() const noexcept { return _blob_store; }
+
 private:
   struct peer_outbox {
     std::unique_ptr<state_bounded_queue<state_message>> queue;
@@ -167,6 +181,7 @@ private:
   std::atomic<std::uint64_t> _quarantined_mutations{0};
   std::atomic<std::uint64_t> _auto_isolations{0};
   std::atomic<std::uint64_t> _auto_isolation_threshold{0};
+  state_blob_store *_blob_store = nullptr;
 };
 
 } // namespace CVC_NAMESPACE

--- a/inc/cvc/state_volume_codec.h
+++ b/inc/cvc/state_volume_codec.h
@@ -1,0 +1,68 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+
+  This file is part of libcvc.
+
+  libcvc is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+*/
+
+#ifndef __CVC_STATE_VOLUME_CODEC_H__
+#define __CVC_STATE_VOLUME_CODEC_H__
+
+#include <cvc/namespace.h>
+#include <cvc/state_codec_registry.h>
+#include <string>
+
+namespace CVC_NAMESPACE {
+
+// ----------------
+// Volume / Geometry codec registration
+// ----------------
+// Registers encode/decode pairs for cvc::volume and cvc::geometry
+// into a state_codec_registry so the distributed-state layer can
+// serialize them into blob payloads.
+//
+// Wire format — cvc::volume (codec id "cvc.volume.v1"):
+//   Header (little-endian):
+//     magic[4]   = 'C','V','V','1'
+//     xdim       = uint64
+//     ydim       = uint64
+//     zdim       = uint64
+//     voxel_type = uint32 (data_type enum)
+//     minx,miny,minz,maxx,maxy,maxz = double[6]
+//     desc_len   = uint32
+//     desc_bytes[desc_len]
+//   Body:
+//     raw voxel bytes (XDim*YDim*ZDim*voxelSize)
+//
+// Wire format — cvc::geometry (codec id "cvc.geometry.v1"):
+//   Header (little-endian):
+//     magic[4]     = 'C','V','G','1'
+//     geom_type    = uint32 (geometry_type enum)
+//     num_points   = uint64
+//     num_normals  = uint64
+//     num_colors   = uint64
+//     num_tris     = uint64
+//     num_quads    = uint64
+//     num_tets     = uint64
+//     num_hexs     = uint64
+//     num_lines    = uint64
+//   Body:
+//     points[num_points]    — 3 x double each
+//     normals[num_normals]  — 3 x double each
+//     colors[num_colors]    — 3 x double each
+//     tris[num_tris]        — 3 x uint64 each
+//     quads[num_quads]      — 4 x uint64 each
+//     tets[num_tets]        — 4 x uint64 each
+//     hexs[num_hexs]        — 8 x uint64 each
+//     lines[num_lines]      — 2 x uint64 each
+//
+
+// Register volume and geometry codecs on `registry`. Idempotent.
+void register_volume_geometry_codecs(state_codec_registry &registry);
+
+} // namespace CVC_NAMESPACE
+
+#endif // __CVC_STATE_VOLUME_CODEC_H__

--- a/src/cvc/CMakeLists.txt
+++ b/src/cvc/CMakeLists.txt
@@ -41,6 +41,9 @@ set(INCLUDE_FILES
   ../../inc/cvc/state_distributed_metrics.h
   ../../inc/cvc/state_delegation_manager.h
   ../../inc/cvc/state_distributed_admin.h
+  ../../inc/cvc/state_volume_codec.h
+  ../../inc/cvc/state_brick_manifest.h
+  ../../inc/cvc/state_data_hydrator.h
   ../../inc/cvc/state_transport.h
   ../../inc/cvc/state_transport_inproc.h
   ../../inc/cvc/state_transport_ipc.h
@@ -93,6 +96,9 @@ set(SOURCE_FILES
   state_distributed_metrics.cpp
   state_delegation_manager.cpp
   state_distributed_admin.cpp
+  state_volume_codec.cpp
+  state_brick_manifest.cpp
+  state_data_hydrator.cpp
   state_message.cpp
   utility.cpp
   cuda_utils.cpp

--- a/src/cvc/state_brick_manifest.cpp
+++ b/src/cvc/state_brick_manifest.cpp
@@ -1,0 +1,508 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+
+  This file is part of libcvc.
+
+  libcvc is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+*/
+
+#include <algorithm>
+#include <cstring>
+#include <cvc/state_brick_manifest.h>
+#include <cvc/types.h>
+#include <stdexcept>
+
+namespace CVC_NAMESPACE {
+
+namespace {
+
+constexpr unsigned char BRICK_MAGIC[4] = {'C', 'V', 'B', '1'};
+
+void wr_u8(std::vector<unsigned char> &o, std::uint8_t v) { o.push_back(v); }
+void wr_u32(std::vector<unsigned char> &o, std::uint32_t v) {
+  for (int i = 0; i < 4; ++i)
+    o.push_back(static_cast<unsigned char>((v >> (8 * i)) & 0xff));
+}
+void wr_u64(std::vector<unsigned char> &o, std::uint64_t v) {
+  for (int i = 0; i < 8; ++i)
+    o.push_back(static_cast<unsigned char>((v >> (8 * i)) & 0xff));
+}
+void wr_str(std::vector<unsigned char> &o, const std::string &s) {
+  wr_u32(o, static_cast<std::uint32_t>(s.size()));
+  o.insert(o.end(), s.begin(), s.end());
+}
+
+bool rd_u8(const unsigned char *&p, const unsigned char *e, std::uint8_t &v) {
+  if (p >= e)
+    return false;
+  v = *p++;
+  return true;
+}
+bool rd_u32(const unsigned char *&p, const unsigned char *e, std::uint32_t &v) {
+  if (p + 4 > e)
+    return false;
+  v = 0;
+  for (int i = 0; i < 4; ++i)
+    v |= static_cast<std::uint32_t>(p[i]) << (8 * i);
+  p += 4;
+  return true;
+}
+bool rd_u64(const unsigned char *&p, const unsigned char *e, std::uint64_t &v) {
+  if (p + 8 > e)
+    return false;
+  v = 0;
+  for (int i = 0; i < 8; ++i)
+    v |= static_cast<std::uint64_t>(p[i]) << (8 * i);
+  p += 8;
+  return true;
+}
+bool rd_str(const unsigned char *&p, const unsigned char *e, std::string &v) {
+  std::uint32_t n;
+  if (!rd_u32(p, e, n))
+    return false;
+  if (p + n > e)
+    return false;
+  v.assign(reinterpret_cast<const char *>(p), n);
+  p += n;
+  return true;
+}
+
+} // namespace
+
+// ---------- state_brick_manifest ----------
+
+std::vector<unsigned char> state_brick_manifest::serialize() const {
+  std::vector<unsigned char> out;
+  out.reserve(128 + chunks.size() * 128);
+
+  out.insert(out.end(), BRICK_MAGIC, BRICK_MAGIC + 4);
+  wr_u32(out, version);
+  wr_u32(out, chunk_size);
+  wr_u64(out, total_size);
+  wr_str(out, codec);
+  wr_str(out, content_digest);
+
+  wr_u8(out, has_volume_header ? 1 : 0);
+  if (has_volume_header) {
+    wr_u64(out, vol_xdim);
+    wr_u64(out, vol_ydim);
+    wr_u64(out, vol_zdim);
+    wr_u32(out, voxel_type);
+    wr_u64(out, brick_xdim);
+    wr_u64(out, brick_ydim);
+    wr_u64(out, brick_zdim);
+  }
+
+  wr_u32(out, static_cast<std::uint32_t>(chunks.size()));
+  for (std::size_t i = 0; i < chunks.size(); ++i) {
+    wr_str(out, chunks[i]);
+    wr_u32(out, i < chunk_bytes.size() ? chunk_bytes[i] : 0u);
+
+    const brick_extent &ext = i < extents.size() ? extents[i] : brick_extent{};
+    wr_u64(out, ext.origin_x);
+    wr_u64(out, ext.origin_y);
+    wr_u64(out, ext.origin_z);
+    wr_u64(out, ext.size_x);
+    wr_u64(out, ext.size_y);
+    wr_u64(out, ext.size_z);
+    wr_u32(out, ext.variable_index);
+    wr_u64(out, ext.element_begin);
+    wr_u64(out, ext.element_end);
+  }
+  return out;
+}
+
+bool state_brick_manifest::parse(const std::vector<unsigned char> &bytes,
+                                 state_brick_manifest &out) {
+  if (bytes.size() < 4)
+    return false;
+  const unsigned char *p = bytes.data();
+  const unsigned char *e = p + bytes.size();
+
+  if (std::memcmp(p, BRICK_MAGIC, 4) != 0)
+    return false;
+  p += 4;
+
+  if (!rd_u32(p, e, out.version) || out.version != 1)
+    return false;
+  if (!rd_u32(p, e, out.chunk_size))
+    return false;
+  if (!rd_u64(p, e, out.total_size))
+    return false;
+  if (!rd_str(p, e, out.codec))
+    return false;
+  if (!rd_str(p, e, out.content_digest))
+    return false;
+
+  std::uint8_t has_vh;
+  if (!rd_u8(p, e, has_vh))
+    return false;
+  out.has_volume_header = (has_vh != 0);
+  if (out.has_volume_header) {
+    if (!rd_u64(p, e, out.vol_xdim) || !rd_u64(p, e, out.vol_ydim) || !rd_u64(p, e, out.vol_zdim))
+      return false;
+    if (!rd_u32(p, e, out.voxel_type))
+      return false;
+    if (!rd_u64(p, e, out.brick_xdim) || !rd_u64(p, e, out.brick_ydim) ||
+        !rd_u64(p, e, out.brick_zdim))
+      return false;
+  }
+
+  std::uint32_t count;
+  if (!rd_u32(p, e, count))
+    return false;
+
+  out.chunks.clear();
+  out.chunks.reserve(count);
+  out.chunk_bytes.clear();
+  out.chunk_bytes.reserve(count);
+  out.extents.clear();
+  out.extents.reserve(count);
+
+  for (std::uint32_t i = 0; i < count; ++i) {
+    std::string digest;
+    std::uint32_t sb;
+    if (!rd_str(p, e, digest))
+      return false;
+    if (!rd_u32(p, e, sb))
+      return false;
+
+    brick_extent ext;
+    if (!rd_u64(p, e, ext.origin_x) || !rd_u64(p, e, ext.origin_y) || !rd_u64(p, e, ext.origin_z))
+      return false;
+    if (!rd_u64(p, e, ext.size_x) || !rd_u64(p, e, ext.size_y) || !rd_u64(p, e, ext.size_z))
+      return false;
+    if (!rd_u32(p, e, ext.variable_index))
+      return false;
+    if (!rd_u64(p, e, ext.element_begin) || !rd_u64(p, e, ext.element_end))
+      return false;
+
+    out.chunks.push_back(std::move(digest));
+    out.chunk_bytes.push_back(sb);
+    out.extents.push_back(ext);
+  }
+  return true;
+}
+
+std::vector<std::size_t>
+state_brick_manifest::bricks_in_region(std::uint64_t lo_x, std::uint64_t lo_y, std::uint64_t lo_z,
+                                       std::uint64_t hi_x, std::uint64_t hi_y,
+                                       std::uint64_t hi_z) const {
+  std::vector<std::size_t> result;
+  for (std::size_t i = 0; i < extents.size(); ++i) {
+    const brick_extent &ext = extents[i];
+    // AABB overlap test.
+    if (ext.origin_x + ext.size_x <= lo_x || ext.origin_x >= hi_x)
+      continue;
+    if (ext.origin_y + ext.size_y <= lo_y || ext.origin_y >= hi_y)
+      continue;
+    if (ext.origin_z + ext.size_z <= lo_z || ext.origin_z >= hi_z)
+      continue;
+    result.push_back(i);
+  }
+  return result;
+}
+
+// ---------- state_brick_writer ----------
+
+state_brick_writer::state_brick_writer(state_blob_store &store, std::uint32_t brick_dim,
+                                       const state_compression_registry *compression)
+    : _store(store), _brick_dim(brick_dim == 0 ? 1u : brick_dim), _compression(compression) {}
+
+state_blob_ref state_brick_writer::put_volume(const unsigned char *voxel_data, std::uint64_t xdim,
+                                              std::uint64_t ydim, std::uint64_t zdim,
+                                              std::uint32_t voxel_size, std::uint32_t voxel_type,
+                                              const std::string &codec) {
+  state_brick_manifest m;
+  m.version = 1;
+  m.chunk_size = _brick_dim;
+  m.total_size = xdim * ydim * zdim * voxel_size;
+  m.codec = codec;
+
+  // Compute content_digest over the full voxel data.
+  m.content_digest = sha256_hex(voxel_data, static_cast<std::size_t>(m.total_size));
+
+  m.has_volume_header = true;
+  m.vol_xdim = xdim;
+  m.vol_ydim = ydim;
+  m.vol_zdim = zdim;
+  m.voxel_type = voxel_type;
+  m.brick_xdim = _brick_dim;
+  m.brick_ydim = _brick_dim;
+  m.brick_zdim = _brick_dim;
+
+  // Resolve compression codec.
+  std::shared_ptr<state_compression_codec> compressor;
+  if (!codec.empty() && codec != "raw" && _compression) {
+    compressor = _compression->get(codec);
+    if (!compressor)
+      throw std::runtime_error("state_brick_writer: unknown compression codec: " + codec);
+  }
+
+  // Iterate over the 3D brick grid.
+  for (std::uint64_t bz = 0; bz < zdim; bz += _brick_dim) {
+    for (std::uint64_t by = 0; by < ydim; by += _brick_dim) {
+      for (std::uint64_t bx = 0; bx < xdim; bx += _brick_dim) {
+        const std::uint64_t sx = std::min<std::uint64_t>(_brick_dim, xdim - bx);
+        const std::uint64_t sy = std::min<std::uint64_t>(_brick_dim, ydim - by);
+        const std::uint64_t sz = std::min<std::uint64_t>(_brick_dim, zdim - bz);
+
+        // Extract the brick from the linear volume.
+        std::vector<unsigned char> brick(static_cast<std::size_t>(sx * sy * sz * voxel_size));
+        for (std::uint64_t z = 0; z < sz; ++z) {
+          for (std::uint64_t y = 0; y < sy; ++y) {
+            const std::uint64_t src_off =
+                ((bz + z) * ydim * xdim + (by + y) * xdim + bx) * voxel_size;
+            const std::uint64_t dst_off = (z * sy * sx + y * sx) * voxel_size;
+            std::memcpy(brick.data() + dst_off, voxel_data + src_off,
+                        static_cast<std::size_t>(sx * voxel_size));
+          }
+        }
+
+        // Compress.
+        std::vector<unsigned char> stored;
+        if (compressor) {
+          stored = compressor->encode(brick);
+        } else {
+          stored = std::move(brick);
+        }
+
+        state_blob_ref ref = _store.put(stored);
+        m.chunks.push_back(ref.digest);
+        m.chunk_bytes.push_back(static_cast<std::uint32_t>(stored.size()));
+
+        brick_extent ext;
+        ext.origin_x = bx;
+        ext.origin_y = by;
+        ext.origin_z = bz;
+        ext.size_x = sx;
+        ext.size_y = sy;
+        ext.size_z = sz;
+        m.extents.push_back(ext);
+      }
+    }
+  }
+
+  auto manifest_bytes = m.serialize();
+  return _store.put(manifest_bytes, codec);
+}
+
+state_blob_ref state_brick_writer::put_geometry(const std::vector<unsigned char> &bytes,
+                                                std::uint64_t num_elements,
+                                                const std::string &codec) {
+  state_brick_manifest m;
+  m.version = 1;
+  m.total_size = bytes.size();
+  m.codec = codec;
+  m.content_digest = sha256_hex(bytes);
+  m.has_volume_header = false;
+
+  std::shared_ptr<state_compression_codec> compressor;
+  if (!codec.empty() && codec != "raw" && _compression) {
+    compressor = _compression->get(codec);
+    if (!compressor)
+      throw std::runtime_error("state_brick_writer: unknown compression codec: " + codec);
+  }
+
+  // Partition into fixed-size byte chunks; assign element ranges
+  // proportionally.
+  const std::uint32_t chunk_sz = _brick_dim * _brick_dim * _brick_dim; // reuse brick_dim^3
+  m.chunk_size = chunk_sz;
+  std::size_t off = 0;
+  std::uint64_t elem_cursor = 0;
+
+  while (off < bytes.size()) {
+    const std::size_t n = std::min<std::size_t>(chunk_sz, bytes.size() - off);
+    std::vector<unsigned char> chunk(bytes.begin() + off, bytes.begin() + off + n);
+
+    std::vector<unsigned char> stored;
+    if (compressor) {
+      stored = compressor->encode(chunk);
+    } else {
+      stored = std::move(chunk);
+    }
+
+    state_blob_ref ref = _store.put(stored);
+    m.chunks.push_back(ref.digest);
+    m.chunk_bytes.push_back(static_cast<std::uint32_t>(stored.size()));
+
+    // Estimate element range proportionally.
+    std::uint64_t elem_end =
+        (bytes.size() == 0) ? 0 : std::min(num_elements, (off + n) * num_elements / bytes.size());
+
+    brick_extent ext;
+    ext.element_begin = elem_cursor;
+    ext.element_end = elem_end;
+    m.extents.push_back(ext);
+
+    elem_cursor = elem_end;
+    off += n;
+  }
+
+  auto manifest_bytes = m.serialize();
+  return _store.put(manifest_bytes, codec);
+}
+
+// ---------- state_brick_reader ----------
+
+state_brick_reader::state_brick_reader(state_blob_store &store,
+                                       const state_compression_registry *compression)
+    : _store(store), _compression(compression) {}
+
+bool state_brick_reader::load_manifest(const std::string &digest, state_brick_manifest &out) const {
+  std::vector<unsigned char> bytes;
+  if (!_store.get(digest, bytes))
+    return false;
+  return state_brick_manifest::parse(bytes, out);
+}
+
+std::vector<std::string> state_brick_reader::missing_chunks(const state_brick_manifest &m) const {
+  std::vector<std::string> missing;
+  for (const auto &d : m.chunks) {
+    if (!_store.has(d))
+      missing.push_back(d);
+  }
+  return missing;
+}
+
+bool state_brick_reader::get(const state_brick_manifest &m, std::vector<unsigned char> &out) const {
+  if (!m.has_volume_header) {
+    // Non-volume: concatenate chunks in order.
+    out.clear();
+    out.reserve(static_cast<std::size_t>(m.total_size));
+
+    std::shared_ptr<state_compression_codec> decompressor;
+    if (!m.codec.empty() && m.codec != "raw" && _compression) {
+      decompressor = _compression->get(m.codec);
+      if (!decompressor)
+        return false;
+    }
+
+    for (const auto &d : m.chunks) {
+      std::vector<unsigned char> stored;
+      if (!_store.get(d, stored))
+        return false;
+      if (decompressor) {
+        std::vector<unsigned char> decoded;
+        if (!decompressor->decode(stored, decoded))
+          return false;
+        out.insert(out.end(), decoded.begin(), decoded.end());
+      } else {
+        out.insert(out.end(), stored.begin(), stored.end());
+      }
+    }
+    return true;
+  }
+
+  // Volume: scatter bricks into a linear voxel buffer.
+  const std::uint64_t vs = data_type_sizes[m.voxel_type];
+  out.assign(static_cast<std::size_t>(m.vol_xdim * m.vol_ydim * m.vol_zdim * vs), 0);
+
+  std::shared_ptr<state_compression_codec> decompressor;
+  if (!m.codec.empty() && m.codec != "raw" && _compression) {
+    decompressor = _compression->get(m.codec);
+    if (!decompressor)
+      return false;
+  }
+
+  for (std::size_t i = 0; i < m.chunks.size(); ++i) {
+    std::vector<unsigned char> stored;
+    if (!_store.get(m.chunks[i], stored))
+      return false;
+
+    std::vector<unsigned char> brick;
+    if (decompressor) {
+      if (!decompressor->decode(stored, brick))
+        return false;
+    } else {
+      brick = std::move(stored);
+    }
+
+    const brick_extent &ext = m.extents[i];
+    for (std::uint64_t z = 0; z < ext.size_z; ++z) {
+      for (std::uint64_t y = 0; y < ext.size_y; ++y) {
+        const std::uint64_t dst_off = ((ext.origin_z + z) * m.vol_ydim * m.vol_xdim +
+                                       (ext.origin_y + y) * m.vol_xdim + ext.origin_x) *
+                                      vs;
+        const std::uint64_t src_off = (z * ext.size_y * ext.size_x + y * ext.size_x) * vs;
+        std::memcpy(out.data() + dst_off, brick.data() + src_off,
+                    static_cast<std::size_t>(ext.size_x * vs));
+      }
+    }
+  }
+
+  if (!m.content_digest.empty() && sha256_hex(out) != m.content_digest) {
+    out.clear();
+    return false;
+  }
+  return true;
+}
+
+bool state_brick_reader::get_brick(const state_brick_manifest &m, std::size_t brick_index,
+                                   std::vector<unsigned char> &out) const {
+  if (brick_index >= m.chunks.size())
+    return false;
+
+  std::vector<unsigned char> stored;
+  if (!_store.get(m.chunks[brick_index], stored))
+    return false;
+
+  if (!m.codec.empty() && m.codec != "raw" && _compression) {
+    auto dec = _compression->get(m.codec);
+    if (!dec)
+      return false;
+    return dec->decode(stored, out);
+  }
+  out = std::move(stored);
+  return true;
+}
+
+std::size_t state_brick_reader::get_region(const state_brick_manifest &m,
+                                           unsigned char *dest_buffer, std::uint64_t dest_xdim,
+                                           std::uint64_t dest_ydim, std::uint64_t dest_zdim,
+                                           std::uint32_t voxel_size, std::uint64_t lo_x,
+                                           std::uint64_t lo_y, std::uint64_t lo_z,
+                                           std::uint64_t hi_x, std::uint64_t hi_y,
+                                           std::uint64_t hi_z) const {
+  auto indices = m.bricks_in_region(lo_x, lo_y, lo_z, hi_x, hi_y, hi_z);
+  std::size_t fetched = 0;
+
+  for (std::size_t idx : indices) {
+    std::vector<unsigned char> brick;
+    if (!get_brick(m, idx, brick))
+      continue; // skip missing bricks
+
+    const brick_extent &ext = m.extents[idx];
+
+    // Compute overlap region.
+    const std::uint64_t ox = std::max(ext.origin_x, lo_x);
+    const std::uint64_t oy = std::max(ext.origin_y, lo_y);
+    const std::uint64_t oz = std::max(ext.origin_z, lo_z);
+    const std::uint64_t ex = std::min(ext.origin_x + ext.size_x, hi_x);
+    const std::uint64_t ey = std::min(ext.origin_y + ext.size_y, hi_y);
+    const std::uint64_t ez = std::min(ext.origin_z + ext.size_z, hi_z);
+
+    for (std::uint64_t z = oz; z < ez; ++z) {
+      for (std::uint64_t y = oy; y < ey; ++y) {
+        const std::uint64_t src_off = ((z - ext.origin_z) * ext.size_y * ext.size_x +
+                                       (y - ext.origin_y) * ext.size_x + (ox - ext.origin_x)) *
+                                      voxel_size;
+        const std::uint64_t dst_off =
+            ((z - lo_z) * dest_ydim * dest_xdim + (y - lo_y) * dest_xdim + (ox - lo_x)) *
+            voxel_size;
+        const std::uint64_t copy_len = (ex - ox) * voxel_size;
+        if (src_off + copy_len <= brick.size() &&
+            dst_off + copy_len <= dest_xdim * dest_ydim * dest_zdim * voxel_size) {
+          std::memcpy(dest_buffer + dst_off, brick.data() + src_off,
+                      static_cast<std::size_t>(copy_len));
+        }
+      }
+    }
+    ++fetched;
+  }
+  return fetched;
+}
+
+} // namespace CVC_NAMESPACE

--- a/src/cvc/state_cluster_shard.cpp
+++ b/src/cvc/state_cluster_shard.cpp
@@ -15,6 +15,7 @@
 #include <cvc/state.h>
 #include <cvc/state_cluster_shard.h>
 #include <cvc/state_transport.h>
+#include <cvc/state_volume_codec.h>
 #include <mutex>
 #include <stdexcept>
 #include <unordered_map>
@@ -86,6 +87,7 @@ state_cluster_shard::state_cluster_shard(app &ctx, std::string cluster_id,
   _delegation = std::make_unique<state_delegation_manager>(_cluster_id);
   _codecs = std::make_unique<state_codec_registry>();
   _codecs->register_builtin_codecs();
+  register_volume_geometry_codecs(*_codecs);
   _message_bus = std::make_unique<state_message_bus>();
   _write_policy = std::make_unique<state_write_policy>();
 }

--- a/src/cvc/state_data_hydrator.cpp
+++ b/src/cvc/state_data_hydrator.cpp
@@ -1,0 +1,199 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+
+  This file is part of libcvc.
+
+  libcvc is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+*/
+
+#include <cvc/state.h>
+#include <cvc/state_data_hydrator.h>
+
+namespace CVC_NAMESPACE {
+
+state_data_hydrator::state_data_hydrator(state_blob_store &store, state_codec_registry &codecs,
+                                         const state_compression_registry *compression)
+    : _store(store), _codecs(codecs), _compression(compression) {}
+
+state_data_hydrator::hydration_status
+state_data_hydrator::request(const std::string &path, const std::string &manifest_digest,
+                             const std::string &type_name, state *target) {
+  std::lock_guard<std::mutex> lk(_mutex);
+
+  auto it = _entries.find(path);
+  if (it != _entries.end() && it->second.status == hydration_status::ready)
+    return hydration_status::ready;
+
+  entry &e = _entries[path];
+  e.manifest_digest = manifest_digest;
+  e.type_name = type_name;
+  e.target = target;
+  e.status = hydration_status::pending;
+
+  try_hydrate(path, e);
+  return e.status;
+}
+
+state_data_hydrator::hydration_status state_data_hydrator::status(const std::string &path) const {
+  std::lock_guard<std::mutex> lk(_mutex);
+  auto it = _entries.find(path);
+  if (it == _entries.end())
+    return hydration_status::unknown;
+  return it->second.status;
+}
+
+bool state_data_hydrator::is_hydrated(const std::string &path) const {
+  return status(path) == hydration_status::ready;
+}
+
+state_data_hydrator::hydration_status
+state_data_hydrator::wait(const std::string &path, std::chrono::milliseconds timeout) const {
+  std::unique_lock<std::mutex> lk(_mutex);
+  auto pred = [&]() {
+    auto it = _entries.find(path);
+    return it == _entries.end() || it->second.status == hydration_status::ready ||
+           it->second.status == hydration_status::failed;
+  };
+
+  if (timeout.count() == 0) {
+    _cv.wait(lk, pred);
+  } else {
+    if (!_cv.wait_for(lk, timeout, pred))
+      return hydration_status::pending;
+  }
+
+  auto it = _entries.find(path);
+  if (it == _entries.end())
+    return hydration_status::unknown;
+  return it->second.status;
+}
+
+void state_data_hydrator::on_hydrated(on_hydrated_func callback) {
+  std::lock_guard<std::mutex> lk(_mutex);
+  _callbacks.push_back(std::move(callback));
+}
+
+bool state_data_hydrator::cancel(const std::string &path) {
+  std::lock_guard<std::mutex> lk(_mutex);
+  return _entries.erase(path) > 0;
+}
+
+std::size_t state_data_hydrator::retry_pending() {
+  std::lock_guard<std::mutex> lk(_mutex);
+  std::size_t retried = 0;
+  for (auto &kv : _entries) {
+    if (kv.second.status == hydration_status::pending) {
+      try_hydrate(kv.first, kv.second);
+      ++retried;
+    }
+  }
+  return retried;
+}
+
+std::size_t state_data_hydrator::pending_count() const {
+  std::lock_guard<std::mutex> lk(_mutex);
+  std::size_t n = 0;
+  for (const auto &kv : _entries)
+    if (kv.second.status == hydration_status::pending)
+      ++n;
+  return n;
+}
+
+void state_data_hydrator::try_hydrate(const std::string &path, entry &e) {
+  // Must hold _mutex when called.
+
+  state_chunked_blob_reader reader(_store, _compression);
+
+  // 1. Load manifest.
+  state_chunk_manifest manifest;
+  if (!reader.load_manifest(e.manifest_digest, manifest)) {
+    // Manifest not in local store — try fetching it.
+    if (_transport) {
+      bool fetched = _transport->fetch_chunk(
+          e.manifest_digest,
+          [this](const std::string & /*digest*/, const std::vector<unsigned char> &bytes) {
+            _store.put(bytes);
+            _total_chunks_fetched.fetch_add(1, std::memory_order_relaxed);
+          });
+      if (!fetched) {
+        e.status = hydration_status::pending;
+        return;
+      }
+      if (!reader.load_manifest(e.manifest_digest, manifest)) {
+        e.status = hydration_status::failed;
+        _total_failed.fetch_add(1, std::memory_order_relaxed);
+        notify(path, e.status);
+        return;
+      }
+    } else {
+      e.status = hydration_status::pending;
+      return;
+    }
+  }
+
+  // 2. Check for missing chunks and fetch them.
+  auto missing = reader.missing_chunks(manifest);
+  if (!missing.empty()) {
+    if (_transport) {
+      std::size_t fetched = _transport->fetch_chunks(
+          missing, [this](const std::string & /*digest*/, const std::vector<unsigned char> &bytes) {
+            _store.put(bytes);
+            _total_chunks_fetched.fetch_add(1, std::memory_order_relaxed);
+          });
+      (void)fetched;
+      // Recheck.
+      missing = reader.missing_chunks(manifest);
+    }
+    if (!missing.empty()) {
+      e.status = hydration_status::pending;
+      return;
+    }
+  }
+
+  // 3. Reassemble blob.
+  std::vector<unsigned char> payload;
+  if (!reader.get(manifest, payload)) {
+    e.status = hydration_status::failed;
+    _total_failed.fetch_add(1, std::memory_order_relaxed);
+    notify(path, e.status);
+    return;
+  }
+
+  // 4. Decode via codec registry.
+  if (!e.type_name.empty() && _codecs.has(e.type_name)) {
+    try {
+      boost::any decoded = _codecs.decode(e.type_name, payload);
+      if (e.target) {
+        e.target->data(decoded);
+      }
+    } catch (...) {
+      e.status = hydration_status::failed;
+      _total_failed.fetch_add(1, std::memory_order_relaxed);
+      notify(path, e.status);
+      return;
+    }
+  }
+
+  // 5. Mark ready.
+  e.status = hydration_status::ready;
+  _total_hydrated.fetch_add(1, std::memory_order_relaxed);
+  notify(path, e.status);
+}
+
+void state_data_hydrator::notify(const std::string &path, hydration_status status) {
+  // Must hold _mutex when called. Copy callbacks to call without lock.
+  auto cbs = _callbacks;
+  // Release lock would be needed if we didn't hold it for the caller.
+  // Since try_hydrate holds the lock, we fire callbacks under lock
+  // for simplicity. In production, a signal-queue pattern would be
+  // better, but this matches the existing cvc::state callback model.
+  _cv.notify_all();
+  for (auto &cb : cbs) {
+    if (cb)
+      cb(path, status);
+  }
+}
+
+} // namespace CVC_NAMESPACE

--- a/src/cvc/state_transport_inproc.cpp
+++ b/src/cvc/state_transport_inproc.cpp
@@ -344,4 +344,33 @@ void state_transport_inproc::set_auto_isolation_drop_threshold(std::uint64_t thr
   _auto_isolation_threshold.store(threshold, std::memory_order_relaxed);
 }
 
+// ---------- chunk fetch ----------
+
+bool state_transport_inproc::fetch_chunk(const std::string &digest, chunk_callback on_chunk) {
+  if (!_blob_store || digest.empty())
+    return false;
+  std::vector<unsigned char> bytes;
+  if (!_blob_store->get(digest, bytes))
+    return false;
+  if (on_chunk)
+    on_chunk(digest, bytes);
+  return true;
+}
+
+std::size_t state_transport_inproc::fetch_chunks(const std::vector<std::string> &digests,
+                                                 chunk_callback on_chunk) {
+  if (!_blob_store)
+    return 0;
+  std::size_t n = 0;
+  for (const auto &d : digests) {
+    std::vector<unsigned char> bytes;
+    if (_blob_store->get(d, bytes)) {
+      if (on_chunk)
+        on_chunk(d, bytes);
+      ++n;
+    }
+  }
+  return n;
+}
+
 } // namespace CVC_NAMESPACE

--- a/src/cvc/state_volume_codec.cpp
+++ b/src/cvc/state_volume_codec.cpp
@@ -1,0 +1,355 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+
+  This file is part of libcvc.
+
+  libcvc is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+*/
+
+#include <boost/any.hpp>
+#include <cstring>
+#include <cvc/app.h>
+#include <cvc/geometry.h>
+#include <cvc/state_volume_codec.h>
+#include <cvc/volume.h>
+#include <stdexcept>
+
+namespace CVC_NAMESPACE {
+
+namespace {
+
+// ---- little-endian helpers ----
+
+void write_u32(std::vector<unsigned char> &out, std::uint32_t v) {
+  for (int i = 0; i < 4; ++i)
+    out.push_back(static_cast<unsigned char>((v >> (8 * i)) & 0xff));
+}
+
+void write_u64(std::vector<unsigned char> &out, std::uint64_t v) {
+  for (int i = 0; i < 8; ++i)
+    out.push_back(static_cast<unsigned char>((v >> (8 * i)) & 0xff));
+}
+
+void write_f64(std::vector<unsigned char> &out, double v) {
+  std::uint64_t bits;
+  static_assert(sizeof(double) == 8, "double must be 8 bytes");
+  std::memcpy(&bits, &v, 8);
+  write_u64(out, bits);
+}
+
+void write_str(std::vector<unsigned char> &out, const std::string &s) {
+  write_u32(out, static_cast<std::uint32_t>(s.size()));
+  out.insert(out.end(), s.begin(), s.end());
+}
+
+void write_raw(std::vector<unsigned char> &out, const unsigned char *data, std::size_t len) {
+  out.insert(out.end(), data, data + len);
+}
+
+bool read_u32(const unsigned char *&p, const unsigned char *end, std::uint32_t &v) {
+  if (p + 4 > end)
+    return false;
+  v = 0;
+  for (int i = 0; i < 4; ++i)
+    v |= static_cast<std::uint32_t>(p[i]) << (8 * i);
+  p += 4;
+  return true;
+}
+
+bool read_u64(const unsigned char *&p, const unsigned char *end, std::uint64_t &v) {
+  if (p + 8 > end)
+    return false;
+  v = 0;
+  for (int i = 0; i < 8; ++i)
+    v |= static_cast<std::uint64_t>(p[i]) << (8 * i);
+  p += 8;
+  return true;
+}
+
+bool read_f64(const unsigned char *&p, const unsigned char *end, double &v) {
+  std::uint64_t bits;
+  if (!read_u64(p, end, bits))
+    return false;
+  std::memcpy(&v, &bits, 8);
+  return true;
+}
+
+bool read_str(const unsigned char *&p, const unsigned char *end, std::string &v) {
+  std::uint32_t len;
+  if (!read_u32(p, end, len))
+    return false;
+  if (p + len > end)
+    return false;
+  v.assign(reinterpret_cast<const char *>(p), len);
+  p += len;
+  return true;
+}
+
+// ---- volume codec ----
+
+constexpr unsigned char VOL_MAGIC[4] = {'C', 'V', 'V', '1'};
+
+std::vector<unsigned char> encode_volume(const boost::any &val) {
+  const volume &vol = boost::any_cast<const volume &>(val);
+
+  const std::uint64_t xdim = vol.XDim();
+  const std::uint64_t ydim = vol.YDim();
+  const std::uint64_t zdim = vol.ZDim();
+  const std::uint32_t vtype = static_cast<std::uint32_t>(vol.voxelType());
+  const std::uint64_t voxel_bytes = xdim * ydim * zdim * data_type_sizes[vol.voxelType()];
+
+  std::vector<unsigned char> out;
+  out.reserve(4 + 3 * 8 + 4 + 6 * 8 + 4 + vol.desc().size() + voxel_bytes);
+
+  out.insert(out.end(), VOL_MAGIC, VOL_MAGIC + 4);
+  write_u64(out, xdim);
+  write_u64(out, ydim);
+  write_u64(out, zdim);
+  write_u32(out, vtype);
+
+  write_f64(out, vol.XMin());
+  write_f64(out, vol.YMin());
+  write_f64(out, vol.ZMin());
+  write_f64(out, vol.XMax());
+  write_f64(out, vol.YMax());
+  write_f64(out, vol.ZMax());
+
+  write_str(out, vol.desc());
+
+  const unsigned char *voxels = *vol;
+  write_raw(out, voxels, static_cast<std::size_t>(voxel_bytes));
+
+  return out;
+}
+
+boost::any decode_volume(const std::vector<unsigned char> &bytes) {
+  const unsigned char *p = bytes.data();
+  const unsigned char *end = p + bytes.size();
+
+  if (bytes.size() < 4 || std::memcmp(p, VOL_MAGIC, 4) != 0)
+    throw std::runtime_error("decode_volume: bad magic");
+  p += 4;
+
+  std::uint64_t xdim, ydim, zdim;
+  std::uint32_t vtype;
+  if (!read_u64(p, end, xdim) || !read_u64(p, end, ydim) || !read_u64(p, end, zdim) ||
+      !read_u32(p, end, vtype))
+    throw std::runtime_error("decode_volume: truncated header");
+
+  if (vtype > static_cast<std::uint32_t>(Undefined))
+    throw std::runtime_error("decode_volume: invalid voxel type");
+
+  double minx, miny, minz, maxx, maxy, maxz;
+  if (!read_f64(p, end, minx) || !read_f64(p, end, miny) || !read_f64(p, end, minz) ||
+      !read_f64(p, end, maxx) || !read_f64(p, end, maxy) || !read_f64(p, end, maxz))
+    throw std::runtime_error("decode_volume: truncated bounding box");
+
+  std::string desc;
+  if (!read_str(p, end, desc))
+    throw std::runtime_error("decode_volume: truncated description");
+
+  data_type dt = static_cast<data_type>(vtype);
+  std::uint64_t voxel_bytes = xdim * ydim * zdim * data_type_sizes[dt];
+  if (static_cast<std::size_t>(end - p) < voxel_bytes)
+    throw std::runtime_error("decode_volume: truncated voxel data");
+
+  // Construct volume via a scratch app context.
+  // The caller is expected to extract the volume from the any and
+  // manage ownership. We use a thread-local static app so we don't
+  // create one per decode call.
+  thread_local app decode_ctx;
+
+  dimension dim;
+  dim.xdim = xdim;
+  dim.ydim = ydim;
+  dim.zdim = zdim;
+  bounding_box bbox(minx, miny, minz, maxx, maxy, maxz);
+
+  volume vol(decode_ctx, p, dim, dt, bbox);
+  vol.desc(desc);
+  p += voxel_bytes;
+
+  return boost::any(vol);
+}
+
+// ---- geometry codec ----
+
+constexpr unsigned char GEO_MAGIC[4] = {'C', 'V', 'G', '1'};
+
+std::vector<unsigned char> encode_geometry(const boost::any &val) {
+  const geometry &geo = boost::any_cast<const geometry &>(val);
+
+  const auto &pts = geo.const_points();
+  const auto &nrm = geo.const_normals();
+  const auto &clr = geo.const_colors();
+  const auto &tri = geo.const_tris();
+  const auto &qua = geo.const_quads();
+  const auto &tet = geo.const_tets();
+  const auto &hex = geo.const_hexs();
+  const auto &lin = geo.const_lines();
+
+  const std::uint64_t np = pts.size();
+  const std::uint64_t nn = nrm.size();
+  const std::uint64_t nc = clr.size();
+  const std::uint64_t nt = tri.size();
+  const std::uint64_t nq = qua.size();
+  const std::uint64_t nte = tet.size();
+  const std::uint64_t nh = hex.size();
+  const std::uint64_t nl = lin.size();
+
+  std::vector<unsigned char> out;
+  // Header: 4 + 4 + 8*8 = 72 bytes
+  // Body est: pts*24 + nrm*24 + clr*24 + tri*24 + qua*32 + tet*32 + hex*64 + lin*16
+  out.reserve(72 + np * 24 + nn * 24 + nc * 24 + nt * 24 + nq * 32 + nte * 32 + nh * 64 + nl * 16);
+
+  out.insert(out.end(), GEO_MAGIC, GEO_MAGIC + 4);
+  write_u32(out, static_cast<std::uint32_t>(geo.get_geometry_type()));
+  write_u64(out, np);
+  write_u64(out, nn);
+  write_u64(out, nc);
+  write_u64(out, nt);
+  write_u64(out, nq);
+  write_u64(out, nte);
+  write_u64(out, nh);
+  write_u64(out, nl);
+
+  for (const auto &pt : pts) {
+    write_f64(out, pt[0]);
+    write_f64(out, pt[1]);
+    write_f64(out, pt[2]);
+  }
+  for (const auto &n : nrm) {
+    write_f64(out, n[0]);
+    write_f64(out, n[1]);
+    write_f64(out, n[2]);
+  }
+  for (const auto &c : clr) {
+    write_f64(out, c[0]);
+    write_f64(out, c[1]);
+    write_f64(out, c[2]);
+  }
+  for (const auto &t : tri) {
+    write_u64(out, t[0]);
+    write_u64(out, t[1]);
+    write_u64(out, t[2]);
+  }
+  for (const auto &q : qua) {
+    write_u64(out, q[0]);
+    write_u64(out, q[1]);
+    write_u64(out, q[2]);
+    write_u64(out, q[3]);
+  }
+  for (const auto &te : tet) {
+    write_u64(out, te[0]);
+    write_u64(out, te[1]);
+    write_u64(out, te[2]);
+    write_u64(out, te[3]);
+  }
+  for (const auto &h : hex) {
+    for (int i = 0; i < 8; ++i)
+      write_u64(out, h[i]);
+  }
+  for (const auto &l : lin) {
+    write_u64(out, l[0]);
+    write_u64(out, l[1]);
+  }
+
+  return out;
+}
+
+boost::any decode_geometry(const std::vector<unsigned char> &bytes) {
+  const unsigned char *p = bytes.data();
+  const unsigned char *end = p + bytes.size();
+
+  if (bytes.size() < 4 || std::memcmp(p, GEO_MAGIC, 4) != 0)
+    throw std::runtime_error("decode_geometry: bad magic");
+  p += 4;
+
+  std::uint32_t gtype;
+  std::uint64_t np, nn, nc, nt, nq, nte, nh, nl;
+  if (!read_u32(p, end, gtype) || !read_u64(p, end, np) || !read_u64(p, end, nn) ||
+      !read_u64(p, end, nc) || !read_u64(p, end, nt) || !read_u64(p, end, nq) ||
+      !read_u64(p, end, nte) || !read_u64(p, end, nh) || !read_u64(p, end, nl))
+    throw std::runtime_error("decode_geometry: truncated header");
+
+  thread_local app decode_ctx;
+  geometry geo(decode_ctx);
+  geo.set_geometry_type(static_cast<geometry::geometry_type>(gtype));
+
+  auto &pts = geo.points();
+  pts.resize(np);
+  for (std::uint64_t i = 0; i < np; ++i) {
+    if (!read_f64(p, end, pts[i][0]) || !read_f64(p, end, pts[i][1]) ||
+        !read_f64(p, end, pts[i][2]))
+      throw std::runtime_error("decode_geometry: truncated points");
+  }
+
+  auto &nrm = geo.normals();
+  nrm.resize(nn);
+  for (std::uint64_t i = 0; i < nn; ++i) {
+    if (!read_f64(p, end, nrm[i][0]) || !read_f64(p, end, nrm[i][1]) ||
+        !read_f64(p, end, nrm[i][2]))
+      throw std::runtime_error("decode_geometry: truncated normals");
+  }
+
+  auto &clr = geo.colors();
+  clr.resize(nc);
+  for (std::uint64_t i = 0; i < nc; ++i) {
+    if (!read_f64(p, end, clr[i][0]) || !read_f64(p, end, clr[i][1]) ||
+        !read_f64(p, end, clr[i][2]))
+      throw std::runtime_error("decode_geometry: truncated colors");
+  }
+
+  auto &tri = geo.tris();
+  tri.resize(nt);
+  for (std::uint64_t i = 0; i < nt; ++i) {
+    if (!read_u64(p, end, tri[i][0]) || !read_u64(p, end, tri[i][1]) ||
+        !read_u64(p, end, tri[i][2]))
+      throw std::runtime_error("decode_geometry: truncated tris");
+  }
+
+  auto &qua = geo.quads();
+  qua.resize(nq);
+  for (std::uint64_t i = 0; i < nq; ++i) {
+    if (!read_u64(p, end, qua[i][0]) || !read_u64(p, end, qua[i][1]) ||
+        !read_u64(p, end, qua[i][2]) || !read_u64(p, end, qua[i][3]))
+      throw std::runtime_error("decode_geometry: truncated quads");
+  }
+
+  auto &tet = geo.tets();
+  tet.resize(nte);
+  for (std::uint64_t i = 0; i < nte; ++i) {
+    if (!read_u64(p, end, tet[i][0]) || !read_u64(p, end, tet[i][1]) ||
+        !read_u64(p, end, tet[i][2]) || !read_u64(p, end, tet[i][3]))
+      throw std::runtime_error("decode_geometry: truncated tets");
+  }
+
+  auto &hex = geo.hexs();
+  hex.resize(nh);
+  for (std::uint64_t i = 0; i < nh; ++i) {
+    for (int k = 0; k < 8; ++k) {
+      if (!read_u64(p, end, hex[i][k]))
+        throw std::runtime_error("decode_geometry: truncated hexs");
+    }
+  }
+
+  auto &lin = geo.lines();
+  lin.resize(nl);
+  for (std::uint64_t i = 0; i < nl; ++i) {
+    if (!read_u64(p, end, lin[i][0]) || !read_u64(p, end, lin[i][1]))
+      throw std::runtime_error("decode_geometry: truncated lines");
+  }
+
+  return boost::any(geo);
+}
+
+} // anonymous namespace
+
+void register_volume_geometry_codecs(state_codec_registry &registry) {
+  registry.register_codec("cvc::volume", encode_volume, decode_volume, "cvc.volume.v1");
+  registry.register_codec("cvc::geometry", encode_geometry, decode_geometry, "cvc.geometry.v1");
+}
+
+} // namespace CVC_NAMESPACE

--- a/src/cvc/tests/CMakeLists.txt
+++ b/src/cvc/tests/CMakeLists.txt
@@ -42,6 +42,9 @@ add_executable(state_sync_adapter_link_forwarding_test state_sync_adapter_link_f
 add_executable(state_cross_cluster_link_test state_cross_cluster_link_test.cpp)
 add_executable(state_link_bench_test state_link_bench_test.cpp)
 add_executable(state_delta_codec_test state_delta_codec_test.cpp)
+add_executable(state_volume_codec_test state_volume_codec_test.cpp)
+add_executable(state_brick_manifest_test state_brick_manifest_test.cpp)
+add_executable(state_data_hydrator_test state_data_hydrator_test.cpp)
 if(CVC_ENABLE_GRPC)
   add_executable(state_transport_grpc_test state_transport_grpc_test.cpp)
 endif()
@@ -82,6 +85,9 @@ set(TEST_TARGETS
   state_cross_cluster_link_test
   state_link_bench_test
   state_delta_codec_test
+  state_volume_codec_test
+  state_brick_manifest_test
+  state_data_hydrator_test
   voxels_test
   volume_test
   procedural_geometry_test
@@ -423,6 +429,27 @@ target_link_libraries(state_link_bench_test
     GTest::gtest_main
 )
 
+target_link_libraries(state_volume_codec_test
+  PRIVATE
+    cvc
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_link_libraries(state_brick_manifest_test
+  PRIVATE
+    cvc
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_link_libraries(state_data_hydrator_test
+  PRIVATE
+    cvc
+    GTest::gtest
+    GTest::gtest_main
+)
+
 target_link_libraries(state_delta_codec_test
   PRIVATE
     cvc
@@ -490,6 +517,9 @@ target_compile_features(state_sync_adapter_link_forwarding_test PRIVATE cxx_std_
 target_compile_features(state_cross_cluster_link_test PRIVATE cxx_std_17)
 target_compile_features(state_link_bench_test PRIVATE cxx_std_17)
 target_compile_features(state_delta_codec_test PRIVATE cxx_std_17)
+target_compile_features(state_volume_codec_test PRIVATE cxx_std_17)
+target_compile_features(state_brick_manifest_test PRIVATE cxx_std_17)
+target_compile_features(state_data_hydrator_test PRIVATE cxx_std_17)
 
 # Only build HDF5-dependent tests when HDF5 support is enabled
 if(CVC_USING_HDF5 AND NOT CVC_HDF5_DISABLED)
@@ -581,6 +611,9 @@ gtest_discover_tests(state_sync_adapter_link_forwarding_test)
 gtest_discover_tests(state_cross_cluster_link_test)
 gtest_discover_tests(state_link_bench_test)
 gtest_discover_tests(state_delta_codec_test)
+gtest_discover_tests(state_volume_codec_test)
+gtest_discover_tests(state_brick_manifest_test)
+gtest_discover_tests(state_data_hydrator_test)
 if(TARGET state_transport_grpc_test)
   gtest_discover_tests(state_transport_grpc_test)
 endif()

--- a/src/cvc/tests/state_brick_manifest_test.cpp
+++ b/src/cvc/tests/state_brick_manifest_test.cpp
@@ -1,0 +1,283 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+  Tests for brick-aware manifests, brick writer/reader, and spatial queries.
+*/
+
+#include <cstring>
+#include <cvc/state_blob_store.h>
+#include <cvc/state_brick_manifest.h>
+#include <cvc/state_compression_registry.h>
+#include <cvc/types.h>
+#include <gtest/gtest.h>
+
+using namespace CVC_NAMESPACE;
+
+class BrickManifestTest : public ::testing::Test {
+protected:
+  memory_state_blob_store store;
+  state_compression_registry compression;
+};
+
+// ---- manifest serialization ----
+
+TEST_F(BrickManifestTest, SerializeParseRoundTrip) {
+  state_brick_manifest m;
+  m.version = 1;
+  m.chunk_size = 32;
+  m.total_size = 1024;
+  m.codec = "raw";
+  m.content_digest = "abc123";
+  m.has_volume_header = true;
+  m.vol_xdim = 64;
+  m.vol_ydim = 64;
+  m.vol_zdim = 64;
+  m.voxel_type = static_cast<std::uint32_t>(Float);
+  m.brick_xdim = 32;
+  m.brick_ydim = 32;
+  m.brick_zdim = 32;
+
+  m.chunks = {"chunk1", "chunk2"};
+  m.chunk_bytes = {512, 512};
+
+  brick_extent e1;
+  e1.origin_x = 0;
+  e1.origin_y = 0;
+  e1.origin_z = 0;
+  e1.size_x = 32;
+  e1.size_y = 32;
+  e1.size_z = 32;
+  m.extents.push_back(e1);
+
+  brick_extent e2;
+  e2.origin_x = 32;
+  e2.origin_y = 0;
+  e2.origin_z = 0;
+  e2.size_x = 32;
+  e2.size_y = 32;
+  e2.size_z = 32;
+  m.extents.push_back(e2);
+
+  auto bytes = m.serialize();
+  EXPECT_GT(bytes.size(), 0u);
+
+  state_brick_manifest parsed;
+  ASSERT_TRUE(state_brick_manifest::parse(bytes, parsed));
+
+  EXPECT_EQ(parsed.version, 1u);
+  EXPECT_EQ(parsed.chunk_size, 32u);
+  EXPECT_EQ(parsed.total_size, 1024u);
+  EXPECT_EQ(parsed.codec, "raw");
+  EXPECT_EQ(parsed.content_digest, "abc123");
+  EXPECT_TRUE(parsed.has_volume_header);
+  EXPECT_EQ(parsed.vol_xdim, 64u);
+  EXPECT_EQ(parsed.voxel_type, static_cast<std::uint32_t>(Float));
+  EXPECT_EQ(parsed.chunks.size(), 2u);
+  EXPECT_EQ(parsed.chunks[0], "chunk1");
+  EXPECT_EQ(parsed.extents[0].size_x, 32u);
+  EXPECT_EQ(parsed.extents[1].origin_x, 32u);
+}
+
+TEST_F(BrickManifestTest, ParseBadMagicFails) {
+  std::vector<unsigned char> bad = {0, 0, 0, 0};
+  state_brick_manifest m;
+  EXPECT_FALSE(state_brick_manifest::parse(bad, m));
+}
+
+TEST_F(BrickManifestTest, NoVolumeHeader) {
+  state_brick_manifest m;
+  m.has_volume_header = false;
+  m.chunks = {"d1"};
+  m.chunk_bytes = {100};
+  brick_extent e;
+  e.element_begin = 0;
+  e.element_end = 50;
+  m.extents.push_back(e);
+
+  auto bytes = m.serialize();
+  state_brick_manifest parsed;
+  ASSERT_TRUE(state_brick_manifest::parse(bytes, parsed));
+  EXPECT_FALSE(parsed.has_volume_header);
+  EXPECT_EQ(parsed.extents[0].element_end, 50u);
+}
+
+// ---- spatial query ----
+
+TEST_F(BrickManifestTest, BricksInRegion) {
+  state_brick_manifest m;
+  m.has_volume_header = true;
+  m.vol_xdim = 64;
+  m.vol_ydim = 64;
+  m.vol_zdim = 64;
+  m.brick_xdim = 32;
+  m.brick_ydim = 32;
+  m.brick_zdim = 32;
+
+  // 8 bricks in a 64^3 volume with 32^3 bricks.
+  for (int bz = 0; bz < 2; ++bz) {
+    for (int by = 0; by < 2; ++by) {
+      for (int bx = 0; bx < 2; ++bx) {
+        m.chunks.push_back("d" + std::to_string(bx + by * 2 + bz * 4));
+        m.chunk_bytes.push_back(32768);
+        brick_extent e;
+        e.origin_x = bx * 32;
+        e.origin_y = by * 32;
+        e.origin_z = bz * 32;
+        e.size_x = 32;
+        e.size_y = 32;
+        e.size_z = 32;
+        m.extents.push_back(e);
+      }
+    }
+  }
+
+  // Query a region that covers the first octant only.
+  auto r = m.bricks_in_region(0, 0, 0, 32, 32, 32);
+  EXPECT_EQ(r.size(), 1u);
+  EXPECT_EQ(r[0], 0u);
+
+  // Query the full volume.
+  auto all = m.bricks_in_region(0, 0, 0, 64, 64, 64);
+  EXPECT_EQ(all.size(), 8u);
+
+  // Query a 2x2x1 slab at z=0.
+  auto slab = m.bricks_in_region(0, 0, 0, 64, 64, 1);
+  EXPECT_EQ(slab.size(), 4u);
+
+  // Query outside volume.
+  auto empty = m.bricks_in_region(100, 100, 100, 200, 200, 200);
+  EXPECT_EQ(empty.size(), 0u);
+}
+
+// ---- brick writer/reader ----
+
+TEST_F(BrickManifestTest, WriteAndReadVolumeBricks) {
+  const std::uint64_t xdim = 8, ydim = 8, zdim = 8;
+  const std::uint32_t vs = sizeof(float);
+  std::vector<unsigned char> voxels(xdim * ydim * zdim * vs);
+
+  // Fill with known pattern.
+  float *fp = reinterpret_cast<float *>(voxels.data());
+  for (std::uint64_t i = 0; i < xdim * ydim * zdim; ++i)
+    fp[i] = static_cast<float>(i);
+
+  state_brick_writer writer(store, 4); // 4^3 bricks
+  auto ref = writer.put_volume(voxels.data(), xdim, ydim, zdim, vs, Float);
+  EXPECT_FALSE(ref.digest.empty());
+
+  state_brick_reader reader(store);
+  state_brick_manifest m;
+  ASSERT_TRUE(reader.load_manifest(ref.digest, m));
+
+  EXPECT_TRUE(m.has_volume_header);
+  EXPECT_EQ(m.vol_xdim, 8u);
+  EXPECT_EQ(m.brick_xdim, 4u);
+  // 8/4 = 2 bricks per axis → 2^3 = 8 bricks.
+  EXPECT_EQ(m.chunks.size(), 8u);
+  EXPECT_EQ(m.extents.size(), 8u);
+
+  // Verify spatial extents.
+  EXPECT_EQ(m.extents[0].origin_x, 0u);
+  EXPECT_EQ(m.extents[0].size_x, 4u);
+
+  // Reassemble and verify full payload.
+  std::vector<unsigned char> reassembled;
+  ASSERT_TRUE(reader.get(m, reassembled));
+  ASSERT_EQ(reassembled.size(), voxels.size());
+
+  float *rp = reinterpret_cast<float *>(reassembled.data());
+  for (std::uint64_t i = 0; i < xdim * ydim * zdim; ++i)
+    EXPECT_FLOAT_EQ(rp[i], static_cast<float>(i)) << "at index " << i;
+}
+
+TEST_F(BrickManifestTest, WriteAndReadSingleBrick) {
+  const std::uint64_t xdim = 4, ydim = 4, zdim = 4;
+  const std::uint32_t vs = sizeof(float);
+  std::vector<unsigned char> voxels(xdim * ydim * zdim * vs, 0);
+  float *fp = reinterpret_cast<float *>(voxels.data());
+  for (int i = 0; i < 64; ++i)
+    fp[i] = static_cast<float>(i * 10);
+
+  state_brick_writer writer(store, 4);
+  auto ref = writer.put_volume(voxels.data(), xdim, ydim, zdim, vs, Float);
+
+  state_brick_reader reader(store);
+  state_brick_manifest m;
+  ASSERT_TRUE(reader.load_manifest(ref.digest, m));
+  EXPECT_EQ(m.chunks.size(), 1u); // 4/4 = 1 brick per axis
+
+  std::vector<unsigned char> brick;
+  ASSERT_TRUE(reader.get_brick(m, 0, brick));
+  EXPECT_EQ(brick.size(), 4u * 4 * 4 * vs);
+}
+
+TEST_F(BrickManifestTest, GetRegion) {
+  const std::uint64_t xdim = 8, ydim = 8, zdim = 8;
+  const std::uint32_t vs = sizeof(float);
+  std::vector<unsigned char> voxels(xdim * ydim * zdim * vs);
+  float *fp = reinterpret_cast<float *>(voxels.data());
+  for (std::uint64_t i = 0; i < xdim * ydim * zdim; ++i)
+    fp[i] = static_cast<float>(i);
+
+  state_brick_writer writer(store, 4);
+  auto ref = writer.put_volume(voxels.data(), xdim, ydim, zdim, vs, Float);
+
+  state_brick_reader reader(store);
+  state_brick_manifest m;
+  ASSERT_TRUE(reader.load_manifest(ref.digest, m));
+
+  // Read the first 4x4x4 subregion.
+  std::vector<unsigned char> region(4 * 4 * 4 * vs, 0);
+  auto fetched = reader.get_region(m, region.data(), 4, 4, 4, vs, 0, 0, 0, 4, 4, 4);
+  EXPECT_EQ(fetched, 1u);
+
+  float *rp = reinterpret_cast<float *>(region.data());
+  // The first voxel at (0,0,0) should be 0.
+  EXPECT_FLOAT_EQ(rp[0], 0.0f);
+  // Voxel at (3,3,3) in original = index 3 + 3*8 + 3*64 = 219.
+  // In the subregion (3,3,3) = index 3 + 3*4 + 3*16 = 63.
+  EXPECT_FLOAT_EQ(rp[63], 219.0f);
+}
+
+TEST_F(BrickManifestTest, MissingChunks) {
+  state_brick_manifest m;
+  m.chunks = {"nonexistent1", "nonexistent2"};
+
+  state_brick_reader reader(store);
+  auto missing = reader.missing_chunks(m);
+  EXPECT_EQ(missing.size(), 2u);
+}
+
+TEST_F(BrickManifestTest, PutGeometry) {
+  std::vector<unsigned char> data(1000, 42);
+  state_brick_writer writer(store, 10); // 10^3 = 1000 chunk size
+  auto ref = writer.put_geometry(data, 100);
+
+  state_brick_reader reader(store);
+  state_brick_manifest m;
+  ASSERT_TRUE(reader.load_manifest(ref.digest, m));
+  EXPECT_FALSE(m.has_volume_header);
+  EXPECT_GE(m.chunks.size(), 1u);
+  EXPECT_EQ(m.extents[0].element_begin, 0u);
+
+  std::vector<unsigned char> reassembled;
+  ASSERT_TRUE(reader.get(m, reassembled));
+  EXPECT_EQ(reassembled, data);
+}
+
+TEST_F(BrickManifestTest, CompressedBricks) {
+  const std::uint64_t xdim = 4, ydim = 4, zdim = 4;
+  const std::uint32_t vs = 1;                                    // UChar
+  std::vector<unsigned char> voxels(xdim * ydim * zdim * vs, 0); // all zeros → good RLE
+
+  state_brick_writer writer(store, 4, &compression);
+  auto ref = writer.put_volume(voxels.data(), xdim, ydim, zdim, vs, UChar, "rle");
+
+  state_brick_reader reader(store, &compression);
+  state_brick_manifest m;
+  ASSERT_TRUE(reader.load_manifest(ref.digest, m));
+  EXPECT_EQ(m.codec, "rle");
+
+  std::vector<unsigned char> out;
+  ASSERT_TRUE(reader.get(m, out));
+  EXPECT_EQ(out, voxels);
+}

--- a/src/cvc/tests/state_data_hydrator_test.cpp
+++ b/src/cvc/tests/state_data_hydrator_test.cpp
@@ -1,0 +1,222 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+  Tests for the lazy data hydrator.
+*/
+
+#include <chrono>
+#include <cvc/app.h>
+#include <cvc/state.h>
+#include <cvc/state_blob_store.h>
+#include <cvc/state_chunked_blob.h>
+#include <cvc/state_codec_registry.h>
+#include <cvc/state_compression_registry.h>
+#include <cvc/state_data_hydrator.h>
+#include <cvc/state_transport_inproc.h>
+#include <gtest/gtest.h>
+#include <string>
+
+using namespace CVC_NAMESPACE;
+
+class DataHydratorTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // Register a trivial "test_string" codec.
+    state_codec_registry::encode_func enc = [](const boost::any &v) -> std::vector<unsigned char> {
+      auto s = boost::any_cast<std::string>(v);
+      return std::vector<unsigned char>(s.begin(), s.end());
+    };
+    state_codec_registry::decode_func dec = [](const std::vector<unsigned char> &b) -> boost::any {
+      return std::string(b.begin(), b.end());
+    };
+    codecs.register_codec("test_string", enc, dec);
+  }
+
+  memory_state_blob_store store;
+  state_codec_registry codecs;
+  state_compression_registry compression;
+};
+
+static state_blob_ref store_chunked(memory_state_blob_store &store, const std::string &payload) {
+  state_chunked_blob_writer writer(store, 64); // small chunks for testing
+  std::vector<unsigned char> bytes(payload.begin(), payload.end());
+  return writer.put(bytes);
+}
+
+// ---- basic lifecycle ----
+
+TEST_F(DataHydratorTest, UnknownPathBeforeRequest) {
+  state_data_hydrator h(store, codecs);
+  EXPECT_EQ(h.status("/foo"), state_data_hydrator::hydration_status::unknown);
+  EXPECT_FALSE(h.is_hydrated("/foo"));
+}
+
+TEST_F(DataHydratorTest, HydrateLocalChunks) {
+  auto ref = store_chunked(store, "hello world");
+
+  state_data_hydrator h(store, codecs);
+  auto s = h.request("/test", ref.digest, "test_string");
+  EXPECT_EQ(s, state_data_hydrator::hydration_status::ready);
+  EXPECT_TRUE(h.is_hydrated("/test"));
+  EXPECT_EQ(h.total_hydrated(), 1u);
+}
+
+TEST_F(DataHydratorTest, HydrateAndInstallOnState) {
+  auto ref = store_chunked(store, "payload123");
+
+  cvc::app a;
+  auto &root = cvc::state::instance(a)("test_hydrate");
+  state_data_hydrator h(store, codecs);
+  auto s = h.request("/val", ref.digest, "test_string", &root);
+  EXPECT_EQ(s, state_data_hydrator::hydration_status::ready);
+  EXPECT_EQ(root.data<std::string>(), "payload123");
+}
+
+TEST_F(DataHydratorTest, WaitReturnsImmediatelyWhenReady) {
+  auto ref = store_chunked(store, "data");
+
+  state_data_hydrator h(store, codecs);
+  h.request("/p", ref.digest, "test_string");
+
+  auto s = h.wait("/p", std::chrono::milliseconds(100));
+  EXPECT_EQ(s, state_data_hydrator::hydration_status::ready);
+}
+
+TEST_F(DataHydratorTest, WaitUnknownPathReturnsUnknown) {
+  state_data_hydrator h(store, codecs);
+  auto s = h.wait("/nope", std::chrono::milliseconds(10));
+  EXPECT_EQ(s, state_data_hydrator::hydration_status::unknown);
+}
+
+// ---- callback ----
+
+TEST_F(DataHydratorTest, OnHydratedCallback) {
+  auto ref = store_chunked(store, "cb_data");
+
+  state_data_hydrator h(store, codecs);
+
+  std::string notified_path;
+  state_data_hydrator::hydration_status notified_status =
+      state_data_hydrator::hydration_status::unknown;
+
+  h.on_hydrated([&](const std::string &p, state_data_hydrator::hydration_status s) {
+    notified_path = p;
+    notified_status = s;
+  });
+
+  h.request("/cb", ref.digest, "test_string");
+  EXPECT_EQ(notified_path, "/cb");
+  EXPECT_EQ(notified_status, state_data_hydrator::hydration_status::ready);
+}
+
+// ---- cancel ----
+
+TEST_F(DataHydratorTest, CancelRemovesEntry) {
+  auto ref = store_chunked(store, "data");
+  state_data_hydrator h(store, codecs);
+  h.request("/x", ref.digest, "test_string");
+  EXPECT_TRUE(h.cancel("/x"));
+  EXPECT_EQ(h.status("/x"), state_data_hydrator::hydration_status::unknown);
+  // Cancel nonexistent returns false.
+  EXPECT_FALSE(h.cancel("/nonexistent"));
+}
+
+// ---- transport fetch path ----
+
+TEST_F(DataHydratorTest, FetchViaTranportInproc) {
+  // Store chunks in a separate "remote" store.
+  memory_state_blob_store remote_store;
+  auto ref = store_chunked(remote_store, "remote_payload");
+
+  // Local store has the manifest only — copy it.
+  {
+    std::vector<unsigned char> manifest_bytes;
+    ASSERT_TRUE(remote_store.get(ref.digest, manifest_bytes));
+    store.put(manifest_bytes);
+  }
+
+  // Copy manifest chunk digests to know which chunks are on remote.
+  state_chunk_manifest manifest;
+  {
+    std::vector<unsigned char> mb;
+    ASSERT_TRUE(store.get(ref.digest, mb));
+    ASSERT_TRUE(state_chunk_manifest::parse(mb, manifest));
+  }
+
+  // Copy chunk data to remote store (they're already there)
+  // and set up transport to look at remote store for chunks.
+  state_transport_inproc transport;
+  transport.set_blob_store(&remote_store);
+
+  state_data_hydrator h(store, codecs);
+  h.set_transport(&transport);
+
+  auto s = h.request("/remote", ref.digest, "test_string");
+  EXPECT_EQ(s, state_data_hydrator::hydration_status::ready);
+  EXPECT_TRUE(h.is_hydrated("/remote"));
+  EXPECT_GT(h.total_chunks_fetched(), 0u);
+}
+
+// ---- diagnostics ----
+
+TEST_F(DataHydratorTest, Diagnostics) {
+  state_data_hydrator h(store, codecs);
+  EXPECT_EQ(h.total_hydrated(), 0u);
+  EXPECT_EQ(h.total_failed(), 0u);
+  EXPECT_EQ(h.total_chunks_fetched(), 0u);
+  EXPECT_EQ(h.pending_count(), 0u);
+
+  auto ref = store_chunked(store, "diag");
+  h.request("/d", ref.digest, "test_string");
+  EXPECT_EQ(h.total_hydrated(), 1u);
+  EXPECT_EQ(h.pending_count(), 0u);
+}
+
+// ---- bad codec ----
+
+TEST_F(DataHydratorTest, UnknownCodecStillReady) {
+  // When the type_name has no registered codec, the hydrator
+  // reassembles bytes but skips decoding → still marked ready.
+  auto ref = store_chunked(store, "data");
+  state_data_hydrator h(store, codecs);
+  auto s = h.request("/unknown", ref.digest, "nonexistent_codec");
+  EXPECT_EQ(s, state_data_hydrator::hydration_status::ready);
+}
+
+TEST_F(DataHydratorTest, ThrowingCodecFails) {
+  // Register a codec that always throws during decode.
+  state_codec_registry::encode_func enc = [](const boost::any &) -> std::vector<unsigned char> {
+    return {};
+  };
+  state_codec_registry::decode_func dec = [](const std::vector<unsigned char> &) -> boost::any {
+    throw std::runtime_error("intentional decode failure");
+  };
+  codecs.register_codec("bad_codec", enc, dec);
+
+  auto ref = store_chunked(store, "data");
+  state_data_hydrator h(store, codecs);
+  auto s = h.request("/bad", ref.digest, "bad_codec");
+  EXPECT_EQ(s, state_data_hydrator::hydration_status::failed);
+  EXPECT_EQ(h.total_failed(), 1u);
+}
+
+// ---- retry ----
+
+TEST_F(DataHydratorTest, RetryPendingNoOp) {
+  state_data_hydrator h(store, codecs);
+  EXPECT_EQ(h.retry_pending(), 0u);
+}
+
+// ---- multiple hydrations ----
+
+TEST_F(DataHydratorTest, MultiplePathsIndependent) {
+  auto r1 = store_chunked(store, "alpha");
+  auto r2 = store_chunked(store, "bravo");
+
+  state_data_hydrator h(store, codecs);
+  h.request("/a", r1.digest, "test_string");
+  h.request("/b", r2.digest, "test_string");
+
+  EXPECT_TRUE(h.is_hydrated("/a"));
+  EXPECT_TRUE(h.is_hydrated("/b"));
+  EXPECT_EQ(h.total_hydrated(), 2u);
+}

--- a/src/cvc/tests/state_volume_codec_test.cpp
+++ b/src/cvc/tests/state_volume_codec_test.cpp
@@ -1,0 +1,206 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+  Tests for cvc::volume and cvc::geometry codec registration.
+*/
+
+#include <boost/any.hpp>
+#include <cvc/app.h>
+#include <cvc/geometry.h>
+#include <cvc/state_codec_registry.h>
+#include <cvc/state_volume_codec.h>
+#include <cvc/volume.h>
+#include <gtest/gtest.h>
+
+using namespace CVC_NAMESPACE;
+
+class VolumeCodecTest : public ::testing::Test {
+protected:
+  void SetUp() override { register_volume_geometry_codecs(reg); }
+
+  state_codec_registry reg;
+  app ctx;
+};
+
+// ---- volume codec ----
+
+TEST_F(VolumeCodecTest, HasVolumeCodec) { EXPECT_TRUE(reg.has("cvc::volume")); }
+
+TEST_F(VolumeCodecTest, HasGeometryCodec) { EXPECT_TRUE(reg.has("cvc::geometry")); }
+
+TEST_F(VolumeCodecTest, VolumeCodecId) {
+  EXPECT_EQ(reg.codec_id_for("cvc::volume"), "cvc.volume.v1");
+}
+
+TEST_F(VolumeCodecTest, GeometryCodecId) {
+  EXPECT_EQ(reg.codec_id_for("cvc::geometry"), "cvc.geometry.v1");
+}
+
+TEST_F(VolumeCodecTest, VolumeRoundTrip_UChar) {
+  dimension d;
+  d.xdim = 4;
+  d.ydim = 4;
+  d.zdim = 4;
+  bounding_box bb(-1.0, -1.0, -1.0, 1.0, 1.0, 1.0);
+  volume vol(ctx, d, UChar, bb);
+  vol.desc("test_volume");
+
+  // Fill with known pattern.
+  for (uint64 z = 0; z < d.zdim; ++z)
+    for (uint64 y = 0; y < d.ydim; ++y)
+      for (uint64 x = 0; x < d.xdim; ++x)
+        vol(x, y, z, static_cast<double>((x + y * 4 + z * 16) % 256));
+
+  auto bytes = reg.encode("cvc::volume", boost::any(vol));
+  EXPECT_GT(bytes.size(), 0u);
+
+  auto decoded_any = reg.decode("cvc::volume", bytes);
+  ASSERT_TRUE(!decoded_any.empty());
+
+  auto decoded = boost::any_cast<volume>(decoded_any);
+  EXPECT_EQ(decoded.XDim(), 4u);
+  EXPECT_EQ(decoded.YDim(), 4u);
+  EXPECT_EQ(decoded.ZDim(), 4u);
+  EXPECT_EQ(decoded.voxelType(), UChar);
+  EXPECT_DOUBLE_EQ(decoded.XMin(), -1.0);
+  EXPECT_DOUBLE_EQ(decoded.XMax(), 1.0);
+  EXPECT_EQ(decoded.desc(), "test_volume");
+
+  for (uint64 z = 0; z < d.zdim; ++z)
+    for (uint64 y = 0; y < d.ydim; ++y)
+      for (uint64 x = 0; x < d.xdim; ++x)
+        EXPECT_DOUBLE_EQ(decoded(x, y, z), vol(x, y, z));
+}
+
+TEST_F(VolumeCodecTest, VolumeRoundTrip_Float) {
+  dimension d;
+  d.xdim = 8;
+  d.ydim = 8;
+  d.zdim = 8;
+  bounding_box bb(0, 0, 0, 10, 10, 10);
+  volume vol(ctx, d, Float, bb);
+  vol.desc("float_vol");
+
+  for (uint64 z = 0; z < d.zdim; ++z)
+    for (uint64 y = 0; y < d.ydim; ++y)
+      for (uint64 x = 0; x < d.xdim; ++x)
+        vol(x, y, z, x * 1.5 + y * 0.5 + z * 0.1);
+
+  auto bytes = reg.encode("cvc::volume", boost::any(vol));
+  auto decoded = boost::any_cast<volume>(reg.decode("cvc::volume", bytes));
+
+  EXPECT_EQ(decoded.XDim(), 8u);
+  EXPECT_EQ(decoded.voxelType(), Float);
+  EXPECT_DOUBLE_EQ(decoded.XMax(), 10.0);
+  EXPECT_EQ(decoded.desc(), "float_vol");
+
+  for (uint64 z = 0; z < d.zdim; ++z)
+    for (uint64 y = 0; y < d.ydim; ++y)
+      for (uint64 x = 0; x < d.xdim; ++x)
+        EXPECT_NEAR(decoded(x, y, z), vol(x, y, z), 1e-5);
+}
+
+TEST_F(VolumeCodecTest, VolumeEncodedSize) {
+  dimension d;
+  d.xdim = 4;
+  d.ydim = 4;
+  d.zdim = 4;
+  volume vol(ctx, d, UChar);
+  auto bytes = reg.encode("cvc::volume", boost::any(vol));
+
+  // Header: 4(magic) + 3*8(dims) + 4(vtype) + 6*8(bbox) + 4+7(desc="No Name") = 91
+  // Body: 4*4*4*1 = 64
+  // Total: 155
+  EXPECT_EQ(bytes.size(), 155u);
+}
+
+// ---- geometry codec ----
+
+TEST_F(VolumeCodecTest, GeometryRoundTrip_TriSurface) {
+  geometry geo(ctx);
+  geo.set_geometry_type(geometry::SURFACE_TRI);
+
+  auto &pts = geo.points();
+  pts.push_back({{0.0, 0.0, 0.0}});
+  pts.push_back({{1.0, 0.0, 0.0}});
+  pts.push_back({{0.0, 1.0, 0.0}});
+
+  auto &nrm = geo.normals();
+  nrm.push_back({{0.0, 0.0, 1.0}});
+  nrm.push_back({{0.0, 0.0, 1.0}});
+  nrm.push_back({{0.0, 0.0, 1.0}});
+
+  auto &clr = geo.colors();
+  clr.push_back({{1.0, 0.0, 0.0}});
+  clr.push_back({{0.0, 1.0, 0.0}});
+  clr.push_back({{0.0, 0.0, 1.0}});
+
+  auto &tri = geo.tris();
+  tri.push_back({{0, 1, 2}});
+
+  auto bytes = reg.encode("cvc::geometry", boost::any(geo));
+  EXPECT_GT(bytes.size(), 0u);
+
+  auto decoded = boost::any_cast<geometry>(reg.decode("cvc::geometry", bytes));
+  EXPECT_EQ(decoded.get_geometry_type(), geometry::SURFACE_TRI);
+  EXPECT_EQ(decoded.num_points(), 3u);
+  EXPECT_EQ(decoded.const_normals().size(), 3u);
+  EXPECT_EQ(decoded.const_colors().size(), 3u);
+  EXPECT_EQ(decoded.num_tris(), 1u);
+
+  EXPECT_DOUBLE_EQ(decoded.const_points()[1][0], 1.0);
+  EXPECT_DOUBLE_EQ(decoded.const_normals()[0][2], 1.0);
+  EXPECT_DOUBLE_EQ(decoded.const_colors()[2][2], 1.0);
+  EXPECT_EQ(decoded.const_tris()[0][2], 2u);
+}
+
+TEST_F(VolumeCodecTest, GeometryRoundTrip_TetVolume) {
+  geometry geo(ctx);
+  geo.set_geometry_type(geometry::VOLUME_TET);
+
+  auto &pts = geo.points();
+  pts.push_back({{0, 0, 0}});
+  pts.push_back({{1, 0, 0}});
+  pts.push_back({{0, 1, 0}});
+  pts.push_back({{0, 0, 1}});
+
+  auto &tet = geo.tets();
+  tet.push_back({{0, 1, 2, 3}});
+
+  auto bytes = reg.encode("cvc::geometry", boost::any(geo));
+  auto decoded = boost::any_cast<geometry>(reg.decode("cvc::geometry", bytes));
+
+  EXPECT_EQ(decoded.get_geometry_type(), geometry::VOLUME_TET);
+  EXPECT_EQ(decoded.num_points(), 4u);
+  EXPECT_EQ(decoded.num_tets(), 1u);
+  EXPECT_EQ(decoded.const_tets()[0][3], 3u);
+}
+
+TEST_F(VolumeCodecTest, GeometryRoundTrip_EmptyGeometry) {
+  geometry geo(ctx);
+  auto bytes = reg.encode("cvc::geometry", boost::any(geo));
+  auto decoded = boost::any_cast<geometry>(reg.decode("cvc::geometry", bytes));
+  EXPECT_EQ(decoded.num_points(), 0u);
+  EXPECT_EQ(decoded.num_tris(), 0u);
+}
+
+TEST_F(VolumeCodecTest, GeometryRoundTrip_Lines) {
+  geometry geo(ctx);
+  auto &pts = geo.points();
+  pts.push_back({{0, 0, 0}});
+  pts.push_back({{1, 1, 1}});
+
+  auto &lin = geo.lines();
+  lin.push_back({{0, 1}});
+
+  auto bytes = reg.encode("cvc::geometry", boost::any(geo));
+  auto decoded = boost::any_cast<geometry>(reg.decode("cvc::geometry", bytes));
+  EXPECT_EQ(decoded.const_lines().size(), 1u);
+  EXPECT_EQ(decoded.const_lines()[0][1], 1u);
+}
+
+TEST_F(VolumeCodecTest, RegistrationIdempotent) {
+  register_volume_geometry_codecs(reg);
+  register_volume_geometry_codecs(reg);
+  EXPECT_TRUE(reg.has("cvc::volume"));
+  EXPECT_TRUE(reg.has("cvc::geometry"));
+}


### PR DESCRIPTION
## Summary

Implements the four volume/geometry streaming features identified in the data transport efficiency analysis:

### 1. Volume/Geometry Codecs (`state_volume_codec.h/.cpp`)
- CVV1 wire format for `cvc::volume`: magic + dims + voxel_type + bbox + desc + raw voxels
- CVG1 wire format for `cvc::geometry`: magic + geom_type + counts + all vertex/element arrays
- Auto-registered in `state_cluster_shard` constructor alongside builtin codecs
- 12 tests covering UChar/Float round-trips, geometry surface/volume/empty/lines variants

### 2. Brick-Aware Manifests (`state_brick_manifest.h/.cpp`)
- CVB1 manifest format extending chunk manifests with spatial metadata (`brick_extent`)
- `state_brick_writer`: splits volumes into 3D brick grids, geometry into element-range chunks
- `state_brick_reader`: full reassembly (`get()`), single brick (`get_brick()`), spatial subregion (`get_region()`)
- `bricks_in_region()`: AABB overlap query returning matching chunk indices
- 10 tests covering serialize round-trip, spatial queries, brick write/read, subregion scatter, compression

### 3. FetchChunk RPC (`state_transport.h`, `state_transport_inproc.h/.cpp`)
- `fetch_chunk(digest, callback)` and `fetch_chunks(digests, callback)` virtual methods on `state_transport`
- `state_transport_inproc` implementation via blob store lookup with `set_blob_store()`

### 4. Lazy Hydration API (`state_data_hydrator.h/.cpp`)
- `request(path, manifest_digest, type_name, target_state)` triggers hydration pipeline
- Manifest fetch → chunk fetch → reassemble → codec decode → state node data install
- `wait(path, timeout)`, `is_hydrated(path)`, `cancel(path)`, `retry_pending()`
- `on_hydrated(callback)` for async notification
- Diagnostics: total_hydrated, total_failed, total_chunks_fetched
- 13 tests covering local/remote hydration, state installation, callbacks, bad codec, retry

### Test Results
All 35 new tests pass (12 + 10 + 13).