### PR TITLE
feat: distributed_state_session convenience API

### DIFF
--- a/inc/cvc/distributed_state_session.h
+++ b/inc/cvc/distributed_state_session.h
@@ -1,0 +1,168 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+
+  This file is part of libcvc.
+
+  libcvc is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+*/
+
+#ifndef __CVC_DISTRIBUTED_STATE_SESSION_H__
+#define __CVC_DISTRIBUTED_STATE_SESSION_H__
+
+#include <atomic>
+#include <cstdint>
+#include <cvc/namespace.h>
+#include <cvc/state_blob_store.h>
+#include <cvc/state_cluster_shard.h>
+#include <cvc/state_compression_registry.h>
+#include <cvc/state_distributed_admin.h>
+#include <cvc/state_transport.h>
+#include <cvc/state_transport_inproc.h>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace CVC_NAMESPACE {
+
+class app;
+
+// ----------------
+// Sync modes for per-path mount points.
+// ----------------
+enum class sync_mode {
+  read_only,     // mirror remote writes, reject local writes
+  read_write,    // bidirectional replication
+  authoritative, // this node is the authority for the prefix
+  delegated      // prefix is delegated to a foreign cluster
+};
+
+// ----------------
+// A single mount point: path prefix + sync mode.
+// ----------------
+struct distributed_state_mount {
+  std::string path;
+  sync_mode mode = sync_mode::read_write;
+};
+
+// ----------------
+// Target for delegation: remote cluster id + endpoint.
+// ----------------
+struct delegation_target {
+  std::string cluster_id;
+  std::string endpoint;
+  std::uint64_t lease_duration_ns = 0; // 0 = infinite
+};
+
+// ----------------
+// Transport selection.
+// ----------------
+enum class transport_kind {
+  inproc, // in-process (testing / single-process multi-tree)
+  ipc,    // unix domain sockets (same-host multi-process)
+  grpc    // gRPC (networked)
+};
+
+// ----------------
+// Configuration for a distributed state session.
+// ----------------
+struct distributed_state_config {
+  std::string cluster_id;
+  std::string node_id;
+  std::string root_path; // subtree to replicate ("" = whole tree)
+
+  transport_kind transport = transport_kind::inproc;
+  std::string listen_address;     // for ipc/grpc: socket path or host:port
+  std::vector<std::string> seeds; // peer endpoints to connect to
+  std::vector<distributed_state_mount> mounts;
+
+  bool enforce_authority = false;
+  bool enforce_write_policy = false;
+  bool enforce_delegation = false;
+  bool resolve_conflicts = false;
+  bool enforce_interest = false;
+
+  std::uint32_t pump_interval_ms = 10; // background pump loop interval (0 = no pump thread)
+};
+
+// ----------------
+// cvc::distributed_state_session
+// ----------------
+// Purpose:
+//   Convenience wrapper that assembles and wires together all the
+//   distributed state components (shard, transport, blob store,
+//   compression, admin) from a single config struct. Provides a
+//   high-level API for joining a cluster, managing sync paths, and
+//   delegating subtrees.
+//
+// Lifecycle:
+//   1. join(app, config) creates the session, starts the transport,
+//      connects to seeds, and begins background pumping.
+//   2. sync_path() / delegate() / undelegate() adjust replication.
+//   3. stop() tears everything down in the correct order.
+//   4. Destructor calls stop() if not already called.
+//
+// Threading:
+//   All public methods are thread-safe.
+//
+class distributed_state_session {
+public:
+  ~distributed_state_session();
+
+  distributed_state_session(const distributed_state_session &) = delete;
+  distributed_state_session &operator=(const distributed_state_session &) = delete;
+
+  // Create and start a session.
+  static std::shared_ptr<distributed_state_session> join(app &ctx,
+                                                         const distributed_state_config &config);
+
+  // Graceful shutdown: detach shard, stop transport, join pump thread.
+  void stop();
+
+  // Whether the session has been stopped.
+  bool is_running() const noexcept { return _running.load(std::memory_order_acquire); }
+
+  // Add a sync path at runtime.
+  void sync_path(const std::string &path, sync_mode mode = sync_mode::read_write);
+
+  // Delegate a subtree to a remote cluster.
+  void delegate(const std::string &path, const delegation_target &target);
+
+  // Revoke a delegation.
+  void undelegate(const std::string &path);
+
+  // Access underlying components for advanced usage.
+  state_cluster_shard &shard() noexcept { return *_shard; }
+  state_transport &transport() noexcept { return *_transport; }
+  state_blob_store &blob_store() noexcept { return *_blob_store; }
+  state_distributed_admin &admin() noexcept { return *_admin; }
+
+  // Diagnostics.
+  const std::string &cluster_id() const noexcept { return _config.cluster_id; }
+  const std::string &node_id() const noexcept { return _config.node_id; }
+  std::uint64_t pump_cycles() const noexcept {
+    return _pump_cycles.load(std::memory_order_relaxed);
+  }
+
+private:
+  explicit distributed_state_session(const distributed_state_config &config);
+
+  void pump_loop();
+
+  distributed_state_config _config;
+
+  std::unique_ptr<state_cluster_shard> _shard;
+  std::unique_ptr<state_transport> _transport;
+  std::unique_ptr<memory_state_blob_store> _blob_store;
+  std::unique_ptr<state_distributed_admin> _admin;
+
+  std::thread _pump_thread;
+  std::atomic<bool> _running{false};
+  std::atomic<std::uint64_t> _pump_cycles{0};
+};
+
+} // namespace CVC_NAMESPACE
+
+#endif // __CVC_DISTRIBUTED_STATE_SESSION_H__

--- a/src/cvc/CMakeLists.txt
+++ b/src/cvc/CMakeLists.txt
@@ -44,6 +44,7 @@ set(INCLUDE_FILES
   ../../inc/cvc/state_volume_codec.h
   ../../inc/cvc/state_brick_manifest.h
   ../../inc/cvc/state_data_hydrator.h
+  ../../inc/cvc/distributed_state_session.h
   ../../inc/cvc/state_transport.h
   ../../inc/cvc/state_transport_inproc.h
   ../../inc/cvc/state_transport_ipc.h
@@ -99,6 +100,7 @@ set(SOURCE_FILES
   state_volume_codec.cpp
   state_brick_manifest.cpp
   state_data_hydrator.cpp
+  distributed_state_session.cpp
   state_message.cpp
   utility.cpp
   cuda_utils.cpp

--- a/src/cvc/distributed_state_session.cpp
+++ b/src/cvc/distributed_state_session.cpp
@@ -1,0 +1,192 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+
+  This file is part of libcvc.
+
+  libcvc is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+*/
+
+#include <chrono>
+#include <cvc/distributed_state_session.h>
+#include <cvc/state_transport_inproc.h>
+#ifndef _WIN32
+#include <cvc/state_transport_ipc.h>
+#endif
+#ifdef CVC_ENABLE_GRPC
+#include <cvc/state_transport_grpc.h>
+#endif
+
+namespace CVC_NAMESPACE {
+
+distributed_state_session::distributed_state_session(const distributed_state_config &config)
+    : _config(config) {}
+
+distributed_state_session::~distributed_state_session() { stop(); }
+
+std::shared_ptr<distributed_state_session>
+distributed_state_session::join(app &ctx, const distributed_state_config &config) {
+  // Use shared_ptr with private ctor via raw-new + shared_ptr(raw).
+  auto session = std::shared_ptr<distributed_state_session>(new distributed_state_session(config));
+
+  // 1. Create blob store.
+  session->_blob_store = std::make_unique<memory_state_blob_store>();
+
+  // 2. Create transport.
+  switch (config.transport) {
+  case transport_kind::inproc: {
+    session->_transport = std::make_unique<state_transport_inproc>();
+    break;
+  }
+  case transport_kind::ipc: {
+#ifndef _WIN32
+    auto ipc = std::make_unique<state_transport_ipc>();
+    if (!config.listen_address.empty())
+      ipc->start(config.listen_address, config.node_id, config.cluster_id);
+    session->_transport = std::move(ipc);
+#else
+    throw std::runtime_error(
+        "distributed_state_session: IPC transport is not available on Windows");
+#endif
+    break;
+  }
+  case transport_kind::grpc: {
+#ifdef CVC_ENABLE_GRPC
+    auto grpc = std::make_unique<state_transport_grpc>();
+    if (!config.listen_address.empty())
+      grpc->start(config.listen_address, config.node_id, config.cluster_id);
+    session->_transport = std::move(grpc);
+#else
+    throw std::runtime_error(
+        "distributed_state_session: gRPC transport requested but CVC_ENABLE_GRPC is not defined");
+#endif
+    break;
+  }
+  }
+
+  // 3. Connect to seed peers.
+  for (const auto &seed : config.seeds) {
+#ifndef _WIN32
+    if (auto *ipc = dynamic_cast<state_transport_ipc *>(session->_transport.get()))
+      ipc->connect_to_peer(seed);
+#endif
+#ifdef CVC_ENABLE_GRPC
+    if (auto *grpc = dynamic_cast<state_transport_grpc *>(session->_transport.get()))
+      grpc->connect_to_peer(seed);
+#endif
+  }
+
+  // 4. Create shard.
+  session->_shard = std::make_unique<state_cluster_shard>(ctx, config.cluster_id, config.node_id,
+                                                          config.root_path);
+
+  // 5. Configure shard policies.
+  session->_shard->set_enforce_authority(config.enforce_authority);
+  session->_shard->set_enforce_write_policy(config.enforce_write_policy);
+  session->_shard->set_enforce_delegation(config.enforce_delegation);
+  session->_shard->set_resolve_conflicts(config.resolve_conflicts);
+  session->_shard->set_enforce_interest(config.enforce_interest);
+
+  // 6. Apply mounts.
+  for (const auto &mount : config.mounts) {
+    session->_shard->add_interest(mount.path);
+
+    switch (mount.mode) {
+    case sync_mode::authoritative:
+      session->_shard->write_policy().allow(mount.path, {config.node_id});
+      break;
+    case sync_mode::read_only:
+      // Interest registered but no write policy entry → reads only.
+      break;
+    case sync_mode::read_write:
+    case sync_mode::delegated:
+      break;
+    }
+  }
+
+  // 7. Wire transport ↔ shard.
+  session->_transport->register_shard(session->_shard.get());
+  session->_shard->set_transport(session->_transport.get());
+
+  // 8. Create admin facade.
+  session->_admin = std::make_unique<state_distributed_admin>();
+  session->_admin->attach_shard(session->_shard.get());
+  session->_admin->attach_blob_store(session->_blob_store.get());
+
+  // 9. Attach shard (start observing state changes).
+  session->_shard->attach();
+  session->_shard->install_as_default();
+
+  // 10. Start pump thread.
+  session->_running.store(true, std::memory_order_release);
+  if (config.pump_interval_ms > 0) {
+    session->_pump_thread = std::thread([session]() { session->pump_loop(); });
+  }
+
+  return session;
+}
+
+void distributed_state_session::stop() {
+  if (!_running.exchange(false, std::memory_order_acq_rel))
+    return;
+
+  // 1. Join pump thread.
+  if (_pump_thread.joinable())
+    _pump_thread.join();
+
+  // 2. Detach shard.
+  if (_shard) {
+    _shard->uninstall_as_default();
+    _shard->detach();
+  }
+
+  // 3. Unregister shard from transport.
+  if (_transport && _shard)
+    _transport->unregister_shard(_shard.get());
+
+    // 4. Stop transport.
+#ifndef _WIN32
+  if (auto *ipc = dynamic_cast<state_transport_ipc *>(_transport.get()))
+    ipc->stop();
+#endif
+#ifdef CVC_ENABLE_GRPC
+  if (auto *grpc = dynamic_cast<state_transport_grpc *>(_transport.get()))
+    grpc->stop();
+#endif
+}
+
+void distributed_state_session::sync_path(const std::string &path, sync_mode mode) {
+  _shard->add_interest(path);
+
+  switch (mode) {
+  case sync_mode::authoritative:
+    _shard->write_policy().allow(path, {_config.node_id});
+    break;
+  case sync_mode::read_only:
+  case sync_mode::read_write:
+  case sync_mode::delegated:
+    break;
+  }
+}
+
+void distributed_state_session::delegate(const std::string &path, const delegation_target &target) {
+  _shard->publish_delegation(path, target.cluster_id, target.endpoint, target.lease_duration_ns);
+}
+
+void distributed_state_session::undelegate(const std::string &path) {
+  _shard->publish_revocation(path);
+}
+
+void distributed_state_session::pump_loop() {
+  const auto interval = std::chrono::milliseconds(_config.pump_interval_ms);
+  while (_running.load(std::memory_order_acquire)) {
+    _transport->pump_all();
+    _pump_cycles.fetch_add(1, std::memory_order_relaxed);
+    std::this_thread::sleep_for(interval);
+  }
+  // Final drain.
+  _transport->pump_all();
+}
+
+} // namespace CVC_NAMESPACE

--- a/src/cvc/tests/CMakeLists.txt
+++ b/src/cvc/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(state_delta_codec_test state_delta_codec_test.cpp)
 add_executable(state_volume_codec_test state_volume_codec_test.cpp)
 add_executable(state_brick_manifest_test state_brick_manifest_test.cpp)
 add_executable(state_data_hydrator_test state_data_hydrator_test.cpp)
+add_executable(distributed_state_session_test distributed_state_session_test.cpp)
 if(CVC_ENABLE_GRPC)
   add_executable(state_transport_grpc_test state_transport_grpc_test.cpp)
 endif()
@@ -88,6 +89,7 @@ set(TEST_TARGETS
   state_volume_codec_test
   state_brick_manifest_test
   state_data_hydrator_test
+  distributed_state_session_test
   voxels_test
   volume_test
   procedural_geometry_test
@@ -457,6 +459,13 @@ target_link_libraries(state_delta_codec_test
     GTest::gtest_main
 )
 
+target_link_libraries(distributed_state_session_test
+  PRIVATE
+    cvc
+    GTest::gtest
+    GTest::gtest_main
+)
+
 if(TARGET state_transport_grpc_test)
   target_link_libraries(state_transport_grpc_test
     PRIVATE
@@ -520,6 +529,7 @@ target_compile_features(state_delta_codec_test PRIVATE cxx_std_17)
 target_compile_features(state_volume_codec_test PRIVATE cxx_std_17)
 target_compile_features(state_brick_manifest_test PRIVATE cxx_std_17)
 target_compile_features(state_data_hydrator_test PRIVATE cxx_std_17)
+target_compile_features(distributed_state_session_test PRIVATE cxx_std_17)
 
 # Only build HDF5-dependent tests when HDF5 support is enabled
 if(CVC_USING_HDF5 AND NOT CVC_HDF5_DISABLED)
@@ -614,6 +624,7 @@ gtest_discover_tests(state_delta_codec_test)
 gtest_discover_tests(state_volume_codec_test)
 gtest_discover_tests(state_brick_manifest_test)
 gtest_discover_tests(state_data_hydrator_test)
+gtest_discover_tests(distributed_state_session_test)
 if(TARGET state_transport_grpc_test)
   gtest_discover_tests(state_transport_grpc_test)
 endif()

--- a/src/cvc/tests/distributed_state_session_test.cpp
+++ b/src/cvc/tests/distributed_state_session_test.cpp
@@ -1,0 +1,241 @@
+/*
+  Copyright 2026 The University of Texas at Austin
+  Tests for the distributed_state_session convenience API.
+*/
+
+#include <chrono>
+#include <cvc/app.h>
+#include <cvc/distributed_state_session.h>
+#include <cvc/state.h>
+#include <gtest/gtest.h>
+#include <string>
+#include <thread>
+
+using namespace CVC_NAMESPACE;
+
+// ---- basic lifecycle ----
+
+TEST(DistributedStateSession, JoinAndStop) {
+  app a;
+  distributed_state_config cfg;
+  cfg.cluster_id = "test_cluster";
+  cfg.node_id = "node1";
+  cfg.pump_interval_ms = 0; // no pump thread
+
+  auto session = distributed_state_session::join(a, cfg);
+  ASSERT_NE(session, nullptr);
+  EXPECT_TRUE(session->is_running());
+  EXPECT_EQ(session->cluster_id(), "test_cluster");
+  EXPECT_EQ(session->node_id(), "node1");
+
+  session->stop();
+  EXPECT_FALSE(session->is_running());
+}
+
+TEST(DistributedStateSession, DestructorCallsStop) {
+  app a;
+  distributed_state_config cfg;
+  cfg.cluster_id = "c";
+  cfg.node_id = "n";
+  cfg.pump_interval_ms = 0;
+
+  { auto session = distributed_state_session::join(a, cfg); }
+  // If destructor didn't call stop(), this would hang or crash.
+}
+
+TEST(DistributedStateSession, DoubleStopIsSafe) {
+  app a;
+  distributed_state_config cfg;
+  cfg.cluster_id = "c";
+  cfg.node_id = "n";
+  cfg.pump_interval_ms = 0;
+
+  auto session = distributed_state_session::join(a, cfg);
+  session->stop();
+  session->stop(); // no-op
+  EXPECT_FALSE(session->is_running());
+}
+
+// ---- component access ----
+
+TEST(DistributedStateSession, ComponentAccessors) {
+  app a;
+  distributed_state_config cfg;
+  cfg.cluster_id = "cluster1";
+  cfg.node_id = "nodeA";
+  cfg.pump_interval_ms = 0;
+
+  auto session = distributed_state_session::join(a, cfg);
+  EXPECT_EQ(&session->shard().codecs(), &session->shard().codecs());
+  EXPECT_EQ(session->shard().cluster_id(), "cluster1");
+  EXPECT_EQ(session->shard().local_node_id(), "nodeA");
+  session->stop();
+}
+
+// ---- two-node inproc replication ----
+
+TEST(DistributedStateSession, TwoNodeInprocReplication) {
+  app a1, a2;
+
+  // For inproc replication, we need a shared transport.
+  state_transport_inproc shared_transport;
+
+  state_cluster_shard s1(a1, "cluster", "node1");
+  state_cluster_shard s2(a2, "cluster", "node2");
+
+  s1.attach();
+  s2.attach();
+
+  shared_transport.register_shard(&s1);
+  shared_transport.register_shard(&s2);
+
+  // First value() on a new child is consumed by creation, so set twice.
+  state::instance(a1)("test.value").value(std::string("initial"));
+  state::instance(a1)("test.value").value(std::string("hello_from_node1"));
+
+  // Pump to propagate.
+  shared_transport.pump_all();
+
+  // Read on node 2.
+  EXPECT_EQ(state::instance(a2)("test.value").value(), "hello_from_node1");
+
+  shared_transport.unregister_shard(&s1);
+  shared_transport.unregister_shard(&s2);
+  s1.detach();
+  s2.detach();
+}
+
+// ---- pump thread ----
+
+TEST(DistributedStateSession, PumpThreadRuns) {
+  app a;
+  distributed_state_config cfg;
+  cfg.cluster_id = "c";
+  cfg.node_id = "n";
+  cfg.pump_interval_ms = 5;
+
+  auto session = distributed_state_session::join(a, cfg);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_GT(session->pump_cycles(), 0u);
+  session->stop();
+}
+
+// ---- sync_path ----
+
+TEST(DistributedStateSession, SyncPath) {
+  app a;
+  distributed_state_config cfg;
+  cfg.cluster_id = "c";
+  cfg.node_id = "n";
+  cfg.pump_interval_ms = 0;
+  cfg.enforce_interest = true;
+
+  auto session = distributed_state_session::join(a, cfg);
+  // Before adding interest, path should not be of interest.
+  EXPECT_FALSE(session->shard().path_is_of_interest("new.path"));
+
+  session->sync_path("new.path", sync_mode::read_write);
+  EXPECT_TRUE(session->shard().path_is_of_interest("new.path"));
+  session->stop();
+}
+
+// ---- config mounts ----
+
+TEST(DistributedStateSession, MountsApplied) {
+  app a;
+  distributed_state_config cfg;
+  cfg.cluster_id = "c";
+  cfg.node_id = "n";
+  cfg.pump_interval_ms = 0;
+  cfg.enforce_interest = true;
+  cfg.mounts = {{"scene", sync_mode::read_write}, {"data", sync_mode::read_only}};
+
+  auto session = distributed_state_session::join(a, cfg);
+  EXPECT_TRUE(session->shard().path_is_of_interest("scene"));
+  EXPECT_TRUE(session->shard().path_is_of_interest("scene.geometry"));
+  EXPECT_TRUE(session->shard().path_is_of_interest("data"));
+  EXPECT_TRUE(session->shard().path_is_of_interest("data.volume"));
+  session->stop();
+}
+
+// ---- delegation ----
+
+TEST(DistributedStateSession, DelegateAndUndelegate) {
+  app a;
+  distributed_state_config cfg;
+  cfg.cluster_id = "local";
+  cfg.node_id = "n";
+  cfg.pump_interval_ms = 0;
+
+  auto session = distributed_state_session::join(a, cfg);
+
+  delegation_target tgt;
+  tgt.cluster_id = "remote";
+  tgt.endpoint = "remote:50051";
+  session->delegate("remote.data", tgt);
+
+  // The delegation should be visible in the shard's delegation manager.
+  auto decision = session->shard().route_path("remote.data.volume");
+  EXPECT_EQ(decision.cluster_id, "remote");
+
+  session->undelegate("remote.data");
+  session->stop();
+}
+
+// ---- policy configuration ----
+
+TEST(DistributedStateSession, PolicyFlags) {
+  app a;
+  distributed_state_config cfg;
+  cfg.cluster_id = "c";
+  cfg.node_id = "n";
+  cfg.pump_interval_ms = 0;
+  cfg.enforce_authority = true;
+  cfg.enforce_write_policy = true;
+  cfg.enforce_delegation = true;
+  cfg.resolve_conflicts = true;
+  cfg.enforce_interest = true;
+
+  auto session = distributed_state_session::join(a, cfg);
+  EXPECT_TRUE(session->shard().enforce_authority());
+  EXPECT_TRUE(session->shard().enforce_write_policy());
+  EXPECT_TRUE(session->shard().enforce_delegation());
+  EXPECT_TRUE(session->shard().resolve_conflicts());
+  EXPECT_TRUE(session->shard().enforce_interest());
+  session->stop();
+}
+
+// ---- admin facade ----
+
+TEST(DistributedStateSession, AdminAttached) {
+  app a;
+  distributed_state_config cfg;
+  cfg.cluster_id = "c";
+  cfg.node_id = "n";
+  cfg.pump_interval_ms = 0;
+
+  auto session = distributed_state_session::join(a, cfg);
+  // Admin should be accessible; verify it doesn't crash.
+  auto &admin = session->admin();
+  (void)admin;
+  session->stop();
+}
+
+// ---- IPC transport selection ----
+
+TEST(DistributedStateSession, IpcTransportCreation) {
+  app a;
+  distributed_state_config cfg;
+  cfg.cluster_id = "c";
+  cfg.node_id = "n";
+  cfg.transport = transport_kind::ipc;
+  cfg.listen_address = "/tmp/cvc_test_session_" + std::to_string(getpid()) + ".sock";
+  cfg.pump_interval_ms = 0;
+
+  auto session = distributed_state_session::join(a, cfg);
+  EXPECT_TRUE(session->is_running());
+  session->stop();
+
+  // Clean up socket.
+  ::unlink(cfg.listen_address.c_str());
+}

--- a/src/cvc/tests/distributed_state_session_test.cpp
+++ b/src/cvc/tests/distributed_state_session_test.cpp
@@ -223,6 +223,7 @@ TEST(DistributedStateSession, AdminAttached) {
 
 // ---- IPC transport selection ----
 
+#ifndef _WIN32
 TEST(DistributedStateSession, IpcTransportCreation) {
   app a;
   distributed_state_config cfg;
@@ -239,3 +240,4 @@ TEST(DistributedStateSession, IpcTransportCreation) {
   // Clean up socket.
   ::unlink(cfg.listen_address.c_str());
 }
+#endif // !_WIN32


### PR DESCRIPTION
## Summary

Implements the `distributed_state_session` high-level convenience API defined in the distributed state plan document. This class wires together all distributed state components from a single `distributed_state_config` struct, eliminating the need to manually assemble shards, transports, blob stores, and admin facades.

### New Files
- **`distributed_state_session.h`**: Header with `distributed_state_config`, `sync_mode`, `delegation_target`, `transport_kind` enums, and the session class
- **`distributed_state_session.cpp`**: Implementation of `join()`, `stop()`, `sync_path()`, `delegate()`, `undelegate()`, and the background pump loop

### API
```cpp
auto session = distributed_state_session::join(app, {
  .cluster_id = "my_cluster",
  .node_id = "node1",
  .transport = transport_kind::grpc,
  .listen_address = "0.0.0.0:50051",
  .seeds = {"peer1:50051", "peer2:50051"},
  .mounts = {{"scene", sync_mode::read_write}},
  .pump_interval_ms = 10,
});

session->sync_path("data.volume", sync_mode::read_only);
session->delegate("remote.data", {"other_cluster", "host:50051"});
session->stop();
```

### What `join()` Wires Together
1. `memory_state_blob_store`
2. Transport (inproc / IPC / gRPC based on config)
3. Seed peer connections
4. `state_cluster_shard` with policy flags (authority, write policy, delegation, conflicts, interest)
5. Mount points → interest filters + write policy entries
6. Transport ↔ shard registration
7. `state_distributed_admin` facade
8. Background pump thread (configurable interval)

### Tests
12 new tests:
- Lifecycle: join/stop, destructor safety, double-stop idempotency
- Component access and policy flag propagation
- Two-node inproc replication (write → pump → read on peer)
- Background pump thread verification
- Runtime sync_path, mount application
- Delegation and undelegation
- Admin facade attachment
- IPC transport creation