### PR TITLE
fix(release): macOS archive missing libcvc dylib and cmake configs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build \
             libboost-all-dev libhdf5-dev libfftw3-dev libgsl-dev \
-            libmagick++-dev libcgal-dev liblog4cplus-dev
+            libmagick++-dev libcgal-dev liblog4cplus-dev libzstd-dev
 
       # CUDA toolkit so the shipped artifacts can offload to NVIDIA GPUs
       # at runtime when an NVIDIA driver is present. cudart is linked
@@ -486,14 +486,14 @@ jobs:
       - name: Install dependencies (libcvc)
         if: matrix.kind == 'libcvc'
         run: |
-          brew install cmake ninja boost hdf5 fftw gsl imagemagick cgal log4cplus
+          brew install cmake ninja boost hdf5 fftw gsl imagemagick cgal log4cplus zstd
           echo "BOOST_ROOT=$(brew --prefix boost)" >> $GITHUB_ENV
           echo "CMAKE_PREFIX_PATH=$(brew --prefix boost):$(brew --prefix hdf5)" >> $GITHUB_ENV
 
       - name: Install dependencies (volrover3)
         if: matrix.kind == 'volrover3'
         run: |
-          brew install cmake ninja boost hdf5 fftw gsl imagemagick qt@6 vtk cgal
+          brew install cmake ninja boost hdf5 fftw gsl imagemagick qt@6 vtk cgal zstd
           echo "BOOST_ROOT=$(brew --prefix boost)" >> $GITHUB_ENV
           echo "CMAKE_PREFIX_PATH=$(brew --prefix boost):$(brew --prefix qt@6):$(brew --prefix hdf5)" >> $GITHUB_ENV
           echo "$(brew --prefix qt@6)/bin" >> $GITHUB_PATH
@@ -602,7 +602,7 @@ jobs:
             for dy in "$DIST"/lib/libcvc*.dylib; do
               [ -e "$dy" ] || continue
               [ -L "$dy" ] && continue
-              dylibbundler -od -b -x "$dy" -d "$DIST/lib" -p '@loader_path/' -of -cd "${BUNDLER_SEARCH[@]}" </dev/null || true
+              dylibbundler -b -x "$dy" -d "$DIST/lib" -p '@loader_path/' -of -cd "${BUNDLER_SEARCH[@]}" </dev/null || true
             done
           else
             # Static flavour: just copy the .a archives. No install_name


### PR DESCRIPTION
## Problem

The macOS release archives from v3.2.3 are missing `libcvc.dylib` (all variants: `.3.0.dylib`, `.3.dylib`, `.dylib`) and the CMake package config files (`cvcTargets.cmake`, `cvcConfig.cmake`, etc). This causes downstream consumers (TexMol, MolSurf, F2Dock) to fail at configure time with `find_package(cvc)` unable to locate the library.

## Root Cause

The `dylibbundler -od` flag in the release workflow's "Stage libcvc + bundle deps" step **erases and recreates the output directory** before copying transitive dependency dylibs. Since the output directory (`-d $DIST/lib`) is the same directory where `cmake --install` already placed:
- `libcvc.3.0.dylib`, `libcvc.3.dylib`, `libcvc.dylib`
- `cmake/cvc/cvcTargets.cmake`, `cvcTargets-release.cmake`
- `cmake/cvc/cvcConfig.cmake`, `cvcConfigVersion.cmake`

…the `-od` flag nukes all these files, then only repopulates with the bundled dependency dylibs (boost, hdf5, fftw, etc).

Evidence from the v3.2.3 release CI logs:
```
* Erasing old output directory .../libcvc-3.2.1-macos-arm64-release/lib/
    rm -r ".../libcvc-3.2.1-macos-arm64-release/lib/"
* Creating output directory .../libcvc-3.2.1-macos-arm64-release/lib/
    mkdir -p ".../libcvc-3.2.1-macos-arm64-release/lib/"
```

## Fix

- Remove `-od` flag from `dylibbundler` invocation. The `-of` (overwrite files) flag already handles the case where a dependency file pre-exists in the output dir.
- Add `zstd` to `brew install` and `apt-get install` lines (matching the CI fix from PR #89).

## Testing

After merge, tag v3.2.4 to produce corrected release archives. The macOS archives should then contain:
- `lib/libcvc.3.0.dylib` (the actual library)
- `lib/libcvc.3.dylib` → symlink
- `lib/libcvc.dylib` → symlink
- `lib/cmake/cvc/cvcConfig.cmake`
- `lib/cmake/cvc/cvcTargets.cmake`
- All bundled dependency dylibs (unchanged)