### PR TITLE
chore(release): bump project VERSION to 3.2.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 # First declare project with C and CXX to initialize CMake properly
 project(libcvc
-  VERSION 3.2.1
+  VERSION 3.2.4
   DESCRIPTION "Computational Visualization Center library from VolumeRover package"
   LANGUAGES C CXX
 )


### PR DESCRIPTION
Bumps project VERSION to 3.2.4 for a new release.

## Changelog since v3.2.3

- **fix(release):** macOS archive now correctly includes libcvc.dylib and cmake config files (#90)
  - dylibbundler `-od` flag was erasing the install directory before repopulating with deps
- **fix(ci):** zstd links correctly on macOS via IMPORTED_TARGET + brew install (#89)
- **feat:** file-backed blob store + multi-process IPC integration test (#88)
- **feat:** automatic cluster membership lifecycle — Phase 10 (#87)
- **feat(state):** per-node telemetry, cluster aggregator, routing feedback — Phase 9 (#83)
- **feat:** distributed state gap closure — 16 items (#89)

## Purpose

This fixes the known issue where the v3.2.3 macOS release archive was missing the libcvc dylib and cmake config files, breaking downstream consumers (e.g., TexMol macOS CI).