### PR TITLE
fix: portable cmake exports and C++17 compat

### DIFF
--- a/CMake/SetupBoost.cmake
+++ b/CMake/SetupBoost.cmake
@@ -26,14 +26,19 @@ function(SetupBoost TargetName)
     message(STATUS "Boost include dirs: ${Boost_INCLUDE_DIRS}")
     message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
     
-    # Use modern target-based approach. Wrap each include dir in
-    # $<BUILD_INTERFACE:...> so a bundled toolchain (e.g. libcvc-deps
-    # under a parent project's build tree) doesn't leak a build-dir path
-    # into the installed cvc target's INTERFACE_INCLUDE_DIRECTORIES.
-    foreach(_boost_inc IN LISTS Boost_INCLUDE_DIRS)
-      target_include_directories(${TargetName} PUBLIC "$<BUILD_INTERFACE:${_boost_inc}>")
+    # Use modern imported targets so that the installed cvc export file
+    # references Boost::thread etc. instead of hard-coded absolute paths.
+    # Wrap each include dir in $<BUILD_INTERFACE:...> so a bundled
+    # toolchain (e.g. libcvc-deps under a parent project's build tree)
+    # does not leak a build-dir path into the installed cvc target's
+    # INTERFACE_INCLUDE_DIRECTORIES.
+    set(_boost_targets Boost::thread Boost::date_time Boost::regex Boost::filesystem)
+    foreach(_bt IN ITEMS Boost::system Boost::chrono)
+      if(TARGET ${_bt})
+        list(APPEND _boost_targets ${_bt})
+      endif()
     endforeach()
-    target_link_libraries(${TargetName} PUBLIC ${Boost_LIBRARIES})
+    target_link_libraries(${TargetName} PUBLIC ${_boost_targets})
     
     # Platform-specific definitions
     target_compile_definitions(${TargetName} PUBLIC BOOST_ALL_DYN_LINK)

--- a/CMake/cvcConfig.cmake.in
+++ b/CMake/cvcConfig.cmake.in
@@ -5,39 +5,56 @@ include(CMakeFindDependencyMacro)
 # Required dependencies
 find_dependency(Boost COMPONENTS thread date_time regex filesystem system chrono)
 
-# Optional dependencies (only required if libcvc was built with them)
+# ---------------------------------------------------------------------------
+# Optional dependencies — only required if libcvc was built with them.
+# Each guard checks the build-time flag baked into this config file.
+# If the dependency is not found on the consumer system the imported
+# target will still load; the consumer just won't be able to use the
+# features that need the missing library at link time.
+# ---------------------------------------------------------------------------
+
 if(NOT @DISABLE_CGAL@)
-  find_dependency(CGAL CONFIG)
+  find_package(CGAL CONFIG QUIET)
 endif()
 
 if(@CVC_USING_HDF5@)
-  find_dependency(HDF5 COMPONENTS C CXX)
+  find_package(HDF5 COMPONENTS C CXX QUIET)
 endif()
 
 if(@CVC_ENABLE_OPENMP@)
-  find_dependency(OpenMP)
+  find_package(OpenMP QUIET)
 endif()
 
 if(@CVC_ENABLE_IMAGEMAGICK@)
-  find_dependency(ImageMagick COMPONENTS Magick++ MagickCore)
+  find_package(ImageMagick COMPONENTS Magick++ MagickCore QUIET)
 endif()
 
 if(@CVC_ENABLE_FFTW@)
-  find_dependency(PkgConfig)
+  find_package(PkgConfig QUIET)
   if(PkgConfig_FOUND)
-    pkg_check_modules(FFTW3 QUIET fftw3)
+    pkg_check_modules(FFTW3 QUIET IMPORTED_TARGET fftw3)
   endif()
   if(NOT FFTW3_FOUND)
     find_path(FFTW3_INCLUDE_DIRS fftw3.h)
     find_library(FFTW3_LIBRARIES NAMES fftw3)
+    if(FFTW3_INCLUDE_DIRS AND FFTW3_LIBRARIES AND NOT TARGET PkgConfig::FFTW3)
+      add_library(PkgConfig::FFTW3 INTERFACE IMPORTED)
+      set_target_properties(PkgConfig::FFTW3 PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${FFTW3_INCLUDE_DIRS}"
+        INTERFACE_LINK_LIBRARIES "${FFTW3_LIBRARIES}")
+    endif()
   endif()
+endif()
+
+if(@CVC_USING_IMOD_MRC@)
+  find_package(libiimod CONFIG QUIET)
 endif()
 
 # CUDA: when libcvc was built with CUDA support its INTERFACE links the
 # CUDA::cudart imported target, so consumers need CUDAToolkit imported
 # before cvcTargets.cmake is read.
 if(@CVC_ENABLE_CUDA@)
-  find_dependency(CUDAToolkit)
+  find_package(CUDAToolkit QUIET)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/cvcTargets.cmake")

--- a/cvc-requirements.yaml
+++ b/cvc-requirements.yaml
@@ -1,0 +1,36 @@
+# cvc-requirements.yaml — component set for libcvc.
+#
+# Usage:
+#   cvcpkg install --from cvc-requirements.yaml --prefix ./deps
+#   cmake -B build -DCMAKE_PREFIX_PATH=./deps
+#
+# For a debug build:
+#   cvcpkg install --from cvc-requirements.yaml --config debug
+#
+# See https://github.com/transfix/libcvc-deps/blob/master/docs/roadmap/split-distribution.md
+platform: auto
+arch: auto
+config: release
+link: shared
+
+components:
+  - zlib
+  - boost
+  - fftw3
+  - gsl
+  - cgal
+  - hdf5
+  - log4cplus
+  - tiff
+  - imagemagick
+  - yaml
+  - levmar
+  - libiimod
+  - openblas
+  - openssl
+  - c-ares
+  - re2
+  - abseil
+  - protobuf
+  - grpc
+  - pthreads4w

--- a/src/cvc/CMakeLists.txt
+++ b/src/cvc/CMakeLists.txt
@@ -601,7 +601,7 @@ option(CVC_ENABLE_FFTW "Enable FFTW support for filtered back-projection in volu
 if(CVC_ENABLE_FFTW)
   find_package(PkgConfig QUIET)
   if(PkgConfig_FOUND)
-    pkg_check_modules(FFTW3 QUIET fftw3)
+    pkg_check_modules(FFTW3 QUIET IMPORTED_TARGET fftw3)
     # pkg_check_modules sets <prefix>_LIBRARIES to bare `-l` names and puts
     # full paths in <prefix>_LINK_LIBRARIES. Prefer the full-path form so
     # the linker doesn't need a separate -L for Homebrew etc.
@@ -826,17 +826,27 @@ if(CVC_ENABLE_IMAGEMAGICK)
   foreach(_im_inc IN LISTS ImageMagick_INCLUDE_DIRS)
     target_include_directories(cvc PUBLIC "$<BUILD_INTERFACE:${_im_inc}>")
   endforeach()
-  target_link_libraries(cvc PUBLIC ${ImageMagick_LIBRARIES})
+  # Link via imported targets when available (config-mode from libcvc-deps),
+  # otherwise fall back to the raw library paths from FindImageMagick.
+  if(TARGET ImageMagick::Magick++ AND TARGET ImageMagick::MagickCore)
+    target_link_libraries(cvc PUBLIC ImageMagick::Magick++ ImageMagick::MagickCore)
+  else()
+    target_link_libraries(cvc PUBLIC ${ImageMagick_LIBRARIES})
+  endif()
 endif()
 
 # FFTW linking
 if(CVC_ENABLE_FFTW)
   target_compile_definitions(cvc PUBLIC CVC_ENABLE_FFTW)
   # Same BUILD_INTERFACE wrapping rationale as the ImageMagick block above.
-  foreach(_fftw_inc IN LISTS FFTW3_INCLUDE_DIRS)
-    target_include_directories(cvc PUBLIC "$<BUILD_INTERFACE:${_fftw_inc}>")
-  endforeach()
-  target_link_libraries(cvc PUBLIC ${FFTW3_LIBRARIES})
+  if(TARGET PkgConfig::FFTW3)
+    target_link_libraries(cvc PUBLIC PkgConfig::FFTW3)
+  else()
+    foreach(_fftw_inc IN LISTS FFTW3_INCLUDE_DIRS)
+      target_include_directories(cvc PUBLIC "$<BUILD_INTERFACE:${_fftw_inc}>")
+    endforeach()
+    target_link_libraries(cvc PUBLIC ${FFTW3_LIBRARIES})
+  endif()
 endif()
 
 # zstd compression (production compressor for distributed state).

--- a/src/cvc/rawiv_io.cpp
+++ b/src/cvc/rawiv_io.cpp
@@ -26,7 +26,6 @@
 #include <cvc/endians.h>
 #include <cvc/volmagick.h>
 #include <errno.h>
-#include <format>
 #include <fstream>
 #include <iostream>
 #include <math.h>
@@ -532,12 +531,12 @@ struct rawiv_io : public volume_file_io {
     if (dimension.isNull())
       throw invalid_bounding_box("Dimension must not be null");
     if (numVariables > 1) {
-      throw invalid_rawiv_header(
-          std::format("RawIV format only supports 1 variable ({} requested)", numVariables));
+      throw invalid_rawiv_header("RawIV format only supports 1 variable (" +
+                                 std::to_string(numVariables) + " requested)");
     }
     if (numTimesteps > 1) {
-      throw invalid_rawiv_header(
-          std::format("RawIV format only supports 1 timestep ({} requested)", numTimesteps));
+      throw invalid_rawiv_header("RawIV format only supports 1 timestep (" +
+                                 std::to_string(numTimesteps) + " requested)");
     }
     if (voxelTypes.size() > 1)
       throw invalid_rawiv_header(

--- a/src/cvc/state_chunked_blob.cpp
+++ b/src/cvc/state_chunked_blob.cpp
@@ -10,6 +10,7 @@
 
 #include <cstring>
 #include <cvc/state_chunked_blob.h>
+#include <stdexcept>
 
 namespace CVC_NAMESPACE {
 

--- a/src/cvc/vtk_io.cpp
+++ b/src/cvc/vtk_io.cpp
@@ -37,7 +37,6 @@
 #include <cvc/endians.h>
 #include <cvc/volmagick.h>
 #include <errno.h>
-#include <format>
 
 #ifdef __WINDOWS__
 #define SNPRINTF _snprintf
@@ -268,15 +267,27 @@ void writevtk(const char *filename, const DataInfo &di, const FLOAT *dataPtr,
   }
   unsigned long nMem = di.n[0] * di.n[1] * di.n[2];
   fputs("# vtk DataFile Version 3.0\n", fd);
-  fputs(std::format("created by levelSet (Ojaswa Sharma). Zero level: {:f}\n", value_increment)
-            .c_str(),
-        fd);
+  {
+    char _buf[128];
+    SNPRINTF(_buf, sizeof(_buf), "created by levelSet (Ojaswa Sharma). Zero level: %f\n",
+             value_increment);
+    fputs(_buf, fd);
+  }
   fputs("BINARY\n", fd);
   fputs("DATASET STRUCTURED_POINTS\n", fd);
-  fputs(std::format("DIMENSIONS {} {} {}\n", di.n[0], di.n[1], di.n[2]).c_str(), fd);
+  {
+    char _buf[128];
+    SNPRINTF(_buf, sizeof(_buf), "DIMENSIONS %lu %lu %lu\n", (unsigned long)di.n[0],
+             (unsigned long)di.n[1], (unsigned long)di.n[2]);
+    fputs(_buf, fd);
+  }
   fputs("ORIGIN 0.000000 0.000000 0.000000\n", fd);
   fputs("SPACING 1.000000 1.000000 1.000000\n", fd);
-  fputs(std::format("POINT_DATA {}\n", nMem).c_str(), fd);
+  {
+    char _buf[64];
+    SNPRINTF(_buf, sizeof(_buf), "POINT_DATA %lu\n", (unsigned long)nMem);
+    fputs(_buf, fd);
+  }
   fputs("SCALARS image_data unsigned_short\n", fd);
   fputs("LOOKUP_TABLE default\n", fd);
   unsigned short dataval;


### PR DESCRIPTION
## Summary

Fixes three issues that prevent downstream consumers (e.g. TexMol) from using the prebuilt libcvc SDK archives:

### 1. C++17 compatibility
- Replace `std::format` with `std::to_string` / `snprintf` in `rawiv_io.cpp` and `vtk_io.cpp`
- Add missing `#include <stdexcept>` in `state_chunked_blob.cpp`
- libcvc now compiles cleanly under both C++17 and C++20

### 2. Portable cmake exports (no more hard-coded paths)
- **Boost**: Link via `Boost::thread`, `Boost::filesystem`, etc. instead of raw `${Boost_LIBRARIES}`
- **ImageMagick**: Prefer `ImageMagick::Magick++` / `ImageMagick::MagickCore` imported targets
- **FFTW**: Add `IMPORTED_TARGET` to `pkg_check_modules`, prefer `PkgConfig::FFTW3` target

### 3. Graceful optional dependencies in cvcConfig.cmake
- Switch optional `find_dependency()` calls to `find_package(... QUIET)` — consumers don't fail if CGAL, CUDA, ImageMagick, etc. aren't installed
- Add `find_package(libiimod)` for IMOD MRC support
- Create synthetic `PkgConfig::FFTW3` imported target when pkg-config isn't available

### Testing
- Full local build passes with both C++17 and C++20
- Exported `cvc::cvc` target uses only imported targets (no `/usr/lib/...` paths)
- `cvcConfig.cmake` loads successfully even when optional deps are absent

### After merge
Re-tag `v3.2.4` with these fixes so TexMol CI can consume the prebuilt SDK.