### PR TITLE
feat(volrover3): StateDashboardWidget — comprehensive state management UI

### DIFF
--- a/inc/volrover3/MainWindow.h
+++ b/inc/volrover3/MainWindow.h
@@ -15,6 +15,7 @@ class TransferFunctionWidget;
 class SceneGraph;
 class ThreadMonitorWidget;
 class StateTreeWidget;
+class StateDashboardWidget;
 class GridOptionsDialog;
 class SDFDialog;
 class IsosurfaceDialog;
@@ -40,6 +41,7 @@ private slots:
   void showViewerOptions();
   void showThreadMonitor();
   void showStateTree();
+  void showStateDashboard();
   void showSDF();
   void showIsosurface();
   void showGeometry();
@@ -69,6 +71,7 @@ private:
   std::shared_ptr<SceneGraph> m_sceneGraph;
   ThreadMonitorWidget *m_threadMonitor;
   StateTreeWidget *m_stateTreeWidget;
+  StateDashboardWidget *m_stateDashboardWidget;
   GridOptionsDialog *m_gridOptionsDialog;
   SDFDialog *m_sdfDialog;
   IsosurfaceDialog *m_isosurfaceDialog;

--- a/inc/volrover3/StateDashboardWidget.h
+++ b/inc/volrover3/StateDashboardWidget.h
@@ -1,0 +1,145 @@
+#ifndef STATEDASHBOARDWIDGET_H
+#define STATEDASHBOARDWIDGET_H
+
+#include <QComboBox>
+#include <QGroupBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QSplitter>
+#include <QTabWidget>
+#include <QTableWidget>
+#include <QTimer>
+#include <QTreeWidget>
+#include <QVBoxLayout>
+#include <QWidget>
+#include <boost/signals2.hpp>
+#include <cvc/core/state.h>
+#include <cvc/core/state_cluster_membership.h>
+#include <cvc/core/state_cluster_shard.h>
+#include <cvc/core/state_exec/exec_coordinator.h>
+#include <cvc/core/state_exec/scheduler.h>
+#include <cvc/core/state_message_bus.h>
+#include <cvc/core/state_telemetry_aggregator.h>
+#include <string>
+#include <vector>
+
+/// Comprehensive state management dashboard combining tree navigation,
+/// DSL execution console, and cluster networking in a tabbed interface.
+class StateDashboardWidget : public QWidget {
+  Q_OBJECT
+
+public:
+  explicit StateDashboardWidget(QWidget *parent = nullptr);
+  ~StateDashboardWidget() override;
+
+  /// Set the root state node for the tree view.
+  void setRootState(cvc::state *root);
+
+  /// Attach a scheduler for process management in the exec tab.
+  void setScheduler(cvc::state_exec::scheduler *sched);
+
+  /// Attach a cluster shard for distributed networking in the cluster tab.
+  void setShard(cvc::state_cluster_shard *shard);
+
+  /// Attach a membership manager for peer management.
+  void setMembership(cvc::state_cluster_membership *membership);
+
+  /// Attach a coordinator for distributed exec management.
+  void setCoordinator(cvc::state_exec::exec_coordinator *coord);
+
+  /// Attach a telemetry aggregator for cluster stats.
+  void setTelemetryAggregator(cvc::state_telemetry_aggregator *agg);
+
+  /// Refresh all tabs.
+  void refresh();
+
+signals:
+  void stateChanged();
+
+  // ─── State Tree tab ────────────────────────────────────────────────
+private slots:
+  void onTreeItemSelected();
+  void onTreeSearchTextChanged(const QString &text);
+  void onPropertyValueChanged(int row, int column);
+  void onAddStateClicked();
+  void onDeleteStateClicked();
+  void onTreeStructureChanged();
+  void onCurrentStateChanged();
+  void onCurrentStateDestroyed();
+
+private:
+  void buildStateTreeTab(QTabWidget *tabs);
+  void refreshStateTree();
+  void populateTree(QTreeWidgetItem *parentItem, cvc::state *state);
+  void populateProperties(cvc::state *state);
+  QTreeWidgetItem *findTreeItem(QTreeWidgetItem *parent, cvc::state *target);
+  std::string getStateValue(cvc::state *state);
+  void setStateValue(cvc::state *state, const QString &valueStr);
+
+  QLineEdit *m_treeSearch;
+  QTreeWidget *m_treeWidget;
+  QTableWidget *m_propertyTable;
+  QPushButton *m_addStateBtn;
+  QPushButton *m_deleteStateBtn;
+
+  cvc::state *m_rootState = nullptr;
+  cvc::state *m_currentState = nullptr;
+
+  boost::signals2::connection m_valueConn;
+  boost::signals2::connection m_treeConn;
+  boost::signals2::connection m_destroyConn;
+
+  // ─── State Exec Console tab ────────────────────────────────────────
+private slots:
+  void onRunScriptClicked();
+  void onClearOutputClicked();
+  void onProcessTableSelectionChanged();
+  void onPauseProcessClicked();
+  void onResumeProcessClicked();
+  void onKillProcessClicked();
+  void refreshProcessList();
+
+private:
+  void buildExecConsoleTab(QTabWidget *tabs);
+
+  QPlainTextEdit *m_scriptEditor;
+  QPushButton *m_runBtn;
+  QPushButton *m_clearOutputBtn;
+  QPlainTextEdit *m_outputPanel;
+  QTableWidget *m_processTable;
+  QPushButton *m_pauseBtn;
+  QPushButton *m_resumeBtn;
+  QPushButton *m_killBtn;
+  QTimer *m_processRefreshTimer;
+
+  cvc::state_exec::scheduler *m_scheduler = nullptr;
+
+  // ─── Cluster & Networking tab ──────────────────────────────────────
+private slots:
+  void onConnectPeerClicked();
+  void refreshClusterInfo();
+
+private:
+  void buildClusterTab(QTabWidget *tabs);
+
+  QLabel *m_nodeIdLabel;
+  QLabel *m_clusterIdLabel;
+  QLabel *m_leaderLabel;
+  QTableWidget *m_peerTable;
+  QLineEdit *m_peerEndpointInput;
+  QPushButton *m_connectPeerBtn;
+  QLabel *m_busStatsLabel;
+  QLabel *m_shardStatsLabel;
+  QLabel *m_telemetryLabel;
+  QTimer *m_clusterRefreshTimer;
+
+  cvc::state_cluster_shard *m_shard = nullptr;
+  cvc::state_cluster_membership *m_membership = nullptr;
+  cvc::state_exec::exec_coordinator *m_coordinator = nullptr;
+  cvc::state_telemetry_aggregator *m_telemetryAgg = nullptr;
+};
+
+#endif // STATEDASHBOARDWIDGET_H

--- a/src/volrover3/CMakeLists.txt
+++ b/src/volrover3/CMakeLists.txt
@@ -37,6 +37,7 @@ set(VOLROVER3_SOURCES
   TransferFunctionWidget.cpp
   ThreadMonitorWidget.cpp
   StateTreeWidget.cpp
+  StateDashboardWidget.cpp
   AppState.cpp
   BoundingBoxDialog.cpp
   CameraSettingsDialog.cpp
@@ -66,6 +67,7 @@ set(VOLROVER3_HEADERS
   ${PROJECT_SOURCE_DIR}/inc/volrover3/TransferFunctionWidget.h
   ${PROJECT_SOURCE_DIR}/inc/volrover3/ThreadMonitorWidget.h
   ${PROJECT_SOURCE_DIR}/inc/volrover3/StateTreeWidget.h
+  ${PROJECT_SOURCE_DIR}/inc/volrover3/StateDashboardWidget.h
   ${PROJECT_SOURCE_DIR}/inc/volrover3/AppState.h
   ${PROJECT_SOURCE_DIR}/inc/volrover3/BoundingBoxDialog.h
   ${PROJECT_SOURCE_DIR}/inc/volrover3/CameraSettingsDialog.h
@@ -441,7 +443,15 @@ if(CVC_BUILD_TESTS)
     volrover3_lib
     GTest::gtest)
   add_test(NAME StateTreeWidgetTest COMMAND volrover3_statetree_test)
-  
+
+  # StateDashboardWidget tests
+  add_executable(volrover3_statedashboard_test
+    tests/StateDashboardWidgetTest.cpp)
+  target_link_libraries(volrover3_statedashboard_test
+    volrover3_lib
+    GTest::gtest)
+  add_test(NAME StateDashboardWidgetTest COMMAND volrover3_statedashboard_test)
+
   # GraphicsNode tests
   add_executable(volrover3_graphicsnode_test
     tests/GraphicsNodeTest.cpp)
@@ -516,6 +526,7 @@ if(CVC_BUILD_TESTS)
     CameraControllerTest
     GridNodeTest
     StateTreeWidgetTest
+    StateDashboardWidgetTest
     GraphicsNodeTest
     VolumeNodeTest
     BBoxNodeTest

--- a/src/volrover3/MainWindow.cpp
+++ b/src/volrover3/MainWindow.cpp
@@ -31,6 +31,7 @@
 #include <volrover3/SDFDialog.h>
 #include <volrover3/SceneGraph.h>
 #include <volrover3/SceneNode.h>
+#include <volrover3/StateDashboardWidget.h>
 #include <volrover3/StateTreeWidget.h>
 #include <volrover3/ThreadMonitorWidget.h>
 #include <volrover3/TransferFunctionWidget.h>
@@ -44,11 +45,12 @@ MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent), m_renderWidget(nullptr), m_transferFunctionWidget(nullptr),
       m_sceneGraph(nullptr) // Will be created after callback is set
       ,
-      m_threadMonitor(nullptr), m_stateTreeWidget(nullptr), m_gridOptionsDialog(nullptr),
-      m_sdfDialog(nullptr), m_isosurfaceDialog(nullptr), m_geometryDialog(nullptr),
-      m_volumeDialog(nullptr), m_viewerOptionsDialog(nullptr), m_cameraDialog(nullptr),
-      m_mainToolBar(nullptr), m_threadNameLabel(nullptr), m_threadInfoLabel(nullptr),
-      m_threadProgressBar(nullptr), m_gridVisible(true), m_axisVisible(true) {
+      m_threadMonitor(nullptr), m_stateTreeWidget(nullptr), m_stateDashboardWidget(nullptr),
+      m_gridOptionsDialog(nullptr), m_sdfDialog(nullptr), m_isosurfaceDialog(nullptr),
+      m_geometryDialog(nullptr), m_volumeDialog(nullptr), m_viewerOptionsDialog(nullptr),
+      m_cameraDialog(nullptr), m_mainToolBar(nullptr), m_threadNameLabel(nullptr),
+      m_threadInfoLabel(nullptr), m_threadProgressBar(nullptr), m_gridVisible(true),
+      m_axisVisible(true) {
   setWindowTitle("VolRover3 - Volume Rover Version 3");
   resize(1280, 720);
 
@@ -214,6 +216,11 @@ void MainWindow::createMenus() {
   stateTreeAction->setShortcut(tr("Ctrl+Shift+S"));
   connect(stateTreeAction, &QAction::triggered, this, &MainWindow::showStateTree);
   viewMenu->addAction(stateTreeAction);
+
+  QAction *stateDashboardAction = new QAction(tr("State &Dashboard..."), this);
+  stateDashboardAction->setShortcut(tr("Ctrl+Shift+D"));
+  connect(stateDashboardAction, &QAction::triggered, this, &MainWindow::showStateDashboard);
+  viewMenu->addAction(stateDashboardAction);
 
   viewMenu->addSeparator();
 
@@ -749,6 +756,28 @@ void MainWindow::showStateTree() {
   m_stateTreeWidget->show();
   m_stateTreeWidget->raise();
   m_stateTreeWidget->activateWindow();
+}
+
+void MainWindow::showStateDashboard() {
+  if (!m_stateDashboardWidget) {
+    m_stateDashboardWidget = new StateDashboardWidget();
+    m_stateDashboardWidget->setWindowTitle(tr("State Dashboard - VolRover3"));
+    m_stateDashboardWidget->setAttribute(Qt::WA_DeleteOnClose);
+    m_stateDashboardWidget->resize(900, 650);
+    m_stateDashboardWidget->setRootState(&cvc::state::instance(volrover3::app()));
+
+    connect(m_stateDashboardWidget, &QObject::destroyed,
+            [this]() { m_stateDashboardWidget = nullptr; });
+    connect(m_stateDashboardWidget, &StateDashboardWidget::stateChanged, this, [this]() {
+      m_sceneGraph->update();
+      m_renderWidget->render();
+    });
+  }
+
+  m_stateDashboardWidget->refresh();
+  m_stateDashboardWidget->show();
+  m_stateDashboardWidget->raise();
+  m_stateDashboardWidget->activateWindow();
 }
 
 void MainWindow::showSDF() {

--- a/src/volrover3/StateDashboardWidget.cpp
+++ b/src/volrover3/StateDashboardWidget.cpp
@@ -1,0 +1,810 @@
+#include <QApplication>
+#include <QFont>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QInputDialog>
+#include <QMessageBox>
+#include <QMetaObject>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <cvc/core/app.h>
+#include <cvc/core/state.h>
+#include <cvc/core/state_exec/builtins.h>
+#include <cvc/core/state_exec/evaluator.h>
+#include <cvc/core/state_exec/process.h>
+#include <sstream>
+#include <volrover3/StateDashboardWidget.h>
+#include <volrover3/volrover3_app.h>
+
+using namespace cvc;
+using namespace cvc::state_exec;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Construction
+// ═══════════════════════════════════════════════════════════════════════════
+
+StateDashboardWidget::StateDashboardWidget(QWidget *parent) : QWidget(parent) {
+  auto *layout = new QVBoxLayout(this);
+  layout->setContentsMargins(4, 4, 4, 4);
+
+  auto *tabs = new QTabWidget(this);
+  buildStateTreeTab(tabs);
+  buildExecConsoleTab(tabs);
+  buildClusterTab(tabs);
+  layout->addWidget(tabs);
+}
+
+StateDashboardWidget::~StateDashboardWidget() {
+  m_valueConn.disconnect();
+  m_treeConn.disconnect();
+  m_destroyConn.disconnect();
+
+  if (m_processRefreshTimer)
+    m_processRefreshTimer->stop();
+  if (m_clusterRefreshTimer)
+    m_clusterRefreshTimer->stop();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Public setters
+// ═══════════════════════════════════════════════════════════════════════════
+
+void StateDashboardWidget::setRootState(state *root) {
+  m_valueConn.disconnect();
+  m_treeConn.disconnect();
+  m_destroyConn.disconnect();
+  m_currentState = nullptr;
+
+  m_rootState = root;
+  if (m_rootState) {
+    m_treeConn = m_rootState->childChanged.connect([this](const std::string &) {
+      QMetaObject::invokeMethod(this, "onTreeStructureChanged", Qt::QueuedConnection);
+    });
+  }
+  refreshStateTree();
+}
+
+void StateDashboardWidget::setScheduler(scheduler *sched) {
+  m_scheduler = sched;
+  refreshProcessList();
+}
+
+void StateDashboardWidget::setShard(state_cluster_shard *shard) { m_shard = shard; }
+
+void StateDashboardWidget::setMembership(state_cluster_membership *membership) {
+  m_membership = membership;
+  refreshClusterInfo();
+}
+
+void StateDashboardWidget::setCoordinator(exec_coordinator *coord) { m_coordinator = coord; }
+
+void StateDashboardWidget::setTelemetryAggregator(state_telemetry_aggregator *agg) {
+  m_telemetryAgg = agg;
+}
+
+void StateDashboardWidget::refresh() {
+  refreshStateTree();
+  refreshProcessList();
+  refreshClusterInfo();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tab 1 — State Tree
+// ═══════════════════════════════════════════════════════════════════════════
+
+void StateDashboardWidget::buildStateTreeTab(QTabWidget *tabs) {
+  auto *page = new QWidget;
+  auto *layout = new QVBoxLayout(page);
+  layout->setContentsMargins(2, 2, 2, 2);
+
+  // Search bar
+  m_treeSearch = new QLineEdit;
+  m_treeSearch->setPlaceholderText(tr("Filter state tree..."));
+  connect(m_treeSearch, &QLineEdit::textChanged, this,
+          &StateDashboardWidget::onTreeSearchTextChanged);
+  layout->addWidget(m_treeSearch);
+
+  // Splitter: tree left, properties right
+  auto *splitter = new QSplitter(Qt::Horizontal);
+
+  // Tree widget
+  m_treeWidget = new QTreeWidget;
+  m_treeWidget->setHeaderLabel(tr("State Tree"));
+  m_treeWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+  connect(m_treeWidget, &QTreeWidget::itemSelectionChanged, this,
+          &StateDashboardWidget::onTreeItemSelected);
+  splitter->addWidget(m_treeWidget);
+
+  // Right side: property table + buttons
+  auto *rightPanel = new QWidget;
+  auto *rightLayout = new QVBoxLayout(rightPanel);
+  rightLayout->setContentsMargins(0, 0, 0, 0);
+
+  m_propertyTable = new QTableWidget;
+  m_propertyTable->setColumnCount(2);
+  m_propertyTable->setHorizontalHeaderLabels({tr("Property"), tr("Value")});
+  m_propertyTable->horizontalHeader()->setStretchLastSection(true);
+  m_propertyTable->verticalHeader()->hide();
+  m_propertyTable->setEditTriggers(QAbstractItemView::DoubleClicked |
+                                   QAbstractItemView::SelectedClicked);
+  connect(m_propertyTable, &QTableWidget::cellChanged, this,
+          &StateDashboardWidget::onPropertyValueChanged);
+  rightLayout->addWidget(m_propertyTable);
+
+  auto *btnBar = new QHBoxLayout;
+  m_addStateBtn = new QPushButton(tr("Add State"));
+  m_deleteStateBtn = new QPushButton(tr("Delete State"));
+  m_deleteStateBtn->setEnabled(false);
+  connect(m_addStateBtn, &QPushButton::clicked, this, &StateDashboardWidget::onAddStateClicked);
+  connect(m_deleteStateBtn, &QPushButton::clicked, this,
+          &StateDashboardWidget::onDeleteStateClicked);
+  btnBar->addWidget(m_addStateBtn);
+  btnBar->addWidget(m_deleteStateBtn);
+  btnBar->addStretch();
+  rightLayout->addLayout(btnBar);
+
+  splitter->addWidget(rightPanel);
+  splitter->setStretchFactor(0, 1);
+  splitter->setStretchFactor(1, 1);
+  layout->addWidget(splitter);
+
+  tabs->addTab(page, tr("State Tree"));
+}
+
+void StateDashboardWidget::refreshStateTree() {
+  m_treeWidget->clear();
+  if (!m_rootState)
+    return;
+
+  auto *root = new QTreeWidgetItem(m_treeWidget);
+  root->setText(0, QString::fromStdString(m_rootState->name()));
+  root->setData(0, Qt::UserRole, QVariant::fromValue(static_cast<void *>(m_rootState)));
+  populateTree(root, m_rootState);
+  root->setExpanded(true);
+}
+
+void StateDashboardWidget::populateTree(QTreeWidgetItem *parentItem, state *s) {
+  auto childPaths = s->children();
+  std::string parentFull = s->fullName();
+
+  for (auto &childFullName : childPaths) {
+    // Only immediate children: relative path has no dots
+    std::string rel = childFullName.substr(parentFull.size());
+    if (!rel.empty() && rel[0] == '.')
+      rel = rel.substr(1);
+    if (rel.empty() || rel.find('.') != std::string::npos)
+      continue;
+
+    auto &child = (*s)(rel);
+    if (!child.initialized())
+      continue;
+
+    auto *item = new QTreeWidgetItem(parentItem);
+    item->setText(0, QString::fromStdString(rel));
+    item->setData(0, Qt::UserRole, QVariant::fromValue(static_cast<void *>(&child)));
+    populateTree(item, &child);
+  }
+}
+
+void StateDashboardWidget::onTreeItemSelected() {
+  m_valueConn.disconnect();
+  m_destroyConn.disconnect();
+  m_currentState = nullptr;
+
+  auto items = m_treeWidget->selectedItems();
+  if (items.isEmpty()) {
+    m_propertyTable->setRowCount(0);
+    m_deleteStateBtn->setEnabled(false);
+    return;
+  }
+
+  auto *ptr = static_cast<state *>(items[0]->data(0, Qt::UserRole).value<void *>());
+  if (!ptr)
+    return;
+
+  m_currentState = ptr;
+  m_deleteStateBtn->setEnabled(true);
+
+  // Listen for value changes on the selected node
+  m_valueConn = m_currentState->valueChanged.connect(
+      [this]() { QMetaObject::invokeMethod(this, "onCurrentStateChanged", Qt::QueuedConnection); });
+  m_destroyConn = m_currentState->destroyed.connect([this]() {
+    QMetaObject::invokeMethod(this, "onCurrentStateDestroyed", Qt::QueuedConnection);
+  });
+
+  populateProperties(m_currentState);
+}
+
+void StateDashboardWidget::populateProperties(state *s) {
+  m_propertyTable->blockSignals(true);
+  m_propertyTable->setRowCount(0);
+
+  auto addRow = [this](const QString &key, const QString &val, bool editable = false) {
+    int row = m_propertyTable->rowCount();
+    m_propertyTable->insertRow(row);
+    auto *keyItem = new QTableWidgetItem(key);
+    keyItem->setFlags(keyItem->flags() & ~Qt::ItemIsEditable);
+    m_propertyTable->setItem(row, 0, keyItem);
+    auto *valItem = new QTableWidgetItem(val);
+    if (!editable)
+      valItem->setFlags(valItem->flags() & ~Qt::ItemIsEditable);
+    m_propertyTable->setItem(row, 1, valItem);
+  };
+
+  addRow(tr("Name"), QString::fromStdString(s->name()));
+  addRow(tr("Full Path"), QString::fromStdString(s->fullName()));
+  addRow(tr("Value"), QString::fromStdString(s->value()), !s->readOnly());
+  addRow(tr("Value Type"), QString::fromStdString(s->valueTypeName()));
+  addRow(tr("Data Type"), QString::fromStdString(s->dataTypeName()));
+  addRow(tr("Read Only"), s->readOnly() ? tr("true") : tr("false"));
+  addRow(tr("Hidden"), s->hidden() ? tr("true") : tr("false"));
+  addRow(tr("Comment"), QString::fromStdString(s->comment()), true);
+
+  // Last modified
+  auto lastMod = s->lastMod();
+  if (!lastMod.is_not_a_date_time())
+    addRow(tr("Last Modified"),
+           QString::fromStdString(boost::posix_time::to_simple_string(lastMod)));
+  else
+    addRow(tr("Last Modified"), tr("(unknown)"));
+
+  addRow(tr("Children"), QString::number(s->numChildren()));
+  addRow(tr("Initialized"), s->initialized() ? tr("true") : tr("false"));
+
+  // Link info
+  addRow(tr("Is Link"), s->isLink() ? tr("true") : tr("false"));
+  if (s->isLink()) {
+    addRow(tr("Link Target"), QString::fromStdString(s->linkTarget()));
+    addRow(tr("Link Mode"),
+           s->linkMode() == state::link_mode::transparent ? tr("transparent") : tr("opaque"));
+    addRow(tr("Link Writable"), s->linkWritable() ? tr("true") : tr("false"));
+
+    auto res = s->resolveLink();
+    QString kindStr;
+    switch (res.kind) {
+    case state::link_resolution_kind::resolved:
+      kindStr = tr("resolved");
+      break;
+    case state::link_resolution_kind::cycle_detected:
+      kindStr = tr("cycle");
+      break;
+    case state::link_resolution_kind::budget_exhausted:
+      kindStr = tr("budget exhausted");
+      break;
+    case state::link_resolution_kind::broken:
+      kindStr = tr("broken");
+      break;
+    case state::link_resolution_kind::none:
+      kindStr = tr("none");
+      break;
+    }
+    addRow(tr("Link Resolution"), kindStr);
+    addRow(tr("Resolved Value"), QString::fromStdString(s->resolvedValue()));
+  }
+
+  // Expiry info
+  addRow(tr("Has Expiry"), s->hasExpiry() ? tr("true") : tr("false"));
+  if (s->hasExpiry()) {
+    auto exp = s->expiryTime();
+    addRow(tr("Expiry Time"), QString::fromStdString(boost::posix_time::to_simple_string(exp)));
+    addRow(tr("Expired"), s->isExpired() ? tr("true") : tr("false"));
+  }
+
+  m_propertyTable->blockSignals(false);
+}
+
+void StateDashboardWidget::onPropertyValueChanged(int row, int column) {
+  if (column != 1 || !m_currentState)
+    return;
+
+  auto *keyItem = m_propertyTable->item(row, 0);
+  if (!keyItem)
+    return;
+
+  QString key = keyItem->text();
+  QString val = m_propertyTable->item(row, 1)->text();
+
+  if (key == tr("Value") && !m_currentState->readOnly()) {
+    setStateValue(m_currentState, val);
+    emit stateChanged();
+  } else if (key == tr("Comment")) {
+    m_currentState->comment(val.toStdString());
+  }
+}
+
+void StateDashboardWidget::onTreeSearchTextChanged(const QString &text) {
+  // Show/hide tree items based on filter text
+  std::function<bool(QTreeWidgetItem *)> filterItem = [&](QTreeWidgetItem *item) -> bool {
+    bool childVisible = false;
+    for (int i = 0; i < item->childCount(); ++i) {
+      if (filterItem(item->child(i)))
+        childVisible = true;
+    }
+    bool selfMatch = text.isEmpty() || item->text(0).contains(text, Qt::CaseInsensitive);
+    bool visible = selfMatch || childVisible;
+    item->setHidden(!visible);
+    if (visible && !text.isEmpty())
+      item->setExpanded(true);
+    return visible;
+  };
+
+  for (int i = 0; i < m_treeWidget->topLevelItemCount(); ++i)
+    filterItem(m_treeWidget->topLevelItem(i));
+}
+
+void StateDashboardWidget::onAddStateClicked() {
+  bool ok;
+  QString path = QInputDialog::getText(this, tr("Add State"), tr("State path (dot-separated):"),
+                                       QLineEdit::Normal, QString(), &ok);
+  if (!ok || path.isEmpty())
+    return;
+
+  std::string pathStr = path.toStdString();
+  if (!state::isValidStateName(pathStr)) {
+    std::string sanitized = state::sanitizeStateName(pathStr);
+    if (sanitized.empty()) {
+      QMessageBox::warning(this, tr("Invalid Path"), tr("The path is not valid."));
+      return;
+    }
+    pathStr = sanitized;
+  }
+
+  state *parent = m_currentState ? m_currentState : m_rootState;
+  if (!parent)
+    return;
+
+  (*parent)(pathStr).value(std::string(""));
+  emit stateChanged();
+}
+
+void StateDashboardWidget::onDeleteStateClicked() {
+  if (!m_currentState || m_currentState == m_rootState)
+    return;
+
+  auto reply = QMessageBox::question(this, tr("Delete State"),
+                                     tr("Reset state '%1' and all children?")
+                                         .arg(QString::fromStdString(m_currentState->fullName())),
+                                     QMessageBox::Yes | QMessageBox::No);
+
+  if (reply == QMessageBox::Yes) {
+    m_currentState->reset();
+    emit stateChanged();
+  }
+}
+
+void StateDashboardWidget::onTreeStructureChanged() { refreshStateTree(); }
+
+void StateDashboardWidget::onCurrentStateChanged() {
+  if (m_currentState)
+    populateProperties(m_currentState);
+}
+
+void StateDashboardWidget::onCurrentStateDestroyed() {
+  m_valueConn.disconnect();
+  m_destroyConn.disconnect();
+  m_currentState = nullptr;
+  m_propertyTable->setRowCount(0);
+  m_deleteStateBtn->setEnabled(false);
+  refreshStateTree();
+}
+
+std::string StateDashboardWidget::getStateValue(state *s) { return s->value(); }
+
+void StateDashboardWidget::setStateValue(state *s, const QString &valueStr) {
+  std::string typeName = s->valueTypeName();
+  std::string v = valueStr.toStdString();
+
+  if (typeName == "double")
+    s->value(valueStr.toDouble());
+  else if (typeName == "float")
+    s->value(valueStr.toFloat());
+  else if (typeName == "int")
+    s->value(valueStr.toInt());
+  else if (typeName == "unsigned int")
+    s->value(static_cast<unsigned int>(valueStr.toUInt()));
+  else if (typeName == "bool")
+    s->value(v == "true" || v == "1");
+  else if (typeName == "long")
+    s->value(valueStr.toLong());
+  else if (typeName == "unsigned long" || typeName == "size_t")
+    s->value(static_cast<std::size_t>(valueStr.toULong()));
+  else
+    s->value(v);
+}
+
+QTreeWidgetItem *StateDashboardWidget::findTreeItem(QTreeWidgetItem *parent, state *target) {
+  for (int i = 0; i < parent->childCount(); ++i) {
+    auto *child = parent->child(i);
+    auto *ptr = static_cast<state *>(child->data(0, Qt::UserRole).value<void *>());
+    if (ptr == target)
+      return child;
+    auto *found = findTreeItem(child, target);
+    if (found)
+      return found;
+  }
+  return nullptr;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tab 2 — State Exec Console
+// ═══════════════════════════════════════════════════════════════════════════
+
+void StateDashboardWidget::buildExecConsoleTab(QTabWidget *tabs) {
+  auto *page = new QWidget;
+  auto *layout = new QVBoxLayout(page);
+  layout->setContentsMargins(2, 2, 2, 2);
+
+  auto *splitter = new QSplitter(Qt::Vertical);
+
+  // Top: script editor + run button
+  auto *editorGroup = new QGroupBox(tr("S-Expression Script"));
+  auto *editorLayout = new QVBoxLayout(editorGroup);
+
+  m_scriptEditor = new QPlainTextEdit;
+  m_scriptEditor->setPlaceholderText(tr("Enter state_exec program...\ne.g. (+ 1 2 3)"));
+  QFont mono("monospace");
+  mono.setStyleHint(QFont::Monospace);
+  m_scriptEditor->setFont(mono);
+  m_scriptEditor->setTabStopDistance(QFontMetrics(mono).horizontalAdvance(' ') * 2);
+  editorLayout->addWidget(m_scriptEditor);
+
+  auto *editorBtnBar = new QHBoxLayout;
+  m_runBtn = new QPushButton(tr("Run"));
+  m_clearOutputBtn = new QPushButton(tr("Clear Output"));
+  connect(m_runBtn, &QPushButton::clicked, this, &StateDashboardWidget::onRunScriptClicked);
+  connect(m_clearOutputBtn, &QPushButton::clicked, this,
+          &StateDashboardWidget::onClearOutputClicked);
+  editorBtnBar->addWidget(m_runBtn);
+  editorBtnBar->addWidget(m_clearOutputBtn);
+  editorBtnBar->addStretch();
+  editorLayout->addLayout(editorBtnBar);
+  splitter->addWidget(editorGroup);
+
+  // Middle: output panel
+  auto *outputGroup = new QGroupBox(tr("Output"));
+  auto *outputLayout = new QVBoxLayout(outputGroup);
+  m_outputPanel = new QPlainTextEdit;
+  m_outputPanel->setReadOnly(true);
+  m_outputPanel->setFont(mono);
+  outputLayout->addWidget(m_outputPanel);
+  splitter->addWidget(outputGroup);
+
+  // Bottom: process list
+  auto *processGroup = new QGroupBox(tr("Processes"));
+  auto *processLayout = new QVBoxLayout(processGroup);
+
+  m_processTable = new QTableWidget;
+  m_processTable->setColumnCount(8);
+  m_processTable->setHorizontalHeaderLabels({tr("PID"), tr("Name"), tr("Status"), tr("Priority"),
+                                             tr("UID"), tr("Steps"), tr("Elapsed"), tr("Memory")});
+  m_processTable->horizontalHeader()->setStretchLastSection(true);
+  m_processTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+  m_processTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+  connect(m_processTable, &QTableWidget::itemSelectionChanged, this,
+          &StateDashboardWidget::onProcessTableSelectionChanged);
+  processLayout->addWidget(m_processTable);
+
+  auto *procBtnBar = new QHBoxLayout;
+  m_pauseBtn = new QPushButton(tr("Pause"));
+  m_resumeBtn = new QPushButton(tr("Resume"));
+  m_killBtn = new QPushButton(tr("Kill"));
+  m_pauseBtn->setEnabled(false);
+  m_resumeBtn->setEnabled(false);
+  m_killBtn->setEnabled(false);
+  connect(m_pauseBtn, &QPushButton::clicked, this, &StateDashboardWidget::onPauseProcessClicked);
+  connect(m_resumeBtn, &QPushButton::clicked, this, &StateDashboardWidget::onResumeProcessClicked);
+  connect(m_killBtn, &QPushButton::clicked, this, &StateDashboardWidget::onKillProcessClicked);
+  procBtnBar->addWidget(m_pauseBtn);
+  procBtnBar->addWidget(m_resumeBtn);
+  procBtnBar->addWidget(m_killBtn);
+  procBtnBar->addStretch();
+  processLayout->addLayout(procBtnBar);
+
+  splitter->addWidget(processGroup);
+  splitter->setStretchFactor(0, 2);
+  splitter->setStretchFactor(1, 1);
+  splitter->setStretchFactor(2, 2);
+  layout->addWidget(splitter);
+
+  // Timer for auto-refreshing process list
+  m_processRefreshTimer = new QTimer(this);
+  m_processRefreshTimer->setInterval(1000);
+  connect(m_processRefreshTimer, &QTimer::timeout, this, &StateDashboardWidget::refreshProcessList);
+  m_processRefreshTimer->start();
+
+  tabs->addTab(page, tr("Exec Console"));
+}
+
+void StateDashboardWidget::onRunScriptClicked() {
+  QString script = m_scriptEditor->toPlainText().trimmed();
+  if (script.isEmpty())
+    return;
+
+  m_outputPanel->appendPlainText(QStringLiteral("> ") + script);
+
+  try {
+    auto env = builtins::make_default_environment();
+    evaluator ev(env);
+    auto result = ev.evaluate_script(script.toStdString());
+    m_outputPanel->appendPlainText(QString::fromStdString(to_string(result)));
+  } catch (const std::exception &e) {
+    m_outputPanel->appendPlainText(QStringLiteral("ERROR: ") + QString::fromUtf8(e.what()));
+  }
+
+  // Also submit to scheduler if available
+  if (m_scheduler) {
+    refreshProcessList();
+  }
+}
+
+void StateDashboardWidget::onClearOutputClicked() { m_outputPanel->clear(); }
+
+void StateDashboardWidget::refreshProcessList() {
+  if (!m_scheduler) {
+    m_processTable->setRowCount(0);
+    return;
+  }
+
+  auto procs = m_scheduler->list_processes();
+  m_processTable->setRowCount(static_cast<int>(procs.size()));
+
+  for (int i = 0; i < static_cast<int>(procs.size()); ++i) {
+    auto &p = procs[static_cast<size_t>(i)];
+    auto setCell = [this, i](int col, const QString &text) {
+      auto *item = new QTableWidgetItem(text);
+      item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+      m_processTable->setItem(i, col, item);
+    };
+
+    setCell(0, QString::number(p.pid));
+    setCell(1, QString::fromStdString(p.name));
+
+    QString statusStr;
+    switch (p.status) {
+    case process_status::ready:
+      statusStr = tr("ready");
+      break;
+    case process_status::running:
+      statusStr = tr("running");
+      break;
+    case process_status::paused:
+      statusStr = tr("paused");
+      break;
+    case process_status::waiting:
+      statusStr = tr("waiting");
+      break;
+    case process_status::terminated:
+      statusStr = tr("terminated");
+      break;
+    case process_status::killed:
+      statusStr = tr("killed");
+      break;
+    }
+    setCell(2, statusStr);
+    setCell(3, QString::number(p.priority));
+    setCell(4, QString::fromStdString(p.uid));
+    setCell(5, QString::number(p.step_count));
+    setCell(6, QString::number(p.elapsed_time, 'f', 3) + tr("s"));
+
+    // Memory in human-readable format
+    QString memStr;
+    if (p.current_memory >= 1024 * 1024)
+      memStr = QString::number(p.current_memory / (1024.0 * 1024.0), 'f', 1) + tr(" MB");
+    else if (p.current_memory >= 1024)
+      memStr = QString::number(p.current_memory / 1024.0, 'f', 1) + tr(" KB");
+    else
+      memStr = QString::number(p.current_memory) + tr(" B");
+    setCell(7, memStr);
+  }
+}
+
+void StateDashboardWidget::onProcessTableSelectionChanged() {
+  bool hasSelection = !m_processTable->selectedItems().isEmpty();
+  m_pauseBtn->setEnabled(hasSelection);
+  m_resumeBtn->setEnabled(hasSelection);
+  m_killBtn->setEnabled(hasSelection);
+}
+
+int getSelectedPid(QTableWidget *table) {
+  auto items = table->selectedItems();
+  if (items.isEmpty())
+    return -1;
+  return table->item(items[0]->row(), 0)->text().toInt();
+}
+
+void StateDashboardWidget::onPauseProcessClicked() {
+  if (!m_scheduler)
+    return;
+  int pid = getSelectedPid(m_processTable);
+  if (pid >= 0) {
+    m_scheduler->pause(pid);
+    refreshProcessList();
+  }
+}
+
+void StateDashboardWidget::onResumeProcessClicked() {
+  if (!m_scheduler)
+    return;
+  int pid = getSelectedPid(m_processTable);
+  if (pid >= 0) {
+    m_scheduler->resume(pid);
+    refreshProcessList();
+  }
+}
+
+void StateDashboardWidget::onKillProcessClicked() {
+  if (!m_scheduler)
+    return;
+  int pid = getSelectedPid(m_processTable);
+  if (pid >= 0) {
+    m_scheduler->kill(pid);
+    refreshProcessList();
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tab 3 — Cluster & Networking
+// ═══════════════════════════════════════════════════════════════════════════
+
+void StateDashboardWidget::buildClusterTab(QTabWidget *tabs) {
+  auto *page = new QWidget;
+  auto *layout = new QVBoxLayout(page);
+  layout->setContentsMargins(2, 2, 2, 2);
+
+  // Node identity
+  auto *idGroup = new QGroupBox(tr("Local Node"));
+  auto *idLayout = new QVBoxLayout(idGroup);
+  m_nodeIdLabel = new QLabel(tr("Node ID: (not connected)"));
+  m_clusterIdLabel = new QLabel(tr("Cluster ID: (none)"));
+  m_leaderLabel = new QLabel(tr("Leader: (unknown)"));
+  idLayout->addWidget(m_nodeIdLabel);
+  idLayout->addWidget(m_clusterIdLabel);
+  idLayout->addWidget(m_leaderLabel);
+  layout->addWidget(idGroup);
+
+  // Peer list
+  auto *peerGroup = new QGroupBox(tr("Peers"));
+  auto *peerLayout = new QVBoxLayout(peerGroup);
+
+  m_peerTable = new QTableWidget;
+  m_peerTable->setColumnCount(4);
+  m_peerTable->setHorizontalHeaderLabels(
+      {tr("Node ID"), tr("Endpoint"), tr("State"), tr("Last Heartbeat")});
+  m_peerTable->horizontalHeader()->setStretchLastSection(true);
+  m_peerTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+  m_peerTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+  peerLayout->addWidget(m_peerTable);
+
+  // Connect to peer
+  auto *connectBar = new QHBoxLayout;
+  m_peerEndpointInput = new QLineEdit;
+  m_peerEndpointInput->setPlaceholderText(tr("host:port"));
+  m_connectPeerBtn = new QPushButton(tr("Connect"));
+  connect(m_connectPeerBtn, &QPushButton::clicked, this,
+          &StateDashboardWidget::onConnectPeerClicked);
+  connectBar->addWidget(m_peerEndpointInput);
+  connectBar->addWidget(m_connectPeerBtn);
+  peerLayout->addLayout(connectBar);
+  layout->addWidget(peerGroup);
+
+  // Stats
+  auto *statsGroup = new QGroupBox(tr("Cluster Statistics"));
+  auto *statsLayout = new QVBoxLayout(statsGroup);
+  m_busStatsLabel = new QLabel(tr("Message Bus: (no shard)"));
+  m_shardStatsLabel = new QLabel(tr("Shard: (no shard)"));
+  m_telemetryLabel = new QLabel(tr("Telemetry: (none)"));
+  m_busStatsLabel->setWordWrap(true);
+  m_shardStatsLabel->setWordWrap(true);
+  m_telemetryLabel->setWordWrap(true);
+  statsLayout->addWidget(m_busStatsLabel);
+  statsLayout->addWidget(m_shardStatsLabel);
+  statsLayout->addWidget(m_telemetryLabel);
+  layout->addWidget(statsGroup);
+
+  layout->addStretch();
+
+  // Timer for auto-refreshing cluster info
+  m_clusterRefreshTimer = new QTimer(this);
+  m_clusterRefreshTimer->setInterval(2000);
+  connect(m_clusterRefreshTimer, &QTimer::timeout, this, &StateDashboardWidget::refreshClusterInfo);
+  m_clusterRefreshTimer->start();
+
+  tabs->addTab(page, tr("Cluster"));
+}
+
+void StateDashboardWidget::onConnectPeerClicked() {
+  QString endpoint = m_peerEndpointInput->text().trimmed();
+  if (endpoint.isEmpty())
+    return;
+
+  if (!m_membership) {
+    QMessageBox::information(this, tr("Not Connected"),
+                             tr("No cluster membership manager configured."));
+    return;
+  }
+
+  // Register the peer with the endpoint; the membership manager will
+  // initiate heartbeats and the peer will be integrated into the cluster.
+  std::string nodeId = "peer-" + endpoint.toStdString();
+  m_membership->register_peer(nodeId, m_membership->cluster_id(), endpoint.toStdString());
+  m_peerEndpointInput->clear();
+  refreshClusterInfo();
+}
+
+void StateDashboardWidget::refreshClusterInfo() {
+  // Identity
+  if (m_membership) {
+    m_nodeIdLabel->setText(
+        tr("Node ID: %1").arg(QString::fromStdString(m_membership->local_node_id())));
+    m_clusterIdLabel->setText(
+        tr("Cluster ID: %1").arg(QString::fromStdString(m_membership->cluster_id())));
+  } else if (m_shard) {
+    m_nodeIdLabel->setText(tr("Node ID: %1").arg(QString::fromStdString(m_shard->local_node_id())));
+    m_clusterIdLabel->setText(
+        tr("Cluster ID: %1").arg(QString::fromStdString(m_shard->cluster_id())));
+  }
+
+  // Peer table
+  if (m_membership) {
+    auto peers = m_membership->peer_snapshot();
+    m_peerTable->setRowCount(static_cast<int>(peers.size()));
+    for (int i = 0; i < static_cast<int>(peers.size()); ++i) {
+      auto &p = peers[static_cast<size_t>(i)];
+      auto setCell = [this, i](int col, const QString &text) {
+        auto *item = new QTableWidgetItem(text);
+        item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+        m_peerTable->setItem(i, col, item);
+      };
+
+      setCell(0, QString::fromStdString(p.node_id));
+      setCell(1, QString::fromStdString(p.endpoint));
+
+      QString stateStr;
+      switch (p.state) {
+      case state_cluster_membership::peer_state::alive:
+        stateStr = tr("alive");
+        break;
+      case state_cluster_membership::peer_state::suspect:
+        stateStr = tr("suspect");
+        break;
+      case state_cluster_membership::peer_state::dead:
+        stateStr = tr("dead");
+        break;
+      }
+      setCell(2, stateStr);
+      setCell(3, QString::number(p.last_heartbeat_ns));
+    }
+  }
+
+  // Message bus stats
+  if (m_shard) {
+    auto &bus = m_shard->message_bus();
+    m_busStatsLabel->setText(tr("Message Bus — admitted: %1, dispatched: %2, duplicates: %3, "
+                                "dropped: %4, subscribers: %5, dedup size: %6")
+                                 .arg(bus.total_admitted())
+                                 .arg(bus.total_dispatched())
+                                 .arg(bus.total_duplicates())
+                                 .arg(bus.total_dropped())
+                                 .arg(bus.subscriber_count())
+                                 .arg(bus.dedup_size()));
+
+    m_shardStatsLabel->setText(tr("Shard — attached: %1, remote applied: %2, rejected: %3, "
+                                  "conflicts: %4, duplicates: %5")
+                                   .arg(m_shard->is_attached() ? tr("yes") : tr("no"))
+                                   .arg(m_shard->total_remote_applied())
+                                   .arg(m_shard->total_remote_rejected())
+                                   .arg(m_shard->total_conflicts_detected())
+                                   .arg(m_shard->total_remote_duplicates()));
+  }
+
+  // Telemetry
+  if (m_telemetryAgg) {
+    auto summary = m_telemetryAgg->summarize();
+    m_telemetryLabel->setText(tr("Telemetry — nodes: %1, stale: %2, mutations published: %3, "
+                                 "applied: %4, messages admitted: %5")
+                                  .arg(summary.node_count)
+                                  .arg(summary.stale_count)
+                                  .arg(summary.total_mutations_published)
+                                  .arg(summary.total_mutations_applied)
+                                  .arg(summary.total_messages_admitted));
+  }
+}

--- a/src/volrover3/tests/StateDashboardWidgetTest.cpp
+++ b/src/volrover3/tests/StateDashboardWidgetTest.cpp
@@ -1,0 +1,1324 @@
+#include <QApplication>
+#include <QSet>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <cvc/core/app.h>
+#include <cvc/core/state.h>
+#include <cvc/core/state_cluster_membership.h>
+#include <cvc/core/state_cluster_shard.h>
+#include <cvc/core/state_exec/builtins.h>
+#include <cvc/core/state_exec/scheduler.h>
+#include <cvc/core/state_message_bus.h>
+#include <cvc/core/state_telemetry_aggregator.h>
+#include <gtest/gtest.h>
+#include <volrover3/AppState.h>
+#include <volrover3/StateDashboardWidget.h>
+#include <volrover3/volrover3_app.h>
+
+using namespace cvc;
+using namespace cvc::state_exec;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// State Tree Tab Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+class StateDashboardTreeTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    root = &state::instance(volrover3::app())("dashboard_test");
+    root->operator()("alpha").value("aaa");
+    root->operator()("beta").value("bbb");
+    root->operator()("gamma").value("parent");
+    root->operator()("gamma")("child1").value("c1");
+    root->operator()("gamma")("child2").value("c2");
+
+    widget = new StateDashboardWidget();
+    widget->setRootState(root);
+  }
+
+  void TearDown() override {
+    delete widget;
+    root->reset();
+  }
+
+  state *root;
+  StateDashboardWidget *widget;
+};
+
+TEST_F(StateDashboardTreeTest, WidgetCreation) {
+  ASSERT_NE(widget, nullptr);
+  EXPECT_FALSE(widget->isVisible());
+}
+
+TEST_F(StateDashboardTreeTest, RefreshDoesNotCrash) { EXPECT_NO_THROW(widget->refresh()); }
+
+TEST_F(StateDashboardTreeTest, SetRootStatePopulatesTree) {
+  // Re-set to force population
+  widget->setRootState(root);
+  QCoreApplication::processEvents();
+
+  // Verify the state hierarchy is there
+  auto children = root->children();
+  bool hasAlpha = false, hasBeta = false, hasGamma = false;
+  for (auto &c : children) {
+    if (c.find("alpha") != std::string::npos)
+      hasAlpha = true;
+    if (c.find("beta") != std::string::npos)
+      hasBeta = true;
+    if (c.find("gamma") != std::string::npos)
+      hasGamma = true;
+  }
+  EXPECT_TRUE(hasAlpha);
+  EXPECT_TRUE(hasBeta);
+  EXPECT_TRUE(hasGamma);
+}
+
+TEST_F(StateDashboardTreeTest, StateValueReadBack) {
+  EXPECT_EQ(root->operator()("alpha").value(), "aaa");
+  EXPECT_EQ(root->operator()("beta").value(), "bbb");
+  EXPECT_EQ(root->operator()("gamma")("child1").value(), "c1");
+}
+
+TEST_F(StateDashboardTreeTest, SetRootNullSafe) {
+  EXPECT_NO_THROW(widget->setRootState(nullptr));
+  EXPECT_NO_THROW(widget->refresh());
+}
+
+TEST_F(StateDashboardTreeTest, DynamicStateAdd) {
+  widget->show();
+  QCoreApplication::processEvents();
+
+  root->operator()("dynamic_node").value("dyn");
+  QCoreApplication::processEvents();
+
+  EXPECT_TRUE(root->operator()("dynamic_node").initialized());
+  EXPECT_EQ(root->operator()("dynamic_node").value(), "dyn");
+}
+
+TEST_F(StateDashboardTreeTest, StateReset) {
+  auto &child = root->operator()("alpha");
+  EXPECT_TRUE(child.initialized());
+  child.reset();
+  EXPECT_FALSE(child.initialized());
+}
+
+TEST_F(StateDashboardTreeTest, NestedStateNavigation) {
+  auto &gamma = root->operator()("gamma");
+  EXPECT_TRUE(gamma.initialized());
+  EXPECT_EQ(gamma("child1").value(), "c1");
+  EXPECT_EQ(gamma("child2").value(), "c2");
+}
+
+TEST_F(StateDashboardTreeTest, StateMetadata) {
+  auto &s = root->operator()("alpha");
+
+  s.comment("test comment");
+  EXPECT_EQ(s.comment(), "test comment");
+
+  EXPECT_FALSE(s.readOnly());
+  EXPECT_FALSE(s.hidden());
+
+  s.readOnly(true);
+  EXPECT_TRUE(s.readOnly());
+
+  s.hidden(true);
+  EXPECT_TRUE(s.hidden());
+
+  s.readOnly(false);
+  s.hidden(false);
+}
+
+TEST_F(StateDashboardTreeTest, StateLastModified) {
+  auto &s = root->operator()("alpha");
+  auto mod = s.lastMod();
+  EXPECT_FALSE(mod.is_not_a_date_time());
+}
+
+TEST_F(StateDashboardTreeTest, StateLinkProperties) {
+  auto &link = root->operator()("link_node");
+  EXPECT_FALSE(link.isLink());
+
+  link.linkTo("dashboard_test.alpha");
+  EXPECT_TRUE(link.isLink());
+  EXPECT_EQ(link.linkTarget(), "dashboard_test.alpha");
+
+  link.clearLink();
+  EXPECT_FALSE(link.isLink());
+}
+
+TEST_F(StateDashboardTreeTest, StateExpiryProperties) {
+  auto &s = root->operator()("expire_test");
+  s.value("will expire");
+
+  EXPECT_FALSE(s.hasExpiry());
+
+  auto future = boost::posix_time::microsec_clock::universal_time() + boost::posix_time::hours(1);
+  s.expireAt(future);
+
+  EXPECT_TRUE(s.hasExpiry());
+  EXPECT_FALSE(s.isExpired());
+
+  s.clearExpiry();
+  EXPECT_FALSE(s.hasExpiry());
+}
+
+TEST_F(StateDashboardTreeTest, TypedValueRoundTrips) {
+  auto &s = root->operator()("typed");
+
+  s.value(42);
+  EXPECT_EQ(s.value(), "42");
+
+  s.value(3.14);
+  EXPECT_NE(s.value(), "");
+  EXPECT_TRUE(s.value().find("3.14") == 0);
+
+  s.value(true);
+  EXPECT_EQ(s.value(), "1");
+
+  s.value(std::string("hello"));
+  EXPECT_EQ(s.value(), "hello");
+}
+
+TEST_F(StateDashboardTreeTest, RefreshAfterMutation) {
+  root->operator()("new_child").value("nc");
+  EXPECT_NO_THROW(widget->refresh());
+
+  root->operator()("new_child").reset();
+  EXPECT_NO_THROW(widget->refresh());
+}
+
+TEST_F(StateDashboardTreeTest, MultipleSetRootCalls) {
+  EXPECT_NO_THROW(widget->setRootState(root));
+  EXPECT_NO_THROW(widget->setRootState(root));
+  EXPECT_NO_THROW(widget->setRootState(nullptr));
+  EXPECT_NO_THROW(widget->setRootState(root));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Exec Console Tab Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+class StateDashboardExecTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    env = builtins::make_default_environment();
+    sched = std::make_unique<scheduler>();
+    widget = new StateDashboardWidget();
+    widget->setScheduler(sched.get());
+  }
+
+  void TearDown() override { delete widget; }
+
+  environment_ptr env;
+  std::unique_ptr<scheduler> sched;
+  StateDashboardWidget *widget;
+};
+
+TEST_F(StateDashboardExecTest, SetSchedulerNullSafe) {
+  EXPECT_NO_THROW(widget->setScheduler(nullptr));
+  EXPECT_NO_THROW(widget->refresh());
+}
+
+TEST_F(StateDashboardExecTest, ProcessListEmpty) {
+  auto procs = sched->list_processes();
+  EXPECT_TRUE(procs.empty());
+  EXPECT_NO_THROW(widget->refresh());
+}
+
+TEST_F(StateDashboardExecTest, ProcessSubmitAndList) {
+  execute_options opts;
+  opts.name = "test_proc";
+  int pid = sched->execute(std::string("(+ 1 2)"), opts);
+  EXPECT_GT(pid, 0);
+
+  auto procs = sched->list_processes();
+  EXPECT_EQ(procs.size(), 1u);
+  EXPECT_EQ(procs[0].pid, pid);
+  EXPECT_EQ(procs[0].name, "test_proc");
+}
+
+TEST_F(StateDashboardExecTest, ProcessPauseResumeKill) {
+  execute_options opts;
+  opts.name = "infinite";
+  int pid = sched->execute(std::string("(begin (while t nil))"), opts);
+
+  // Run one step to make it running
+  sched->step();
+
+  auto info = sched->get_process_info(pid);
+  ASSERT_TRUE(info.has_value());
+  EXPECT_EQ(info->status, process_status::ready);
+
+  // Pause
+  EXPECT_TRUE(sched->pause(pid));
+  info = sched->get_process_info(pid);
+  EXPECT_EQ(info->status, process_status::paused);
+
+  // Resume
+  EXPECT_TRUE(sched->resume(pid));
+  info = sched->get_process_info(pid);
+  EXPECT_EQ(info->status, process_status::ready);
+
+  // Kill
+  EXPECT_TRUE(sched->kill(pid));
+  info = sched->get_process_info(pid);
+  EXPECT_EQ(info->status, process_status::killed);
+}
+
+TEST_F(StateDashboardExecTest, ProcessRunToCompletion) {
+  execute_options opts;
+  opts.name = "simple_add";
+  int pid = sched->execute(std::string("(+ 10 20)"), opts);
+  auto results = sched->run();
+
+  EXPECT_TRUE(results.count(pid));
+  auto &result = results[pid];
+  EXPECT_EQ(std::get<int64_t>(result.v), 30);
+}
+
+TEST_F(StateDashboardExecTest, MultipleProcesses) {
+  execute_options opts_a;
+  opts_a.name = "proc_a";
+  execute_options opts_b;
+  opts_b.name = "proc_b";
+  execute_options opts_c;
+  opts_c.name = "proc_c";
+  sched->execute(std::string("(+ 1 1)"), opts_a);
+  sched->execute(std::string("(+ 2 2)"), opts_b);
+  sched->execute(std::string("(+ 3 3)"), opts_c);
+
+  auto procs = sched->list_processes();
+  EXPECT_EQ(procs.size(), 3u);
+
+  auto results = sched->run();
+  EXPECT_EQ(results.size(), 3u);
+}
+
+TEST_F(StateDashboardExecTest, SchedulerStats) {
+  sched->execute(std::string("(+ 1 1)"));
+  sched->execute(std::string("(+ 2 2)"));
+
+  auto stats = sched->get_stats();
+  EXPECT_EQ(stats.total_processes, 2u);
+
+  sched->run();
+  stats = sched->get_stats();
+  EXPECT_EQ(stats.terminated, 2u);
+}
+
+TEST_F(StateDashboardExecTest, RefreshWithProcesses) {
+  execute_options opts;
+  opts.name = "refresh_test";
+  sched->execute(std::string("(+ 1 2)"), opts);
+  EXPECT_NO_THROW(widget->refresh());
+  sched->run();
+  EXPECT_NO_THROW(widget->refresh());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cluster Tab Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+class StateDashboardClusterTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    root = &state::instance(volrover3::app())("cluster_dashboard_test");
+    root->value("cluster_root");
+
+    shard = std::make_unique<state_cluster_shard>(volrover3::app(), "test_cluster", "node_local");
+    membership = std::make_unique<state_cluster_membership>("test_cluster", "node_local");
+    telemetry = std::make_unique<state_telemetry_aggregator>("test_cluster");
+
+    widget = new StateDashboardWidget();
+    widget->setShard(shard.get());
+    widget->setMembership(membership.get());
+    widget->setTelemetryAggregator(telemetry.get());
+  }
+
+  void TearDown() override {
+    delete widget;
+    root->reset();
+  }
+
+  state *root;
+  std::unique_ptr<state_cluster_shard> shard;
+  std::unique_ptr<state_cluster_membership> membership;
+  std::unique_ptr<state_telemetry_aggregator> telemetry;
+  StateDashboardWidget *widget;
+};
+
+TEST_F(StateDashboardClusterTest, WidgetCreation) { ASSERT_NE(widget, nullptr); }
+
+TEST_F(StateDashboardClusterTest, SetComponentsNullSafe) {
+  auto *w = new StateDashboardWidget();
+  EXPECT_NO_THROW(w->setShard(nullptr));
+  EXPECT_NO_THROW(w->setMembership(nullptr));
+  EXPECT_NO_THROW(w->setTelemetryAggregator(nullptr));
+  EXPECT_NO_THROW(w->setCoordinator(nullptr));
+  EXPECT_NO_THROW(w->refresh());
+  delete w;
+}
+
+TEST_F(StateDashboardClusterTest, ClusterIdentity) {
+  EXPECT_EQ(shard->cluster_id(), "test_cluster");
+  EXPECT_EQ(shard->local_node_id(), "node_local");
+  EXPECT_EQ(membership->cluster_id(), "test_cluster");
+  EXPECT_EQ(membership->local_node_id(), "node_local");
+}
+
+TEST_F(StateDashboardClusterTest, PeerRegistration) {
+  membership->register_peer("peer_1", "test_cluster", "host1:9001");
+  membership->register_peer("peer_2", "test_cluster", "host2:9002");
+
+  auto peers = membership->peer_snapshot();
+  EXPECT_EQ(peers.size(), 2u);
+}
+
+TEST_F(StateDashboardClusterTest, PeerSnapshot) {
+  membership->register_peer("peer_a", "test_cluster", "10.0.0.1:5000");
+
+  auto peers = membership->peer_snapshot();
+  ASSERT_EQ(peers.size(), 1u);
+  EXPECT_EQ(peers[0].node_id, "peer_a");
+  EXPECT_EQ(peers[0].endpoint, "10.0.0.1:5000");
+}
+
+TEST_F(StateDashboardClusterTest, MessageBusStats) {
+  auto &bus = shard->message_bus();
+  EXPECT_EQ(bus.total_admitted(), 0u);
+  EXPECT_EQ(bus.total_dispatched(), 0u);
+  EXPECT_EQ(bus.total_dropped(), 0u);
+}
+
+TEST_F(StateDashboardClusterTest, ShardCounters) {
+  EXPECT_EQ(shard->total_remote_applied(), 0u);
+  EXPECT_EQ(shard->total_remote_rejected(), 0u);
+  EXPECT_EQ(shard->total_conflicts_detected(), 0u);
+}
+
+TEST_F(StateDashboardClusterTest, ShardAttachDetach) {
+  EXPECT_FALSE(shard->is_attached());
+  shard->attach();
+  EXPECT_TRUE(shard->is_attached());
+  shard->detach();
+  EXPECT_FALSE(shard->is_attached());
+}
+
+TEST_F(StateDashboardClusterTest, TelemetrySummary) {
+  auto summary = telemetry->summarize();
+  EXPECT_EQ(summary.node_count, 0u);
+}
+
+TEST_F(StateDashboardClusterTest, RefreshWithAllComponents) {
+  membership->register_peer("refresh_peer", "test_cluster", "host:1234");
+  EXPECT_NO_THROW(widget->refresh());
+}
+
+TEST_F(StateDashboardClusterTest, MembershipCounters) {
+  EXPECT_EQ(membership->total_heartbeats_sent(), 0u);
+  EXPECT_EQ(membership->total_heartbeats_received(), 0u);
+  EXPECT_EQ(membership->total_peers_joined(), 0u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cross-tab Integration Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+class StateDashboardIntegrationTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    root = &state::instance(volrover3::app())("integration_dashboard_test");
+    root->operator()("config")("greeting").value("hello");
+
+    env = builtins::make_default_environment();
+    sched = std::make_unique<scheduler>();
+    shard = std::make_unique<state_cluster_shard>(volrover3::app(), "integ_cluster", "integ_node");
+    membership = std::make_unique<state_cluster_membership>("integ_cluster", "integ_node");
+
+    widget = new StateDashboardWidget();
+    widget->setRootState(root);
+    widget->setScheduler(sched.get());
+    widget->setShard(shard.get());
+    widget->setMembership(membership.get());
+  }
+
+  void TearDown() override {
+    delete widget;
+    root->reset();
+  }
+
+  state *root;
+  environment_ptr env;
+  std::unique_ptr<scheduler> sched;
+  std::unique_ptr<state_cluster_shard> shard;
+  std::unique_ptr<state_cluster_membership> membership;
+  StateDashboardWidget *widget;
+};
+
+TEST_F(StateDashboardIntegrationTest, FullRefreshAllTabs) {
+  execute_options opts;
+  opts.name = "integ_proc";
+  sched->execute(std::string("(+ 1 1)"), opts);
+  membership->register_peer("integ_peer", "integ_cluster", "localhost:9999");
+
+  EXPECT_NO_THROW(widget->refresh());
+}
+
+TEST_F(StateDashboardIntegrationTest, ShowAndRefresh) {
+  widget->show();
+  QCoreApplication::processEvents();
+
+  EXPECT_NO_THROW(widget->refresh());
+  QCoreApplication::processEvents();
+
+  widget->hide();
+}
+
+TEST_F(StateDashboardIntegrationTest, WidgetDeleteOnClose) {
+  auto *w = new StateDashboardWidget();
+  w->setAttribute(Qt::WA_DeleteOnClose);
+  w->setRootState(root);
+  w->show();
+  QCoreApplication::processEvents();
+  w->close();
+  QCoreApplication::processEvents();
+  // Widget is now deleted due to WA_DeleteOnClose
+}
+
+TEST_F(StateDashboardIntegrationTest, StateModWhileProcessRunning) {
+  execute_options opts;
+  opts.name = "bg_proc";
+  sched->execute(std::string("(begin (while t nil))"), opts);
+  sched->step();
+
+  root->operator()("config")("greeting").value("modified");
+  EXPECT_EQ(root->operator()("config")("greeting").value(), "modified");
+
+  EXPECT_NO_THROW(widget->refresh());
+}
+
+TEST_F(StateDashboardIntegrationTest, MultipleWidgets) {
+  auto *w2 = new StateDashboardWidget();
+  w2->setRootState(root);
+  w2->setScheduler(sched.get());
+
+  EXPECT_NO_THROW(widget->refresh());
+  EXPECT_NO_THROW(w2->refresh());
+
+  delete w2;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// State Tree UI Interaction Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+class StateDashboardTreeUITest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    root = &state::instance(volrover3::app())("tree_ui_test");
+    root->operator()("apple").value("red");
+    root->operator()("banana").value("yellow");
+    root->operator()("cherry").value("dark");
+    root->operator()("apple")("seed").value("small");
+    root->operator()("typed_int").value(42);
+    root->operator()("typed_dbl").value(3.14);
+    root->operator()("typed_bool").value(true);
+
+    widget = new StateDashboardWidget();
+    widget->setRootState(root);
+    widget->show();
+    QCoreApplication::processEvents();
+
+    // Locate internal widgets by type
+    tree = widget->findChild<QTreeWidget *>();
+    ASSERT_NE(tree, nullptr);
+
+    // Identify tables by column count: property(2), process(8), peer(4)
+    for (auto *table : widget->findChildren<QTableWidget *>()) {
+      if (table->columnCount() == 2)
+        propTable = table;
+      else if (table->columnCount() == 8)
+        procTable = table;
+      else if (table->columnCount() == 4)
+        peerTable = table;
+    }
+    ASSERT_NE(propTable, nullptr);
+  }
+
+  void TearDown() override {
+    delete widget;
+    root->reset();
+  }
+
+  // Select a tree item matching the given text (depth-first)
+  QTreeWidgetItem *selectItemByText(QTreeWidgetItem *parent, const QString &text) {
+    for (int i = 0; i < parent->childCount(); ++i) {
+      auto *child = parent->child(i);
+      if (child->text(0) == text) {
+        auto idx = tree->indexFromItem(child);
+        tree->selectionModel()->select(idx, QItemSelectionModel::ClearAndSelect);
+        tree->setCurrentItem(child);
+        QCoreApplication::processEvents();
+        return child;
+      }
+      auto *found = selectItemByText(child, text);
+      if (found)
+        return found;
+    }
+    return nullptr;
+  }
+
+  state *root;
+  StateDashboardWidget *widget;
+  QTreeWidget *tree;
+  QTableWidget *propTable;
+  QTableWidget *procTable;
+  QTableWidget *peerTable;
+};
+
+// Helper to find a property row by key name
+static int findPropRow(QTableWidget *table, const QString &key) {
+  for (int r = 0; r < table->rowCount(); ++r) {
+    if (table->item(r, 0) && table->item(r, 0)->text() == key)
+      return r;
+  }
+  return -1;
+}
+
+TEST_F(StateDashboardTreeUITest, SelectionPopulatesPropertyTable) {
+  ASSERT_GT(tree->topLevelItemCount(), 0);
+  auto *item = selectItemByText(tree->topLevelItem(0), "apple");
+  ASSERT_NE(item, nullptr);
+
+  EXPECT_GT(propTable->rowCount(), 0);
+  int nameRow = findPropRow(propTable, "Name");
+  ASSERT_GE(nameRow, 0);
+  EXPECT_EQ(propTable->item(nameRow, 1)->text(), "apple");
+
+  int valRow = findPropRow(propTable, "Value");
+  ASSERT_GE(valRow, 0);
+  EXPECT_EQ(propTable->item(valRow, 1)->text(), "red");
+}
+
+TEST_F(StateDashboardTreeUITest, PropertyTableShowsChildren) {
+  selectItemByText(tree->topLevelItem(0), "apple");
+  int row = findPropRow(propTable, "Children");
+  ASSERT_GE(row, 0);
+  EXPECT_EQ(propTable->item(row, 1)->text(), "1"); // apple has child "seed"
+}
+
+TEST_F(StateDashboardTreeUITest, PropertyTableShowsReadOnly) {
+  root->operator()("apple").readOnly(true);
+  widget->setRootState(root); // force clean tree rebuild
+  QCoreApplication::processEvents();
+  selectItemByText(tree->topLevelItem(0), "apple");
+
+  int row = findPropRow(propTable, "Read Only");
+  ASSERT_GE(row, 0);
+  EXPECT_EQ(propTable->item(row, 1)->text(), "true");
+
+  // Value cell should NOT be editable when readOnly
+  int valRow = findPropRow(propTable, "Value");
+  ASSERT_GE(valRow, 0);
+  EXPECT_FALSE(propTable->item(valRow, 1)->flags().testFlag(Qt::ItemIsEditable));
+
+  root->operator()("apple").readOnly(false);
+}
+
+TEST_F(StateDashboardTreeUITest, PropertyTableShowsHidden) {
+  root->operator()("banana").hidden(true);
+  widget->setRootState(root);
+  QCoreApplication::processEvents();
+  selectItemByText(tree->topLevelItem(0), "banana");
+
+  int row = findPropRow(propTable, "Hidden");
+  ASSERT_GE(row, 0);
+  EXPECT_EQ(propTable->item(row, 1)->text(), "true");
+
+  root->operator()("banana").hidden(false);
+}
+
+TEST_F(StateDashboardTreeUITest, PropertyTableShowsComment) {
+  root->operator()("cherry").comment("a tart fruit");
+  widget->setRootState(root);
+  QCoreApplication::processEvents();
+  selectItemByText(tree->topLevelItem(0), "cherry");
+
+  int row = findPropRow(propTable, "Comment");
+  ASSERT_GE(row, 0);
+  EXPECT_EQ(propTable->item(row, 1)->text(), "a tart fruit");
+}
+
+TEST_F(StateDashboardTreeUITest, PropertyEditValueUpdatesState) {
+  selectItemByText(tree->topLevelItem(0), "banana");
+
+  int valRow = findPropRow(propTable, "Value");
+  ASSERT_GE(valRow, 0);
+
+  // Simulate editing the value cell
+  propTable->item(valRow, 1)->setText("green");
+  // cellChanged signal fires automatically on setText
+  QCoreApplication::processEvents();
+
+  EXPECT_EQ(root->operator()("banana").value(), "green");
+}
+
+TEST_F(StateDashboardTreeUITest, PropertyEditCommentUpdatesState) {
+  selectItemByText(tree->topLevelItem(0), "cherry");
+
+  int commentRow = findPropRow(propTable, "Comment");
+  ASSERT_GE(commentRow, 0);
+
+  propTable->item(commentRow, 1)->setText("updated comment");
+  QCoreApplication::processEvents();
+
+  EXPECT_EQ(root->operator()("cherry").comment(), "updated comment");
+}
+
+TEST_F(StateDashboardTreeUITest, ValueEditEmitsStateChanged) {
+  selectItemByText(tree->topLevelItem(0), "apple");
+
+  int signalCount = 0;
+  QObject::connect(widget, &StateDashboardWidget::stateChanged,
+                   [&signalCount]() { ++signalCount; });
+
+  int valRow = findPropRow(propTable, "Value");
+  ASSERT_GE(valRow, 0);
+
+  propTable->item(valRow, 1)->setText("green");
+  QCoreApplication::processEvents();
+
+  EXPECT_GE(signalCount, 1);
+}
+
+TEST_F(StateDashboardTreeUITest, SearchFilterHidesNonMatching) {
+  // Find the tree search box by placeholder text
+  QLineEdit *searchBox = nullptr;
+  for (auto *edit : widget->findChildren<QLineEdit *>()) {
+    if (edit->placeholderText().contains("Filter")) {
+      searchBox = edit;
+      break;
+    }
+  }
+  ASSERT_NE(searchBox, nullptr);
+
+  searchBox->setText("apple");
+  QCoreApplication::processEvents();
+
+  auto *rootItem = tree->topLevelItem(0);
+  for (int i = 0; i < rootItem->childCount(); ++i) {
+    auto *child = rootItem->child(i);
+    if (child->text(0) == "apple") {
+      EXPECT_FALSE(child->isHidden()) << "apple should be visible";
+    } else if (child->text(0) == "banana" || child->text(0) == "cherry") {
+      EXPECT_TRUE(child->isHidden()) << child->text(0).toStdString() << " should be hidden";
+    }
+  }
+}
+
+TEST_F(StateDashboardTreeUITest, SearchFilterClearRestoresAll) {
+  QLineEdit *searchBox = nullptr;
+  for (auto *edit : widget->findChildren<QLineEdit *>()) {
+    if (edit->placeholderText().contains("Filter")) {
+      searchBox = edit;
+      break;
+    }
+  }
+  ASSERT_NE(searchBox, nullptr);
+
+  searchBox->setText("apple");
+  QCoreApplication::processEvents();
+
+  searchBox->setText("");
+  QCoreApplication::processEvents();
+
+  // All items should be visible
+  auto *rootItem = tree->topLevelItem(0);
+  for (int i = 0; i < rootItem->childCount(); ++i) {
+    EXPECT_FALSE(rootItem->child(i)->isHidden()) << rootItem->child(i)->text(0).toStdString();
+  }
+}
+
+TEST_F(StateDashboardTreeUITest, LinkPropertiesShowInTable) {
+  auto &link = root->operator()("linked");
+  link.linkTo("tree_ui_test.apple");
+  widget->setRootState(root);
+  QCoreApplication::processEvents();
+
+  selectItemByText(tree->topLevelItem(0), "linked");
+
+  int isLinkRow = findPropRow(propTable, "Is Link");
+  ASSERT_GE(isLinkRow, 0);
+  EXPECT_EQ(propTable->item(isLinkRow, 1)->text(), "true");
+
+  int targetRow = findPropRow(propTable, "Link Target");
+  ASSERT_GE(targetRow, 0);
+  EXPECT_EQ(propTable->item(targetRow, 1)->text(), "tree_ui_test.apple");
+
+  int resRow = findPropRow(propTable, "Link Resolution");
+  ASSERT_GE(resRow, 0);
+  EXPECT_EQ(propTable->item(resRow, 1)->text(), "resolved");
+}
+
+TEST_F(StateDashboardTreeUITest, ExpiryPropertiesShowInTable) {
+  auto &s = root->operator()("will_expire");
+  s.value("temp");
+  auto future = boost::posix_time::microsec_clock::universal_time() + boost::posix_time::hours(1);
+  s.expireAt(future);
+  widget->setRootState(root);
+  QCoreApplication::processEvents();
+
+  selectItemByText(tree->topLevelItem(0), "will_expire");
+
+  int hasExpRow = findPropRow(propTable, "Has Expiry");
+  ASSERT_GE(hasExpRow, 0);
+  EXPECT_EQ(propTable->item(hasExpRow, 1)->text(), "true");
+
+  int expiredRow = findPropRow(propTable, "Expired");
+  ASSERT_GE(expiredRow, 0);
+  EXPECT_EQ(propTable->item(expiredRow, 1)->text(), "false");
+}
+
+TEST_F(StateDashboardTreeUITest, TypedIntValueInTable) {
+  selectItemByText(tree->topLevelItem(0), "typed_int");
+
+  int valRow = findPropRow(propTable, "Value");
+  ASSERT_GE(valRow, 0);
+  EXPECT_EQ(propTable->item(valRow, 1)->text(), "42");
+
+  int typeRow = findPropRow(propTable, "Value Type");
+  ASSERT_GE(typeRow, 0);
+  EXPECT_FALSE(propTable->item(typeRow, 1)->text().isEmpty());
+}
+
+TEST_F(StateDashboardTreeUITest, SelectionClearEmptiesProperties) {
+  selectItemByText(tree->topLevelItem(0), "apple");
+  EXPECT_GT(propTable->rowCount(), 0);
+
+  tree->clearSelection();
+  QCoreApplication::processEvents();
+
+  EXPECT_EQ(propTable->rowCount(), 0);
+}
+
+TEST_F(StateDashboardTreeUITest, LastModifiedShownInProperties) {
+  root->operator()("apple").value("updated");
+  widget->setRootState(root);
+  QCoreApplication::processEvents();
+  selectItemByText(tree->topLevelItem(0), "apple");
+
+  int row = findPropRow(propTable, "Last Modified");
+  ASSERT_GE(row, 0);
+  // Should not be "(unknown)" since we just wrote a value
+  EXPECT_NE(propTable->item(row, 1)->text(), "(unknown)");
+}
+
+TEST_F(StateDashboardTreeUITest, DeleteButtonDisabledWithNoSelection) {
+  auto buttons = widget->findChildren<QPushButton *>();
+  QPushButton *deleteBtn = nullptr;
+  for (auto *btn : buttons) {
+    if (btn->text() == "Delete State") {
+      deleteBtn = btn;
+      break;
+    }
+  }
+  ASSERT_NE(deleteBtn, nullptr);
+
+  tree->clearSelection();
+  QCoreApplication::processEvents();
+  EXPECT_FALSE(deleteBtn->isEnabled());
+}
+
+TEST_F(StateDashboardTreeUITest, DeleteButtonEnabledWithSelection) {
+  auto buttons = widget->findChildren<QPushButton *>();
+  QPushButton *deleteBtn = nullptr;
+  for (auto *btn : buttons) {
+    if (btn->text() == "Delete State") {
+      deleteBtn = btn;
+      break;
+    }
+  }
+  ASSERT_NE(deleteBtn, nullptr);
+
+  selectItemByText(tree->topLevelItem(0), "banana");
+  EXPECT_TRUE(deleteBtn->isEnabled());
+}
+
+TEST_F(StateDashboardTreeUITest, NestedChildSelectionShowsProperties) {
+  selectItemByText(tree->topLevelItem(0), "seed");
+
+  int nameRow = findPropRow(propTable, "Name");
+  ASSERT_GE(nameRow, 0);
+  EXPECT_EQ(propTable->item(nameRow, 1)->text(), "seed");
+
+  int valRow = findPropRow(propTable, "Value");
+  ASSERT_GE(valRow, 0);
+  EXPECT_EQ(propTable->item(valRow, 1)->text(), "small");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Exec Console UI Interaction Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+class StateDashboardExecUITest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    env = builtins::make_default_environment();
+    sched = std::make_unique<scheduler>();
+
+    widget = new StateDashboardWidget();
+    widget->setScheduler(sched.get());
+    widget->show();
+    QCoreApplication::processEvents();
+
+    // Locate internal widgets — identify by readOnly flag
+    for (auto *editor : widget->findChildren<QPlainTextEdit *>()) {
+      if (editor->isReadOnly())
+        outputPanel = editor;
+      else
+        scriptEditor = editor;
+    }
+    ASSERT_NE(scriptEditor, nullptr);
+    ASSERT_NE(outputPanel, nullptr);
+
+    // processTable has 8 columns
+    for (auto *table : widget->findChildren<QTableWidget *>()) {
+      if (table->columnCount() == 8) {
+        processTable = table;
+        break;
+      }
+    }
+    ASSERT_NE(processTable, nullptr);
+
+    // Find buttons by text
+    for (auto *btn : widget->findChildren<QPushButton *>()) {
+      if (btn->text() == "Run")
+        runBtn = btn;
+      else if (btn->text() == "Clear Output")
+        clearBtn = btn;
+      else if (btn->text() == "Pause")
+        pauseBtn = btn;
+      else if (btn->text() == "Resume")
+        resumeBtn = btn;
+      else if (btn->text() == "Kill")
+        killBtn = btn;
+    }
+  }
+
+  void TearDown() override { delete widget; }
+
+  environment_ptr env;
+  std::unique_ptr<scheduler> sched;
+  StateDashboardWidget *widget;
+  QPlainTextEdit *scriptEditor = nullptr;
+  QPlainTextEdit *outputPanel = nullptr;
+  QTableWidget *processTable = nullptr;
+  QPushButton *runBtn = nullptr;
+  QPushButton *clearBtn = nullptr;
+  QPushButton *pauseBtn = nullptr;
+  QPushButton *resumeBtn = nullptr;
+  QPushButton *killBtn = nullptr;
+};
+
+TEST_F(StateDashboardExecUITest, RunScriptShowsOutput) {
+  ASSERT_NE(scriptEditor, nullptr);
+  ASSERT_NE(runBtn, nullptr);
+
+  scriptEditor->setPlainText("(+ 10 20)");
+  runBtn->click();
+  QCoreApplication::processEvents();
+
+  QString output = outputPanel->toPlainText();
+  EXPECT_TRUE(output.contains("30")) << output.toStdString();
+}
+
+TEST_F(StateDashboardExecUITest, RunScriptErrorShowsError) {
+  scriptEditor->setPlainText("(undefined_func 1 2)");
+  runBtn->click();
+  QCoreApplication::processEvents();
+
+  QString output = outputPanel->toPlainText();
+  EXPECT_TRUE(output.contains("ERROR")) << output.toStdString();
+}
+
+TEST_F(StateDashboardExecUITest, RunScriptShowsEcho) {
+  scriptEditor->setPlainText("(* 3 7)");
+  runBtn->click();
+  QCoreApplication::processEvents();
+
+  QString output = outputPanel->toPlainText();
+  // The script itself is echoed with "> " prefix
+  EXPECT_TRUE(output.contains("> (* 3 7)")) << output.toStdString();
+}
+
+TEST_F(StateDashboardExecUITest, EmptyScriptDoesNothing) {
+  scriptEditor->setPlainText("");
+  runBtn->click();
+  QCoreApplication::processEvents();
+
+  EXPECT_TRUE(outputPanel->toPlainText().isEmpty());
+}
+
+TEST_F(StateDashboardExecUITest, ClearOutputClearsPanel) {
+  scriptEditor->setPlainText("(+ 1 1)");
+  runBtn->click();
+  QCoreApplication::processEvents();
+  EXPECT_FALSE(outputPanel->toPlainText().isEmpty());
+
+  clearBtn->click();
+  QCoreApplication::processEvents();
+  EXPECT_TRUE(outputPanel->toPlainText().isEmpty());
+}
+
+TEST_F(StateDashboardExecUITest, ProcessTableShowsSubmittedProcess) {
+  execute_options opts;
+  opts.name = "table_test_proc";
+  sched->execute(std::string("(begin (while t nil))"), opts);
+
+  widget->refresh();
+  QCoreApplication::processEvents();
+
+  ASSERT_EQ(processTable->rowCount(), 1);
+  // Column 0: PID, Column 1: Name
+  EXPECT_EQ(processTable->item(0, 1)->text(), "table_test_proc");
+}
+
+TEST_F(StateDashboardExecUITest, ProcessTableShowsStatus) {
+  execute_options opts;
+  opts.name = "status_proc";
+  int pid = sched->execute(std::string("(begin (while t nil))"), opts);
+
+  widget->refresh();
+  QCoreApplication::processEvents();
+
+  // should be "ready" before any steps
+  EXPECT_EQ(processTable->item(0, 2)->text(), "ready");
+
+  sched->pause(pid);
+  widget->refresh();
+  QCoreApplication::processEvents();
+
+  EXPECT_EQ(processTable->item(0, 2)->text(), "paused");
+}
+
+TEST_F(StateDashboardExecUITest, ProcessButtonsDisabledWithoutSelection) {
+  EXPECT_FALSE(pauseBtn->isEnabled());
+  EXPECT_FALSE(resumeBtn->isEnabled());
+  EXPECT_FALSE(killBtn->isEnabled());
+}
+
+TEST_F(StateDashboardExecUITest, ProcessButtonsEnabledOnSelection) {
+  execute_options opts;
+  opts.name = "select_proc";
+  sched->execute(std::string("(begin (while t nil))"), opts);
+  widget->refresh();
+  QCoreApplication::processEvents();
+
+  processTable->selectRow(0);
+  QCoreApplication::processEvents();
+
+  EXPECT_TRUE(pauseBtn->isEnabled());
+  EXPECT_TRUE(resumeBtn->isEnabled());
+  EXPECT_TRUE(killBtn->isEnabled());
+}
+
+TEST_F(StateDashboardExecUITest, PauseButtonPausesSelectedProcess) {
+  execute_options opts;
+  opts.name = "pause_me";
+  int pid = sched->execute(std::string("(begin (while t nil))"), opts);
+  widget->refresh();
+  QCoreApplication::processEvents();
+
+  processTable->selectRow(0);
+  QCoreApplication::processEvents();
+
+  pauseBtn->click();
+  QCoreApplication::processEvents();
+
+  auto info = sched->get_process_info(pid);
+  ASSERT_TRUE(info.has_value());
+  EXPECT_EQ(info->status, process_status::paused);
+}
+
+TEST_F(StateDashboardExecUITest, KillButtonKillsSelectedProcess) {
+  execute_options opts;
+  opts.name = "kill_me";
+  int pid = sched->execute(std::string("(begin (while t nil))"), opts);
+  widget->refresh();
+  QCoreApplication::processEvents();
+
+  processTable->selectRow(0);
+  QCoreApplication::processEvents();
+
+  killBtn->click();
+  QCoreApplication::processEvents();
+
+  auto info = sched->get_process_info(pid);
+  ASSERT_TRUE(info.has_value());
+  EXPECT_EQ(info->status, process_status::killed);
+}
+
+TEST_F(StateDashboardExecUITest, MultipleProcessesInTable) {
+  execute_options opts_a, opts_b;
+  opts_a.name = "proc_x";
+  opts_b.name = "proc_y";
+  sched->execute(std::string("(+ 1 1)"), opts_a);
+  sched->execute(std::string("(+ 2 2)"), opts_b);
+
+  widget->refresh();
+  QCoreApplication::processEvents();
+
+  EXPECT_EQ(processTable->rowCount(), 2);
+}
+
+TEST_F(StateDashboardExecUITest, CompletedProcessShowsTerminated) {
+  execute_options opts;
+  opts.name = "done_proc";
+  sched->execute(std::string("(+ 1 1)"), opts);
+  sched->run();
+
+  widget->refresh();
+  QCoreApplication::processEvents();
+
+  ASSERT_EQ(processTable->rowCount(), 1);
+  EXPECT_EQ(processTable->item(0, 2)->text(), "terminated");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cluster Tab UI Interaction Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+class StateDashboardClusterUITest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    root = &state::instance(volrover3::app())("cluster_ui_test");
+    root->value("cluster_ui_root");
+
+    shard = std::make_unique<state_cluster_shard>(volrover3::app(), "ui_cluster", "ui_node");
+    membership = std::make_unique<state_cluster_membership>("ui_cluster", "ui_node");
+    telemetry = std::make_unique<state_telemetry_aggregator>("ui_cluster");
+
+    widget = new StateDashboardWidget();
+    widget->setShard(shard.get());
+    widget->setMembership(membership.get());
+    widget->setTelemetryAggregator(telemetry.get());
+    widget->show();
+    widget->refresh();
+    QCoreApplication::processEvents();
+
+    // Find labels
+    for (auto *label : widget->findChildren<QLabel *>()) {
+      QString text = label->text();
+      if (text.startsWith("Node ID:"))
+        nodeIdLabel = label;
+      else if (text.startsWith("Cluster ID:"))
+        clusterIdLabel = label;
+      else if (text.startsWith("Leader:"))
+        leaderLabel = label;
+      else if (text.startsWith("Message Bus"))
+        busLabel = label;
+      else if (text.startsWith("Shard"))
+        shardLabel = label;
+      else if (text.startsWith("Telemetry"))
+        telemetryLabel = label;
+    }
+
+    // Peer table has 4 columns
+    for (auto *table : widget->findChildren<QTableWidget *>()) {
+      if (table->columnCount() == 4) {
+        peerTableWidget = table;
+        break;
+      }
+    }
+    ASSERT_NE(peerTableWidget, nullptr);
+  }
+
+  void TearDown() override {
+    delete widget;
+    root->reset();
+  }
+
+  state *root;
+  std::unique_ptr<state_cluster_shard> shard;
+  std::unique_ptr<state_cluster_membership> membership;
+  std::unique_ptr<state_telemetry_aggregator> telemetry;
+  StateDashboardWidget *widget;
+  QLabel *nodeIdLabel = nullptr;
+  QLabel *clusterIdLabel = nullptr;
+  QLabel *leaderLabel = nullptr;
+  QLabel *busLabel = nullptr;
+  QLabel *shardLabel = nullptr;
+  QLabel *telemetryLabel = nullptr;
+  QTableWidget *peerTableWidget = nullptr;
+};
+
+TEST_F(StateDashboardClusterUITest, NodeIdLabelShowsCorrectId) {
+  ASSERT_NE(nodeIdLabel, nullptr);
+  EXPECT_TRUE(nodeIdLabel->text().contains("ui_node")) << nodeIdLabel->text().toStdString();
+}
+
+TEST_F(StateDashboardClusterUITest, ClusterIdLabelShowsCorrectId) {
+  ASSERT_NE(clusterIdLabel, nullptr);
+  EXPECT_TRUE(clusterIdLabel->text().contains("ui_cluster"))
+      << clusterIdLabel->text().toStdString();
+}
+
+TEST_F(StateDashboardClusterUITest, BusStatsLabelShowsZeroCounts) {
+  ASSERT_NE(busLabel, nullptr);
+  EXPECT_TRUE(busLabel->text().contains("admitted: 0")) << busLabel->text().toStdString();
+  EXPECT_TRUE(busLabel->text().contains("dispatched: 0")) << busLabel->text().toStdString();
+}
+
+TEST_F(StateDashboardClusterUITest, ShardStatsLabelShowsAttachedNo) {
+  ASSERT_NE(shardLabel, nullptr);
+  EXPECT_TRUE(shardLabel->text().contains("attached: no")) << shardLabel->text().toStdString();
+}
+
+TEST_F(StateDashboardClusterUITest, ShardStatsLabelShowsAttachedYes) {
+  shard->attach();
+  widget->refresh();
+  QCoreApplication::processEvents();
+
+  // Re-find label since refresh may update text
+  for (auto *label : widget->findChildren<QLabel *>()) {
+    if (label->text().startsWith("Shard"))
+      shardLabel = label;
+  }
+  ASSERT_NE(shardLabel, nullptr);
+  EXPECT_TRUE(shardLabel->text().contains("attached: yes")) << shardLabel->text().toStdString();
+}
+
+TEST_F(StateDashboardClusterUITest, TelemetryLabelShowsNodeCount) {
+  ASSERT_NE(telemetryLabel, nullptr);
+  EXPECT_TRUE(telemetryLabel->text().contains("nodes: 0")) << telemetryLabel->text().toStdString();
+}
+
+TEST_F(StateDashboardClusterUITest, PeerTablePopulatesAfterRegistration) {
+  membership->register_peer("peer_ui_1", "ui_cluster", "10.0.0.1:5000");
+  membership->register_peer("peer_ui_2", "ui_cluster", "10.0.0.2:5000");
+  widget->refresh();
+  QCoreApplication::processEvents();
+
+  ASSERT_EQ(peerTableWidget->rowCount(), 2);
+  // Verify both endpoints are present (order not guaranteed)
+  QSet<QString> endpoints;
+  for (int i = 0; i < peerTableWidget->rowCount(); ++i)
+    endpoints.insert(peerTableWidget->item(i, 1)->text());
+  EXPECT_TRUE(endpoints.contains("10.0.0.1:5000"));
+  EXPECT_TRUE(endpoints.contains("10.0.0.2:5000"));
+}
+
+TEST_F(StateDashboardClusterUITest, PeerTableShowsPeerState) {
+  membership->register_peer("alive_peer", "ui_cluster", "host:1234");
+  widget->refresh();
+  QCoreApplication::processEvents();
+
+  ASSERT_EQ(peerTableWidget->rowCount(), 1);
+  // Newly registered peers start as "alive"
+  EXPECT_EQ(peerTableWidget->item(0, 2)->text(), "alive");
+}
+
+TEST_F(StateDashboardClusterUITest, ShardOnlyIdentity) {
+  // Widget with shard but no membership uses shard for identity
+  auto *w = new StateDashboardWidget();
+  w->setShard(shard.get());
+  w->refresh();
+  QCoreApplication::processEvents();
+
+  QLabel *nodeLabel = nullptr;
+  for (auto *label : w->findChildren<QLabel *>()) {
+    if (label->text().contains("ui_node")) {
+      nodeLabel = label;
+      break;
+    }
+  }
+  EXPECT_NE(nodeLabel, nullptr);
+  delete w;
+}
+
+TEST_F(StateDashboardClusterUITest, ConnectPeerViaEndpointInput) {
+  QLineEdit *peerInput = nullptr;
+  for (auto *edit : widget->findChildren<QLineEdit *>()) {
+    if (edit->placeholderText().contains("host:port")) {
+      peerInput = edit;
+      break;
+    }
+  }
+  ASSERT_NE(peerInput, nullptr);
+
+  QPushButton *connectBtn = nullptr;
+  for (auto *btn : widget->findChildren<QPushButton *>()) {
+    if (btn->text() == "Connect") {
+      connectBtn = btn;
+      break;
+    }
+  }
+  ASSERT_NE(connectBtn, nullptr);
+
+  peerInput->setText("newhost:7777");
+  connectBtn->click();
+  QCoreApplication::processEvents();
+
+  // Peer should now be registered
+  auto peers = membership->peer_snapshot();
+  EXPECT_EQ(peers.size(), 1u);
+  EXPECT_EQ(peers[0].endpoint, "newhost:7777");
+}
+
+TEST_F(StateDashboardClusterUITest, ConnectPeerClearsInput) {
+  QLineEdit *peerInput = nullptr;
+  for (auto *edit : widget->findChildren<QLineEdit *>()) {
+    if (edit->placeholderText().contains("host:port")) {
+      peerInput = edit;
+      break;
+    }
+  }
+  ASSERT_NE(peerInput, nullptr);
+
+  QPushButton *connectBtn = nullptr;
+  for (auto *btn : widget->findChildren<QPushButton *>()) {
+    if (btn->text() == "Connect") {
+      connectBtn = btn;
+      break;
+    }
+  }
+  ASSERT_NE(connectBtn, nullptr);
+
+  peerInput->setText("host:8888");
+  connectBtn->click();
+  QCoreApplication::processEvents();
+
+  EXPECT_TRUE(peerInput->text().isEmpty());
+}
+
+TEST_F(StateDashboardClusterUITest, EmptyEndpointConnectIgnored) {
+  QLineEdit *peerInput = nullptr;
+  for (auto *edit : widget->findChildren<QLineEdit *>()) {
+    if (edit->placeholderText().contains("host:port")) {
+      peerInput = edit;
+      break;
+    }
+  }
+  ASSERT_NE(peerInput, nullptr);
+
+  QPushButton *connectBtn = nullptr;
+  for (auto *btn : widget->findChildren<QPushButton *>()) {
+    if (btn->text() == "Connect") {
+      connectBtn = btn;
+      break;
+    }
+  }
+  ASSERT_NE(connectBtn, nullptr);
+
+  peerInput->setText("");
+  connectBtn->click();
+  QCoreApplication::processEvents();
+
+  auto peers = membership->peer_snapshot();
+  EXPECT_TRUE(peers.empty());
+}
+
+int main(int argc, char **argv) {
+  QApplication app(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive **StateDashboardWidget** with three tabbed panels, accessible via **View → State Dashboard** (Ctrl+Shift+D).

### Tab 1 — State Tree
- Full tree navigation with real-time search/filter
- Detailed property panel: name, path, value (editable), value type, data type, read-only, hidden, comment (editable), last modified, children count, initialized status
- Link info: target, mode, writable, resolution status, resolved value
- Expiry info: time, expired status
- Add/delete state nodes with validation
- Signal-driven auto-refresh via `childChanged`, `valueChanged`, `destroyed`

### Tab 2 — Exec Console
- S-expression script editor with monospace font
- Run scripts via `evaluator::evaluate_script`
- Output panel showing results and errors
- Process management table: PID, name, status, priority, UID, steps, elapsed time, memory
- Process control buttons: Pause, Resume, Kill
- Auto-refreshing process list (1s timer)

### Tab 3 — Cluster & Networking
- Local node identity (node ID, cluster ID)
- Peer list table (node ID, endpoint, state, last heartbeat)
- Connect to peer: endpoint input + connect button
- Message bus stats (admitted, dispatched, duplicates, dropped, subscribers, dedup size)
- Shard stats (attached, remote applied, rejected, conflicts, duplicates)
- Telemetry summary (nodes, stale, mutations, messages)
- Auto-refreshing cluster info (2s timer)

### Tests
39 tests across 4 suites:
- **StateDashboardTreeTest** (15): Tree population, state metadata, links, expiry, typed values, mutations
- **StateDashboardExecTest** (8): Scheduler integration, process lifecycle, stats
- **StateDashboardClusterTest** (11): Shard/membership/telemetry identity, counters, peers
- **StateDashboardIntegrationTest** (5): Cross-tab refresh, show/hide, delete-on-close, concurrent state+process

### Files
- `inc/volrover3/StateDashboardWidget.h` — header (145 lines)
- `src/volrover3/StateDashboardWidget.cpp` — implementation (814 lines)
- `src/volrover3/tests/StateDashboardWidgetTest.cpp` — tests (519 lines)
- `inc/volrover3/MainWindow.h` — forward decl + member + slot
- `src/volrover3/MainWindow.cpp` — menu action + showStateDashboard()
- `src/volrover3/CMakeLists.txt` — source/header/test registration