### PR TITLE
fix: resolve 4 flaky CI test failures

### DIFF
--- a/inc/cvc/core/app.h
+++ b/inc/cvc/core/app.h
@@ -34,6 +34,7 @@
 #endif
 
 #include <algorithm>
+#include <atomic>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -50,6 +51,7 @@
 #include <boost/tuple/tuple.hpp>
 #include <boost/utility.hpp>
 #include <map>
+#include <memory>
 #include <queue>
 #include <set>
 #include <string>
@@ -332,7 +334,20 @@ public:
       }
     }
 
-    threads(wait ? key : this->uniqueThreadKey(key), cvc::thread_ptr(new boost::thread(t)));
+    // Gate ensures the thread callable doesn't execute until the handle
+    // is stored in _threads, which is required for keyed progress/info
+    // APIs to locate the thread.  Without this a fast-starting thread
+    // could call threadProgress(key, ...) before _threads[key] exists,
+    // causing the update to be silently dropped.
+    std::string actual_key = wait ? key : this->uniqueThreadKey(key);
+    auto ready = std::make_shared<std::atomic<bool>>(false);
+    T callable(t); // non-const copy of the callable
+    threads(actual_key, cvc::thread_ptr(new boost::thread([ready, callable]() mutable {
+              while (!ready->load(std::memory_order_acquire))
+                boost::this_thread::yield();
+              callable();
+            })));
+    ready->store(true, std::memory_order_release);
   }
 
   // Start a thread with priority using the thread pool

--- a/src/cvc/tests/state_distributed_bench_test.cpp
+++ b/src/cvc/tests/state_distributed_bench_test.cpp
@@ -446,6 +446,10 @@ TEST(StateDistributedBench, BlobStorePutGet) {
     blobs[i].resize(BLOB_SIZE);
     for (std::size_t j = 0; j < BLOB_SIZE; ++j)
       blobs[i][j] = static_cast<unsigned char>((i * 7 + j * 3) & 0xFF);
+    // Stamp the blob index into the first 2 bytes so that blobs
+    // with i differing only above bit 7 are still unique.
+    blobs[i][0] = static_cast<unsigned char>(i & 0xFF);
+    blobs[i][1] = static_cast<unsigned char>((i >> 8) & 0xFF);
   }
 
   // PUT

--- a/src/cvc/tests/state_link_bench_test.cpp
+++ b/src/cvc/tests/state_link_bench_test.cpp
@@ -193,7 +193,7 @@ TEST(StateLinkBenchmark, ResolveRemoteLargeTree) {
   }
 
   cvc::app a;
-  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  cvc::state_cluster_shard shard(a, "alpha", "node_1");
   shard.attach();
   auto &root = cvc::state::instance(a);
   constexpr std::size_t kPaths = 1'000'000;
@@ -304,7 +304,7 @@ TEST(StateLinkBenchmark, SubscriptionsForPathLargeTree) {
   }
 
   cvc::app a;
-  cvc::state_cluster_shard shard(a, "alpha", "node-1");
+  cvc::state_cluster_shard shard(a, "alpha", "node_1");
   shard.attach();
   auto &root = cvc::state::instance(a);
   constexpr std::size_t kPaths = 100'000;


### PR DESCRIPTION
## Summary

Fixes 4 tests that were consistently failing in CI (libcvc standalone builds):

### 1. `StateDistributedBench.BlobStorePutGet`
**Root cause:** The blob generation formula `(i*7 + j*3) & 0xFF` only produced 256 unique SHA-256 digests out of 5000 blobs, because the formula cycles modulo 256. The final assertion `EXPECT_EQ(store.size(), N)` failed with `256 != 5000`.

**Fix:** Stamp the blob index into the first two bytes of each blob, ensuring all 5000 are unique.

### 2-3. `StateLinkBenchmark.ResolveRemoteLargeTree` and `SubscriptionsForPathLargeTree`
**Root cause:** The node ID `"node-1"` contains a hyphen, which violates the C-identifier validation added to `state_cluster_shard` constructor. Both tests threw an exception on construction.

**Fix:** Changed node ID from `"node-1"` to `"node_1"`.

### 4. `AppTest.ThreadFeedbackExceptionSafety`
**Root cause:** Race condition in `startThread()` — the spawned thread could begin executing (and call `threadProgress(key, ...)`) before the thread handle was stored in `_threads`. The keyed progress setter silently dropped the update because `_threads.find(key)` returned `end()`, so `finishThreadProgress` in the `thread_feedback` destructor never wrote 1.0.

**Fix:** Added a ready-gate (`std::atomic<bool>`) so the callable spins until the handle is registered in `_threads`, guaranteeing keyed APIs work from the first instruction of the callable.

## Testing
- All 4 previously-failing tests now pass consistently
- Full affected test suites pass: 91/91 (AppTest, StateDistributedBench, StateLinkBenchmark)
- All 82 StateDashboardWidget tests pass
- Full build clean (Linux, Debug)